### PR TITLE
Fix XSS issues found in documentManager jsp pages

### DIFF
--- a/dependencies-lock.json
+++ b/dependencies-lock.json
@@ -1083,11 +1083,11 @@
   }, {
     "groupId" : "net.java.dev.jna",
     "artifactId" : "jna",
-    "version" : "5.16.0",
+    "version" : "5.17.0",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:2eGpxL6mstiqyWAdCXp3AT/TI7b1xh2D+sIZirapiLXPITkGGJM7FD3kzCVthL0qhnmPyzZ5R5zPxq7LIDQZhA=="
+    "integrity" : "sha512:M/NSUo/HCgf/yRhP+AZHsCxR6ibOsRznDupK29lBmm+BG8EXRtxz3fQP8qIdrtvqq9NJ6QHzDsXoQaH1/G8bUg=="
   }, {
     "groupId" : "net.oauth.core",
     "artifactId" : "oauth-provider",

--- a/dependencies-lock.json
+++ b/dependencies-lock.json
@@ -1083,11 +1083,11 @@
   }, {
     "groupId" : "net.java.dev.jna",
     "artifactId" : "jna",
-    "version" : "5.17.0",
+    "version" : "5.16.0",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:M/NSUo/HCgf/yRhP+AZHsCxR6ibOsRznDupK29lBmm+BG8EXRtxz3fQP8qIdrtvqq9NJ6QHzDsXoQaH1/G8bUg=="
+    "integrity" : "sha512:2eGpxL6mstiqyWAdCXp3AT/TI7b1xh2D+sIZirapiLXPITkGGJM7FD3kzCVthL0qhnmPyzZ5R5zPxq7LIDQZhA=="
   }, {
     "groupId" : "net.oauth.core",
     "artifactId" : "oauth-provider",

--- a/src/main/webapp/documentManager/addDocument.jsp
+++ b/src/main/webapp/documentManager/addDocument.jsp
@@ -46,27 +46,28 @@
         import="java.util.*, oscar.util.*, oscar.OscarProperties, org.oscarehr.util.SpringUtils, org.oscarehr.common.dao.CtlDocClassDao" %>
 <%@ page import="org.oscarehr.documentManager.data.AddEditDocument2Form" %>
 <%@ page import="org.oscarehr.documentManager.EDocUtil" %>
+<%@ page import="org.owasp.encoder.Encode" %>
 
 <%--This is included in documentReport.jsp - wasn't meant to be displayed as a separate page --%>
 <%
     String user_no = (String) session.getAttribute("user");
-    String appointment = request.getParameter("appointmentNo");
+    String appointment = Encode.forHtml(request.getParameter("appointmentNo"));
 
     String module = "";
     String moduleid = "";
     if (request.getParameter("function") != null) {
-        module = request.getParameter("function");
-        moduleid = request.getParameter("functionid");
+        module = Encode.forHtml(request.getParameter("function"));
+        moduleid = Encode.forHtml(request.getParameter("functionid"));
     } else if (request.getAttribute("function") != null) {
-        module = (String) request.getAttribute("function");
-        moduleid = (String) request.getAttribute("functionid");
+        module = Encode.forHtml((String) request.getAttribute("function"));
+        moduleid = Encode.forHtml((String) request.getAttribute("functionid"));
     }
 
     String curUser = "";
     if (request.getParameter("curUser") != null) {
-        curUser = request.getParameter("curUser");
+        curUser = Encode.forHtml(request.getParameter("curUser"));
     } else if (request.getAttribute("curUser") != null) {
-        curUser = (String) request.getAttribute("curUser");
+        curUser = Encode.forHtml((String) request.getAttribute("curUser"));
     }
 
     OscarProperties props = OscarProperties.getInstance();
@@ -78,23 +79,23 @@
     String defaultHtml = "Enter Link URL";
 
     if (request.getParameter("defaultDocType") != null) {
-        defaultType = request.getParameter("defaultDocType");
+        defaultType = Encode.forHtml(request.getParameter("defaultDocType"));
     }
 
 //for "add document" link from the patient master page - the "mode" variable allows the add div to open up
     String mode = "";
     if (request.getAttribute("mode") != null) {
-        mode = (String) request.getAttribute("mode");
+        mode = Encode.forHtml((String) request.getAttribute("mode"));
     } else if (request.getParameter("mode") != null) {
-        mode = request.getParameter("mode");
+        mode = Encode.forHtml(request.getParameter("mode"));
     }
 
 //Retrieve encounter id for updating encounter navbar if info this page changes anything
     String parentAjaxId;
     if (request.getParameter("parentAjaxId") != null)
-        parentAjaxId = request.getParameter("parentAjaxId");
+        parentAjaxId = Encode.forHtml(request.getParameter("parentAjaxId"));
     else if (request.getAttribute("parentAjaxId") != null)
-        parentAjaxId = (String) request.getAttribute("parentAjaxId");
+        parentAjaxId = Encode.forHtml((String) request.getAttribute("parentAjaxId"));
     else
         parentAjaxId = "";
 
@@ -249,7 +250,7 @@
             <fmt:setBundle basename="oscarResources"/><fmt:message key="dms.addDocument.AddLink"/>
         </a>
         <a class="btn" href="javascript:void(0);"
-           onclick="popup1(450, 600, 'addedithtmldocument.jsp?function=<%=module%>&functionid=<%=moduleid%>&mode=addHtml', 'addhtml')">
+           onclick="popup1(450, 600, 'addedithtmldocument.jsp?function=<%=Encode.forHtml(module)%>&functionid=<%=Encode.forHtml(moduleid)%>&mode=addHtml', 'addhtml')">
             <fmt:setBundle basename="oscarResources"/><fmt:message key="dms.addDocument.AddHTML"/>
         </a>
     </div>
@@ -264,12 +265,12 @@
                 </div>
             </c:forEach>
 
-            <input type="hidden" name="function" value="<%=formdata.getFunction()%>">
-            <input type="hidden" name="functionId" value="<%=formdata.getFunctionId()%>">
-            <input type="hidden" name="functionid" value="<%=moduleid%>">
-            <input type="hidden" name="parentAjaxId" value="<%=parentAjaxId%>">
-            <input type="hidden" name="curUser" value="<%=curUser%>">
-            <input type="hidden" name="appointmentNo" value="<%=formdata.getAppointmentNo()%>"/>
+            <input type="hidden" name="function" value="<%=Encode.forHtml(formdata.getFunction())%>">
+            <input type="hidden" name="functionId" value="<%=Encode.forHtml(formdata.getFunctionId())%>">
+            <input type="hidden" name="functionid" value="<%=Encode.forHtml(moduleid)%>">
+            <input type="hidden" name="parentAjaxId" value="<%=Encode.forHtml(parentAjaxId)%>">
+            <input type="hidden" name="curUser" value="<%=Encode.forHtml(curUser)%>">
+            <input type="hidden" name="appointmentNo" value="<%=Encode.forHtml(formdata.getAppointmentNo())%>"/>
 
             <div class="form-group">
                 <label for="docType">Type</label>
@@ -279,8 +280,8 @@
                         <%
                             for (int i = 0; i < doctypes.size(); i++) {
                                 String doctype = (String) doctypes.get(i); %>
-                        <option value="<%= doctype%>"
-                                <%=(formdata.getDocType().equals(doctype)) ? " selected" : ""%>><%= doctype%>
+                        <option value="<%= Encode.forHtml(doctype)%>"
+                                <%=(formdata.getDocType().equals(doctype)) ? " selected" : ""%>><%= Encode.forHtml(doctype)%>
                         </option>
                         <%}%>
                     </select>
@@ -296,14 +297,14 @@
                 <label for="docDesc">Description</label>
                 <input type="text"
                        class="form-control <c:if test='${ docerrors["descmissing"] != null}' >alert-danger</c:if>"
-                       id="docDesc" name="docDesc" value="<%=formdata.getDocDesc()%>"
+                       id="docDesc" name="docDesc" value="<%=Encode.forHtml(formdata.getDocDesc())%>"
                        onfocus="checkDefaultValue(this)"/>
-                <input type="hidden" name="docCreator" value="<%=formdata.getDocCreator()%>"/>
+                <input type="hidden" name="docCreator" value="<%=Encode.forHtml(formdata.getDocCreator())%>"/>
             </div>
             <div class="form-group">
                 <label for="observationDate" title="Observation Date">Observation Date</label>
                 <input class="span2 form-control" type="date" name="observationDate" id="observationDate"
-                       value="<%=formdata.getObservationDate()%>"
+                       value="<%=Encode.forHtml(formdata.getObservationDate().toString())%>"
                        onclick="checkDefaultDate(this, '<%=UtilDateUtilities.DateToString(new Date(), "yyyy-MM-dd")%>')">
             </div>
 
@@ -319,7 +320,7 @@
                                 consult1Shown = true;
                             }
                     %>
-                    <option value="<%=reportClass%>"><%=reportClass%>
+                    <option value="<%=Encode.forHtml(reportClass)%>"><%=reportClass%>
                     </option>
                     <% } %>
                 </select>
@@ -337,7 +338,7 @@
             <% if (module.equals("provider")) {%>
             <div class="checkbox">
                 <label>
-                    <input type="checkbox" id="docPublic" name="docPublic" <%=formdata.getDocPublic() + " "%>
+                    <input type="checkbox" id="docPublic" name="docPublic" <%=Encode.forHtml(formdata.getDocPublic()) + " "%>
                            value="checked">
                     Public</label>
             </div>
@@ -353,7 +354,7 @@
                         <input type="submit" name="Submit" value="Add" class="btn btn-primary">
                         <input type="button" name="Button" class="btn btn-error"
                                value="<fmt:setBundle basename="oscarResources"/><fmt:message key="global.btnCancel"/>"
-                               onclick="window.location='documentReport.jsp?function=<%=module%>&functionid=<%=moduleid%>'">
+                               onclick="window.location='documentReport.jsp?function=<%=Encode.forHtml(module)%>&functionid=<%=Encode.forHtml(moduleid)%>'">
 
                     </div>
                 </div>
@@ -374,11 +375,11 @@
             </div>
         </c:forEach>
 
-        <input type="hidden" name="function" value="<%=formdata.getFunction()%>">
-        <input type="hidden" name="functionId" value="<%=formdata.getFunctionId()%>">
-        <input type="hidden" name="functionid" value="<%=moduleid%>">
-        <input type="hidden" name="observationDate" value="<%=formdata.getObservationDate()%>">
-        <input type="hidden" name="appointmentNo" value="<%=formdata.getAppointmentNo()%>"/>
+        <input type="hidden" name="function" value="<%=Encode.forHtml(formdata.getFunction())%>">
+        <input type="hidden" name="functionId" value="<%=Encode.forHtml(formdata.getFunctionId())%>">
+        <input type="hidden" name="functionid" value="<%=Encode.forHtml(moduleid)%>">
+        <input type="hidden" name="observationDate" value="<%=Encode.forHtml(formdata.getObservationDate().toString())%>">
+        <input type="hidden" name="appointmentNo" value="<%=Encode.forHtml(formdata.getAppointmentNo())%>"/>
 
         <div class="form-group">
             <label for="docType1">Link Type</label>
@@ -388,8 +389,8 @@
                     <%
                         for (int i1 = 0; i1 < doctypes.size(); i1++) {
                             String doctype = (String) doctypes.get(i1); %>
-                    <option value="<%= doctype%>"
-                            <%=(formdata.getDocType().equals(doctype)) ? " selected" : ""%>><%= doctype%>
+                    <option value="<%= Encode.forHtml(doctype)%>"
+                            <%=(formdata.getDocType().equals(doctype)) ? " selected" : ""%>><%= Encode.forHtml(doctype)%>
                     </option>
                     <%}%>
                 </select>
@@ -406,7 +407,7 @@
             <label for="docDesc2">Description</label>
             <input type="text" name="docDesc" id="docDesc2"
                    class="form-control <c:if test="${ linkhtmlerrors['descmissing'] != null }">alert-danger</c:if>"
-                   value="<%=formdata.getDocDesc()%>" onfocus="checkDefaultValue(this)">
+                   value="<%=Encode.forHtml(formdata.getDocDesc())%>" onfocus="checkDefaultValue(this)">
         </div>
 
         <div class="form-group">
@@ -421,7 +422,7 @@
                             consult2Shown = true;
                         }
                 %>
-                <option value="<%=reportClass%>"><%=reportClass%>
+                <option value="<%=Encode.forHtml(reportClass)%>"><%=reportClass%>
                 </option>
                 <% } %>
             </select>
@@ -434,7 +435,7 @@
         <% if (module.equals("provider")) {%>
         <div class="checkbox">
             <label>
-                <input type="checkbox" name="docPublic" <%=formdata.getDocPublic() + " "%> value="checked">
+                <input type="checkbox" name="docPublic" <%=Encode.forHtml(formdata.getDocPublic()) + " "%> value="checked">
                 Public</label>
         </div>
         <% } %>
@@ -443,9 +444,9 @@
             <label for="html">Link</label>
             <div class="input-group">
                 <input type="text" id="html" name="html" class="form-control"
-                       value="<%=formdata.getHtml()%>" onfocus="checkDefaultValue(this)">
+                       value="<%=Encode.forHtml(formdata.getHtml())%>" onfocus="checkDefaultValue(this)">
                 <input type="hidden" name="docCreator"
-                       value="<%=formdata.getDocCreator()%>">
+                       value="<%=Encode.forHtml(formdata.getDocCreator())%>">
                 <input type="hidden" name="appointmentNo" value="<%=formdata.getAppointmentNo()%>"/>
                 <div class="input-group-btn">
                     <input type="hidden" name="mode" value="addLink">

--- a/src/main/webapp/documentManager/addDocument.jsp
+++ b/src/main/webapp/documentManager/addDocument.jsp
@@ -250,7 +250,7 @@
             <fmt:setBundle basename="oscarResources"/><fmt:message key="dms.addDocument.AddLink"/>
         </a>
         <a class="btn" href="javascript:void(0);"
-           onclick="popup1(450, 600, 'addedithtmldocument.jsp?function=<%=Encode.forHtml(module)%>&functionid=<%=Encode.forHtml(moduleid)%>&mode=addHtml', 'addhtml')">
+           onclick="popup1(450, 600, 'addedithtmldocument.jsp?function=<%=Encode.forJavaScriptAttribute(module)%>&functionid=<%=Encode.forJavaScriptAttribute(moduleid)%>&mode=addHtml', 'addhtml')">
             <fmt:setBundle basename="oscarResources"/><fmt:message key="dms.addDocument.AddHTML"/>
         </a>
     </div>

--- a/src/main/webapp/documentManager/addDocument.jsp
+++ b/src/main/webapp/documentManager/addDocument.jsp
@@ -47,6 +47,8 @@
 <%@ page import="org.oscarehr.documentManager.data.AddEditDocument2Form" %>
 <%@ page import="org.oscarehr.documentManager.EDocUtil" %>
 <%@ page import="org.owasp.encoder.Encode" %>
+<%@ page import="java.text.SimpleDateFormat" %>
+
 
 <%--This is included in documentReport.jsp - wasn't meant to be displayed as a separate page --%>
 <%
@@ -112,6 +114,20 @@
         formdata.setAppointmentNo(appointment);
     }
     ArrayList doctypes = EDocUtil.getActiveDocTypes(formdata.getFunction());
+
+    // Get the observation date in the correct format
+    SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
+    String observationDateStr = "";
+    // If the observation date is not null, format it
+    if (formdata.getObservationDate() != null) {
+        try {
+            // Try to parse the observation date string into a Date object
+            observationDateStr = (String) formdata.getObservationDate();
+        } catch (Exception e) {
+            // If there's an error, set a default value
+            observationDateStr = UtilDateUtilities.DateToString(new Date(), "yyyy-MM-dd");
+        }
+    }
 
     CtlDocClassDao docClassDao = (CtlDocClassDao) SpringUtils.getBean(CtlDocClassDao.class);
     List<String> reportClasses = docClassDao.findUniqueReportClasses();
@@ -304,7 +320,7 @@
             <div class="form-group">
                 <label for="observationDate" title="Observation Date">Observation Date</label>
                 <input class="span2 form-control" type="date" name="observationDate" id="observationDate"
-                       value="<%=Encode.forHtml(formdata.getObservationDate().toString())%>"
+                value="<%= Encode.forHtml(observationDateStr) %>"
                        onclick="checkDefaultDate(this, '<%=UtilDateUtilities.DateToString(new Date(), "yyyy-MM-dd")%>')">
             </div>
 
@@ -378,7 +394,7 @@
         <input type="hidden" name="function" value="<%=Encode.forHtml(formdata.getFunction())%>">
         <input type="hidden" name="functionId" value="<%=Encode.forHtml(formdata.getFunctionId())%>">
         <input type="hidden" name="functionid" value="<%=Encode.forHtml(moduleid)%>">
-        <input type="hidden" name="observationDate" value="<%=Encode.forHtml(formdata.getObservationDate().toString())%>">
+        <input type="hidden" name="observationDate" value="<%=Encode.forHtml(observationDateStr)%>">
         <input type="hidden" name="appointmentNo" value="<%=Encode.forHtml(formdata.getAppointmentNo())%>"/>
 
         <div class="form-group">

--- a/src/main/webapp/documentManager/addedithtmldocument.jsp
+++ b/src/main/webapp/documentManager/addedithtmldocument.jsp
@@ -53,6 +53,7 @@
 <%@ page import="org.oscarehr.documentManager.data.AddEditDocument2Form" %>
 <%@ page import="org.oscarehr.documentManager.EDocUtil" %>
 <%@ page import="org.oscarehr.documentManager.EDoc" %>
+<%@ page import="org.owasp.encoder.Encode" %>
 <%
     String mode = "";
     if (request.getAttribute("mode") != null) {
@@ -73,11 +74,11 @@
     String module = "";
     String moduleid = "";
     if (request.getParameter("function") != null) {
-        module = UtilMisc.htmlEscape(request.getParameter("function"));
-        moduleid = UtilMisc.htmlEscape(request.getParameter("functionid"));
+        module = Encode.forHtml(request.getParameter("function"));
+        moduleid = Encode.forHtml(request.getParameter("functionid"));
     } else if (request.getAttribute("function") != null) {
-        module = UtilMisc.htmlEscape((String) request.getAttribute("function"));
-        moduleid = UtilMisc.htmlEscape((String) request.getAttribute("functionid"));
+        module = Encode.forHtml((String) request.getAttribute("function"));
+        moduleid = Encode.forHtml((String) request.getAttribute("functionid"));
     }
 
     OscarProperties props = OscarProperties.getInstance();
@@ -112,7 +113,7 @@
         formdata.setReviewerId(currentDoc.getReviewerId());
         formdata.setReviewDateTime(currentDoc.getReviewDateTime());
         formdata.setContentDateTime(UtilDateUtilities.DateToString(currentDoc.getContentDateTime(), EDocUtil.CONTENT_DATETIME_FORMAT));
-        formdata.setHtml(UtilMisc.htmlEscape(currentDoc.getHtml()));
+        formdata.setHtml(Encode.forHtml(currentDoc.getHtml()));
         lastUpdate = currentDoc.getDateTimeStamp();
         fileName = currentDoc.getFileName();
     } else {
@@ -276,17 +277,17 @@
                        onsubmit="return submitUpload(this);">
     <input type="hidden" name="<csrf:tokenname/>" value="<csrf:tokenvalue/>"/>
     <input type="hidden" name="function"
-           value="<%=UtilMisc.htmlEscape(formdata.getFunction())%>" size="20"/>
+           value="<%=Encode.forHtml(formdata.getFunction())%>" size="20"/>
     <input type="hidden" name="functionId"
-           value="<%=UtilMisc.htmlEscape(formdata.getFunctionId())%>" size="20"/>
-    <input type="hidden" name="functionid" value="<%=UtilMisc.htmlEscape(moduleid)%>" size="20"/>
-    <input type="hidden" name="mode" value="<%=UtilMisc.htmlEscape(mode)%>"/>
+           value="<%=Encode.forHtml(formdata.getFunctionId())%>" size="20"/>
+    <input type="hidden" name="functionid" value="<%=Encode.forHtml(moduleid)%>" size="20"/>
+    <input type="hidden" name="mode" value="<%=Encode.forHtml(mode)%>"/>
     <input type="hidden" name="docCreator"
-           value="<%=UtilMisc.htmlEscape(formdata.getDocCreator())%>"/>
-    <input type="hidden" name="reviewerId" value="<%=UtilMisc.htmlEscape(formdata.getReviewerId())%>"/>
-    <input type="hidden" name="reviewDateTime" value="<%=UtilMisc.htmlEscape(formdata.getReviewDateTime())%>"/>
+           value="<%=Encode.forHtml(formdata.getDocCreator())%>"/>
+    <input type="hidden" name="reviewerId" value="<%=Encode.forHtml(formdata.getReviewerId())%>"/>
+    <input type="hidden" name="reviewDateTime" value="<%=Encode.forHtml(formdata.getReviewDateTime())%>"/>
     <input type="hidden" name="reviewDoc" value="false"/>
-    <input type="hidden" name="annotation_attrib" value="<%=UtilMisc.htmlEscape(annotation_attrib)%>"/>
+    <input type="hidden" name="annotation_attrib" value="<%=Encode.forHtml(annotation_attrib)%>"/>
 
     <table width="100%" height="100%" class="layouttable">
         <tr>
@@ -296,7 +297,7 @@
                     <option value=""><fmt:setBundle basename="oscarResources"/><fmt:message key="dms.addDocument.formSelect"/></option>
                     <% for (int i = 0; i < doctypes.size(); i++) {
                         String doctype = doctypes.get(i); %>
-                    <option value="<%=UtilMisc.htmlEscape(doctype)%>" <%=(formdata.getDocType().equals(doctype)) ? " selected" : ""%>><%=UtilMisc.htmlEscape(doctype)%>
+                    <option value="<%=Encode.forHtml(doctype)%>" <%=(formdata.getDocType().equals(doctype)) ? " selected" : ""%>><%=Encode.forHtml(doctype)%>
                     </option>
                     <%}%>
                 </select>
@@ -316,7 +317,7 @@
                             consultShown = true;
                         }
                 %>
-                <option value="<%=UtilMisc.htmlEscape(reportClass)%>" <%=reportClass.equals(formdata.getDocClass()) ? "selected" : ""%>><%=UtilMisc.htmlEscape(reportClass)%>
+                <option value="<%=Encode.forHtml(reportClass)%>" <%=reportClass.equals(formdata.getDocClass()) ? "selected" : ""%>><%=Encode.forHtml(reportClass)%>
                 </option>
                 <% } %>
             </select>
@@ -324,7 +325,7 @@
         </tr>
         <tr>
             <td><fmt:setBundle basename="oscarResources"/><fmt:message key="dms.addDocument.msgDocSubClass"/>:</td>
-            <td><input type="text" name="docSubClass" id="docSubClass" value="<%=UtilMisc.htmlEscape(formdata.getDocSubClass())%>"
+            <td><input type="text" name="docSubClass" id="docSubClass" value="<%=Encode.forHtml(formdata.getDocSubClass())%>"
                        style="width:330px">
                 <div class="autocomplete_style" id="docSubClass_list"></div>
             </td>
@@ -333,11 +334,11 @@
             <td>Description:</td>
             <td><input <% if (linkhtmlerrors.containsKey("descmissing")) {%>
                     class="warning" <%}%> type="text" name="docDesc" size="30"
-                    onfocus="checkDefaultValue(this)" value="<%=UtilMisc.htmlEscape(formdata.getDocDesc())%>"></td>
+                    onfocus="checkDefaultValue(this)" value="<%=Encode.forHtml(formdata.getDocDesc())%>"></td>
         </tr>
         <tr>
             <td>Added By:</td>
-            <td><%=UtilMisc.htmlEscape(EDocUtil.getProviderName(formdata.getDocCreator()))%>
+            <td><%=Encode.forHtml(EDocUtil.getProviderName(formdata.getDocCreator()))%>
             </td>
         </tr>
         <tr>
@@ -349,8 +350,8 @@
                         String selected = "";
                         if (formdata.getResponsibleId().equals(pd.get("providerNo"))) selected = "selected";
                     %>
-                    <option value="<%=UtilMisc.htmlEscape((String)pd.get("providerNo"))%>" <%=selected%>><%=UtilMisc.htmlEscape((String)pd.get("lastName"))%>
-                        , <%=UtilMisc.htmlEscape((String)pd.get("firstName"))%>
+                    <option value="<%=Encode.forHtml((String)pd.get("providerNo"))%>" <%=selected%>><%=Encode.forHtml((String)pd.get("lastName"))%>
+                        , <%=Encode.forHtml((String)pd.get("firstName"))%>
                     </option>
                     <% } %>
                 </select>
@@ -358,26 +359,26 @@
         </tr>
         <tr>
             <td>Date Added/Updated:</td>
-            <td><%=UtilMisc.htmlEscape(lastUpdate)%>
+            <td><%=Encode.forHtml(lastUpdate)%>
             </td>
         </tr>
         <tr>
             <td><fmt:setBundle basename="oscarResources"/><fmt:message key="dms.addDocument.formContentAddedUpdated"/>:</td>
-            <td><%=UtilMisc.htmlEscape(formdata.getContentDateTime())%>
+            <td><%=Encode.forHtml(formdata.getContentDateTime())%>
             </td>
         </tr>
         <tr>
             <td>Source Author:</td>
-            <td><input type="text" name="source" size="15" value="<%=UtilMisc.htmlEscape(formdata.getSource())%>"/></td>
+            <td><input type="text" name="source" size="15" value="<%=Encode.forHtml(formdata.getSource())%>"/></td>
         </tr>
         <tr>
             <td>Source Facility:</td>
-            <td><input type="text" name="sourceFacility" size="15" value="<%=UtilMisc.htmlEscape(formdata.getSourceFacility())%>"/></td>
+            <td><input type="text" name="sourceFacility" size="15" value="<%=Encode.forHtml(formdata.getSourceFacility())%>"/></td>
         </tr>
         <tr>
             <td>Observation Date <font class="comment">(yyyy/mm/dd):</font></td>
             <td><input type="text" name="observationDate"
-                       id="observationDate" value="<%=UtilMisc.htmlEscape(formdata.getObservationDate())%>"><a
+                       id="observationDate" value="<%=Encode.forHtml(formdata.getObservationDate())%>"><a
                     id="obsdate"><img title="Calendar" src="../images/cal.gif"
                                       alt="Calendar" border="0"/></a></td>
         </tr>
@@ -385,15 +386,15 @@
         <tr>
             <td>Public?</td>
             <td><input type="checkbox" name="docPublic"
-                    <%=UtilMisc.htmlEscape(formdata.getDocPublic() + " ")%> value="checked"></td>
+                    <%=Encode.forHtml(formdata.getDocPublic() + " ")%> value="checked"></td>
         </tr>
         <% }
             if (oldDoc) { %>
         <tr>
             <td colspan="2">
                 <% if (formdata.getReviewerId() != null && !formdata.getReviewerId().equals("")) { %>
-                Reviewed: &nbsp; <%=UtilMisc.htmlEscape(EDocUtil.getProviderName(formdata.getReviewerId()))%>
-                &nbsp; [<%=UtilMisc.htmlEscape(formdata.getReviewDateTime())%>]
+                Reviewed: &nbsp; <%=Encode.forHtml(EDocUtil.getProviderName(formdata.getReviewerId()))%>
+                &nbsp; [<%=Encode.forHtml(formdata.getReviewDateTime())%>]
                 <% } else { %>
                 <input type="button" value="Reviewed" title="Click to set Reviewed" onclick="reviewed(this);"/>
                 <% } %>
@@ -403,7 +404,7 @@
         <tr>
             <td colspan="2">
                 <input type="button" value="Annotation"
-                       onclick="window.open('../annotation/annotation.jsp?atbname=<%=UtilMisc.htmlEscape(annotation_attrib)%>&display=<%=UtilMisc.htmlEscape(annotation_display)%>&table_id=<%=UtilMisc.htmlEscape(annotation_tableid)%>&demo=<%=UtilMisc.htmlEscape(moduleid)%>','anwin','width=400,height=500');"/>
+                       onclick="window.open('../annotation/annotation.jsp?atbname=<%=Encode.forHtml(annotation_attrib)%>&display=<%=Encode.forHtml(annotation_display)%>&table_id=<%=Encode.forHtml(annotation_tableid)%>&demo=<%=Encode.forHtml(moduleid)%>','anwin','width=400,height=500');"/>
             </td>
         </tr>
         <tr>
@@ -412,7 +413,7 @@
         <tr>
             <td colspan="2">
 			    <textarea name="html" <% if (linkhtmlerrors.containsKey("uploaderror")) {%>
-                          class="warning" <%}%> wrap="off" style="width: 98%; height: 200px;"><%=UtilMisc.htmlEscape(formdata.getHtml())%>
+                          class="warning" <%}%> wrap="off" style="width: 98%; height: 200px;"><%=Encode.forHtml(formdata.getHtml())%>
 			    </textarea>
             </td>
         </tr>

--- a/src/main/webapp/documentManager/addedithtmldocument.jsp
+++ b/src/main/webapp/documentManager/addedithtmldocument.jsp
@@ -385,7 +385,7 @@
         <tr>
             <td>Public?</td>
             <td><input type="checkbox" name="docPublic"
-                    <%=formdata.getDocPublic() + " "%> value="checked"></td>
+                    <%=UtilMisc.htmlEscape(formdata.getDocPublic() + " ")%> value="checked"></td>
         </tr>
         <% }
             if (oldDoc) { %>
@@ -412,7 +412,7 @@
         <tr>
             <td colspan="2">
 			    <textarea name="html" <% if (linkhtmlerrors.containsKey("uploaderror")) {%>
-                          class="warning" <%}%> wrap="off" style="width: 98%; height: 200px;"><%=formdata.getHtml()%>
+                          class="warning" <%}%> wrap="off" style="width: 98%; height: 200px;"><%=UtilMisc.htmlEscape(formdata.getHtml())%>
 			    </textarea>
             </td>
         </tr>

--- a/src/main/webapp/documentManager/addedithtmldocument.jsp
+++ b/src/main/webapp/documentManager/addedithtmldocument.jsp
@@ -73,11 +73,11 @@
     String module = "";
     String moduleid = "";
     if (request.getParameter("function") != null) {
-        module = request.getParameter("function");
-        moduleid = request.getParameter("functionid");
+        module = UtilMisc.htmlEscape(request.getParameter("function"));
+        moduleid = UtilMisc.htmlEscape(request.getParameter("functionid"));
     } else if (request.getAttribute("function") != null) {
-        module = (String) request.getAttribute("function");
-        moduleid = (String) request.getAttribute("functionid");
+        module = UtilMisc.htmlEscape((String) request.getAttribute("function"));
+        moduleid = UtilMisc.htmlEscape((String) request.getAttribute("functionid"));
     }
 
     OscarProperties props = OscarProperties.getInstance();

--- a/src/main/webapp/documentManager/addedithtmldocument.jsp
+++ b/src/main/webapp/documentManager/addedithtmldocument.jsp
@@ -276,17 +276,17 @@
                        onsubmit="return submitUpload(this);">
     <input type="hidden" name="<csrf:tokenname/>" value="<csrf:tokenvalue/>"/>
     <input type="hidden" name="function"
-           value="<%=formdata.getFunction()%>" size="20"/>
+           value="<%=UtilMisc.htmlEscape(formdata.getFunction())%>" size="20"/>
     <input type="hidden" name="functionId"
-           value="<%=formdata.getFunctionId()%>" size="20"/>
-    <input type="hidden" name="functionid" value="<%=moduleid%>" size="20"/>
-    <input type="hidden" name="mode" value="<%=mode%>"/>
+           value="<%=UtilMisc.htmlEscape(formdata.getFunctionId())%>" size="20"/>
+    <input type="hidden" name="functionid" value="<%=UtilMisc.htmlEscape(moduleid)%>" size="20"/>
+    <input type="hidden" name="mode" value="<%=UtilMisc.htmlEscape(mode)%>"/>
     <input type="hidden" name="docCreator"
-           value="<%=formdata.getDocCreator()%>"/>
-    <input type="hidden" name="reviewerId" value="<%=formdata.getReviewerId()%>"/>
-    <input type="hidden" name="reviewDateTime" value="<%=formdata.getReviewDateTime()%>"/>
+           value="<%=UtilMisc.htmlEscape(formdata.getDocCreator())%>"/>
+    <input type="hidden" name="reviewerId" value="<%=UtilMisc.htmlEscape(formdata.getReviewerId())%>"/>
+    <input type="hidden" name="reviewDateTime" value="<%=UtilMisc.htmlEscape(formdata.getReviewDateTime())%>"/>
     <input type="hidden" name="reviewDoc" value="false"/>
-    <input type="hidden" name="annotation_attrib" value="<%=annotation_attrib%>"/>
+    <input type="hidden" name="annotation_attrib" value="<%=UtilMisc.htmlEscape(annotation_attrib)%>"/>
 
     <table width="100%" height="100%" class="layouttable">
         <tr>
@@ -296,7 +296,7 @@
                     <option value=""><fmt:setBundle basename="oscarResources"/><fmt:message key="dms.addDocument.formSelect"/></option>
                     <% for (int i = 0; i < doctypes.size(); i++) {
                         String doctype = doctypes.get(i); %>
-                    <option value="<%= doctype%>" <%=(formdata.getDocType().equals(doctype)) ? " selected" : ""%>><%= doctype%>
+                    <option value="<%=UtilMisc.htmlEscape(doctype)%>" <%=(formdata.getDocType().equals(doctype)) ? " selected" : ""%>><%=UtilMisc.htmlEscape(doctype)%>
                     </option>
                     <%}%>
                 </select>
@@ -316,7 +316,7 @@
                             consultShown = true;
                         }
                 %>
-                <option value="<%=reportClass%>" <%=reportClass.equals(formdata.getDocClass()) ? "selected" : ""%>><%=reportClass%>
+                <option value="<%=UtilMisc.htmlEscape(reportClass)%>" <%=reportClass.equals(formdata.getDocClass()) ? "selected" : ""%>><%=UtilMisc.htmlEscape(reportClass)%>
                 </option>
                 <% } %>
             </select>
@@ -324,7 +324,7 @@
         </tr>
         <tr>
             <td><fmt:setBundle basename="oscarResources"/><fmt:message key="dms.addDocument.msgDocSubClass"/>:</td>
-            <td><input type="text" name="docSubClass" id="docSubClass" value="<%=formdata.getDocSubClass()%>"
+            <td><input type="text" name="docSubClass" id="docSubClass" value="<%=UtilMisc.htmlEscape(formdata.getDocSubClass())%>"
                        style="width:330px">
                 <div class="autocomplete_style" id="docSubClass_list"></div>
             </td>
@@ -333,11 +333,11 @@
             <td>Description:</td>
             <td><input <% if (linkhtmlerrors.containsKey("descmissing")) {%>
                     class="warning" <%}%> type="text" name="docDesc" size="30"
-                    onfocus="checkDefaultValue(this)" value="<%=formdata.getDocDesc()%>"></td>
+                    onfocus="checkDefaultValue(this)" value="<%=UtilMisc.htmlEscape(formdata.getDocDesc())%>"></td>
         </tr>
         <tr>
             <td>Added By:</td>
-            <td><%=EDocUtil.getProviderName(formdata.getDocCreator())%>
+            <td><%=UtilMisc.htmlEscape(EDocUtil.getProviderName(formdata.getDocCreator()))%>
             </td>
         </tr>
         <tr>
@@ -349,8 +349,8 @@
                         String selected = "";
                         if (formdata.getResponsibleId().equals(pd.get("providerNo"))) selected = "selected";
                     %>
-                    <option value="<%=pd.get("providerNo")%>" <%=selected%>><%=pd.get("lastName")%>
-                        , <%=pd.get("firstName")%>
+                    <option value="<%=UtilMisc.htmlEscape((String)pd.get("providerNo"))%>" <%=selected%>><%=UtilMisc.htmlEscape((String)pd.get("lastName"))%>
+                        , <%=UtilMisc.htmlEscape((String)pd.get("firstName"))%>
                     </option>
                     <% } %>
                 </select>
@@ -358,26 +358,26 @@
         </tr>
         <tr>
             <td>Date Added/Updated:</td>
-            <td><%=lastUpdate%>
+            <td><%=UtilMisc.htmlEscape(lastUpdate)%>
             </td>
         </tr>
         <tr>
             <td><fmt:setBundle basename="oscarResources"/><fmt:message key="dms.addDocument.formContentAddedUpdated"/>:</td>
-            <td><%=formdata.getContentDateTime()%>
+            <td><%=UtilMisc.htmlEscape(formdata.getContentDateTime())%>
             </td>
         </tr>
         <tr>
             <td>Source Author:</td>
-            <td><input type="text" name="source" size="15" value="<%=formdata.getSource()%>"/></td>
+            <td><input type="text" name="source" size="15" value="<%=UtilMisc.htmlEscape(formdata.getSource())%>"/></td>
         </tr>
         <tr>
             <td>Source Facility:</td>
-            <td><input type="text" name="sourceFacility" size="15" value="<%=formdata.getSourceFacility()%>"/></td>
+            <td><input type="text" name="sourceFacility" size="15" value="<%=UtilMisc.htmlEscape(formdata.getSourceFacility())%>"/></td>
         </tr>
         <tr>
             <td>Observation Date <font class="comment">(yyyy/mm/dd):</font></td>
             <td><input type="text" name="observationDate"
-                       id="observationDate" value="<%=formdata.getObservationDate()%>"><a
+                       id="observationDate" value="<%=UtilMisc.htmlEscape(formdata.getObservationDate())%>"><a
                     id="obsdate"><img title="Calendar" src="../images/cal.gif"
                                       alt="Calendar" border="0"/></a></td>
         </tr>
@@ -392,8 +392,8 @@
         <tr>
             <td colspan="2">
                 <% if (formdata.getReviewerId() != null && !formdata.getReviewerId().equals("")) { %>
-                Reviewed: &nbsp; <%=EDocUtil.getProviderName(formdata.getReviewerId())%>
-                &nbsp; [<%=formdata.getReviewDateTime()%>]
+                Reviewed: &nbsp; <%=UtilMisc.htmlEscape(EDocUtil.getProviderName(formdata.getReviewerId()))%>
+                &nbsp; [<%=UtilMisc.htmlEscape(formdata.getReviewDateTime())%>]
                 <% } else { %>
                 <input type="button" value="Reviewed" title="Click to set Reviewed" onclick="reviewed(this);"/>
                 <% } %>
@@ -403,7 +403,7 @@
         <tr>
             <td colspan="2">
                 <input type="button" value="Annotation"
-                       onclick="window.open('../annotation/annotation.jsp?atbname=<%=annotation_attrib%>&display=<%=annotation_display%>&table_id=<%=annotation_tableid%>&demo=<%=moduleid%>','anwin','width=400,height=500');"/>
+                       onclick="window.open('../annotation/annotation.jsp?atbname=<%=UtilMisc.htmlEscape(annotation_attrib)%>&display=<%=UtilMisc.htmlEscape(annotation_display)%>&table_id=<%=UtilMisc.htmlEscape(annotation_tableid)%>&demo=<%=UtilMisc.htmlEscape(moduleid)%>','anwin','width=400,height=500');"/>
             </td>
         </tr>
         <tr>

--- a/src/main/webapp/documentManager/documentReport.jsp
+++ b/src/main/webapp/documentManager/documentReport.jsp
@@ -550,7 +550,7 @@
                                 </td>
                                 <td><%=Encode.forHtml(curdoc.getObservationDate())%>
                                 </td>
-                                <td><%=Encode.forHtml(curdoc.getContentDateTime())%>
+                                <td><%=Encode.forHtml(curdoc.getContentDateTime().toString())%>
                                 </td>
 
                                 <td style="text-align: right;">

--- a/src/main/webapp/documentManager/documentReport.jsp
+++ b/src/main/webapp/documentManager/documentReport.jsp
@@ -40,7 +40,7 @@
     String demographicNo = (String) session.getAttribute("casemgmt_DemoNo");
 
     String annotation_display = org.oscarehr.casemgmt.model.CaseManagementNoteLink.DISP_DOCUMENT;
-    String appointment = UtilMisc.htmlEscape(request.getParameter("appointmentNo"));
+    String appointment = Encode.forHtml(request.getParameter("appointmentNo"));
     int appointmentNo = 0;
     if (appointment != null && !appointment.isEmpty()) {
         appointmentNo = Integer.parseInt(appointment);
@@ -82,20 +82,20 @@
 
 //if delete request is made
     if (request.getParameter("delDocumentNo") != null) {
-        EDocUtil.deleteDocument(UtilMisc.htmlEscape(request.getParameter("delDocumentNo")));
+        EDocUtil.deleteDocument(Encode.forHtml(request.getParameter("delDocumentNo")));
     }
 
 //if undelete request is made
     if (request.getParameter("undelDocumentNo") != null) {
-        EDocUtil.undeleteDocument(UtilMisc.htmlEscape(request.getParameter("undelDocumentNo")));
+        EDocUtil.undeleteDocument(Encode.forHtml(request.getParameter("undelDocumentNo")));
     }
 
 //view  - tabs
     String view = "all";
     if (request.getParameter("view") != null) {
-        view = UtilMisc.htmlEscape(request.getParameter("view"));
+        view = Encode.forHtml(request.getParameter("view"));
     } else if (request.getAttribute("view") != null) {
-        view = UtilMisc.htmlEscape((String) request.getAttribute("view"));
+        view = Encode.forHtml((String) request.getAttribute("view"));
     }
 //preliminary JSP code
 
@@ -103,11 +103,11 @@
     String module = "";
     String moduleid = "";
     if (request.getParameter("function") != null) {
-        module = UtilMisc.htmlEscape(request.getParameter("function"));
-        moduleid = UtilMisc.htmlEscape(request.getParameter("functionid"));
+        module = Encode.forHtml(request.getParameter("function"));
+        moduleid = Encode.forHtml(request.getParameter("functionid"));
     } else if (request.getAttribute("function") != null) {
-        module = UtilMisc.htmlEscape((String) request.getAttribute("function"));
-        moduleid = UtilMisc.htmlEscape((String) request.getAttribute("functionid"));
+        module = Encode.forHtml((String) request.getAttribute("function"));
+        moduleid = Encode.forHtml((String) request.getAttribute("functionid"));
     }
 
     if (!"".equalsIgnoreCase(moduleid) && (demographicNo == null || demographicNo.equalsIgnoreCase("null"))) {
@@ -130,20 +130,20 @@
 //Retrieve encounter id for updating encounter navbar if info this page changes anything
     String parentAjaxId;
     if (request.getParameter("parentAjaxId") != null)
-        parentAjaxId = UtilMisc.htmlEscape(request.getParameter("parentAjaxId"));
+        parentAjaxId = Encode.forHtml(request.getParameter("parentAjaxId"));
     else if (request.getAttribute("parentAjaxId") != null)
-        parentAjaxId = UtilMisc.htmlEscape((String) request.getAttribute("parentAjaxId"));
+        parentAjaxId = Encode.forHtml((String) request.getAttribute("parentAjaxId"));
     else
         parentAjaxId = "";
 
 
     String updateParent;
     if (request.getParameter("updateParent") != null)
-        updateParent = UtilMisc.htmlEscape(request.getParameter("updateParent"));
+        updateParent = Encode.forHtml(request.getParameter("updateParent"));
     else
         updateParent = "false";
 
-    String viewstatus = UtilMisc.htmlEscape(request.getParameter("viewstatus"));
+    String viewstatus = Encode.forHtml(request.getParameter("viewstatus"));
     if (viewstatus == null) {
         viewstatus = "active";
     }
@@ -357,7 +357,7 @@
         </h2>
 
         <% if (module.equals("demographic")) { %>
-        <oscar:nameage demographicNo="<%=UtilMisc.htmlEscape(moduleid)%>"/>
+        <oscar:nameage demographicNo="<%=Encode.forHtml(moduleid)%>"/>
         <%} %>
 
         <jsp:include page="addDocument.jsp">
@@ -367,8 +367,8 @@
 
 
         <form action="${pageContext.request.contextPath}/documentManager/combinePDFs.do" method="post">
-            <input type="hidden" name="curUser" value="<%=UtilMisc.htmlEscape(curUser)%>">
-            <input type="hidden" name="demoId" value="<%=UtilMisc.htmlEscape(moduleid)%>">
+            <input type="hidden" name="curUser" value="<%=Encode.forHtmlAttribute(curUser)%>">
+            <input type="hidden" name="demoId" value="<%=Encode.forHtmlAttribute(moduleid)%>">
             <div class="documentLists"><%-- STUFF TO DISPLAY --%> <%
                 ArrayList categories = new ArrayList();
                 ArrayList categoryKeys = new ArrayList();

--- a/src/main/webapp/documentManager/documentReport.jsp
+++ b/src/main/webapp/documentManager/documentReport.jsp
@@ -422,7 +422,7 @@
                                 <%}%>
                                 <div class="form-group">
                                         <%--          <label for="view"><fmt:setBundle basename="oscarResources"/><fmt:message key="dms.documentReport.msgView"/></label>--%>
-                                    <select id="viewdoctype<%=i%>" name="view"
+                                    <select id="viewdoctype<%=i%>" name="view" id="view"
                                             class="input-medium form-control"
                                             onchange="window.location.href='?function=<%=Encode.forJavaScriptAttribute(module)%>&functionid=<%=Encode.forJavaScriptAttribute(moduleid)%>&view='+this.options[this.selectedIndex].value;">
                                         <option value="">All</option>

--- a/src/main/webapp/documentManager/documentReport.jsp
+++ b/src/main/webapp/documentManager/documentReport.jsp
@@ -408,7 +408,7 @@
                                 <div class="form-group">
                                         <%--      <label for="viewstatus"><fmt:setBundle basename="oscarResources"/><fmt:message key="dms.documentReport.msgViewStatus"/></label>--%>
                                     <select class="form-control" id="viewstatus" name="viewstatus"
-                                            onchange="window.location.href='?function=<%=UtilMisc.htmlEscape(module)%>&functionid=<%=UtilMisc.htmlEscape(moduleid)%>&view=<%=UtilMisc.htmlEscape(view)%>&viewstatus='+this.options[this.selectedIndex].value;">
+                                            onchange="window.location.href='?function=<%=Encode.forJavaScriptAttribute(module)%>&functionid=<%=Encode.forJavaScriptAttribute(moduleid)%>&view=<%=Encode.forJavaScriptAttribute(view)%>&viewstatus='+this.options[this.selectedIndex].value;">
                                         <option value="all"
                                                 <%=viewstatus.equalsIgnoreCase("all") ? "selected" : ""%>><fmt:setBundle basename="oscarResources"/><fmt:message key="dms.documentReport.msgAll"/></option>
                                         <option value="deleted"
@@ -422,9 +422,9 @@
                                 <%}%>
                                 <div class="form-group">
                                         <%--          <label for="view"><fmt:setBundle basename="oscarResources"/><fmt:message key="dms.documentReport.msgView"/></label>--%>
-                                    <select id="viewdoctype<%=i%>" name="view" id="view"
+                                    <select id="viewdoctype<%=i%>" name="view"
                                             class="input-medium form-control"
-                                            onchange="window.location.href='?function=<%=UtilMisc.htmlEscape(module)%>&functionid=<%=UtilMisc.htmlEscape(moduleid)%>&view='+this.options[this.selectedIndex].value;">
+                                            onchange="window.location.href='?function=<%=Encode.forJavaScriptAttribute(module)%>&functionid=<%=Encode.forJavaScriptAttribute(moduleid)%>&view='+this.options[this.selectedIndex].value;">
                                         <option value="">All</option>
                                         <%
                                             for (int i3 = 0; i3 < doctypes.size(); i3++) {
@@ -439,7 +439,7 @@
                                 <%if (DocumentBrowserLink) {%>
                                 <div class="form-group">
                                     <a class="btn btn-link form-control"
-                                       href="${ pageContext.request.contextPath }/documentManager/documentBrowser.jsp?function=<%=UtilMisc.htmlEscape(module)%>&functionid=<%=UtilMisc.htmlEscape(moduleid)%>&categorykey=<%=Encode.forUri(currentkey)%>">
+                                       href="${ pageContext.request.contextPath }/documentManager/documentBrowser.jsp?function=<%=Encode.forUriComponent(module)%>&functionid=<%=Encode.forUriComponent(moduleid)%>&categorykey=<%=Encode.forUriComponent(currentkey)%>">
                                         <fmt:setBundle basename="oscarResources"/><fmt:message key="dms.documentReport.msgBrowser"/>
                                     </a>
                                 </div>
@@ -522,7 +522,7 @@
                                            style="margin: 0; padding: 0;"/>
                                     <%}%>
                                 </td>
-                                <td><%=curdoc.getType() == null ? "N/A" : Encode.forHtmlContent(curdoc.getType())%>
+                                <td><%=curdoc.getType() == null ? "N/A" : Encode.forHtml(curdoc.getType())%>
                                 </td>
 
                                 <td>
@@ -540,7 +540,7 @@
                                 <td>
                                     <div style="overflow:hidden; text-overflow: ellipsis;"
                                          title="<%=Encode.forHtmlAttribute(contentType)%>">
-                                        <%=Encode.forHtmlContent(contentType)%>
+                                        <%=Encode.forHtml(contentType)%>
                                     </div>
                                 </td>
 
@@ -550,7 +550,7 @@
                                 </td>
                                 <td><%=Encode.forHtml(curdoc.getObservationDate())%>
                                 </td>
-                                <td><%=curdoc.getContentDateTime()%>
+                                <td><%=Encode.forHtml(curdoc.getContentDateTime())%>
                                 </td>
 
                                 <td style="text-align: right;">
@@ -559,7 +559,7 @@
                                             if (curdoc.getRemoteFacilityId() == null) {
                                                 if (curdoc.getCreatorId().equalsIgnoreCase(user_no)) {
                                                     if (curdoc.getStatus() == 'D') { %>
-                                        <a href="documentReport.jsp?undelDocumentNo=<%=curdoc.getDocId()%>&function=<%=UtilMisc.htmlEscape(module)%>&functionid=<%=UtilMisc.htmlEscape(moduleid)%>&viewstatus=<%=viewstatus%>"
+                                        <a href="documentReport.jsp?undelDocumentNo=<%=Encode.forUriComponent(curdoc.getDocId())%>&function=<%=Encode.forUriComponent(module)%>&functionid=<%=Encode.forUriComponent(moduleid)%>&viewstatus=<%=Encode.forUriComponent(viewstatus)%>"
                                            class="btn btn-link" style="padding:0;"
                                            title="<fmt:setBundle basename="oscarResources"/><fmt:message key="dms.documentReport.btnUnDelete"/>">
                                             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
@@ -574,7 +574,7 @@
                                         } else { // curdoc get status
                                         %>
                                         <a style="color:red; padding:0;"
-                                           href="javascript: checkDelete('documentReport.jsp?delDocumentNo=<%=curdoc.getDocId()%>&function=<%=UtilMisc.htmlEscape(module)%>&functionid=<%=UtilMisc.htmlEscape(moduleid)%>&viewstatus=<%=viewstatus%>','<%=StringEscapeUtils.escapeJavaScript(curdoc.getDescription())%>')"
+                                           href="javascript: checkDelete('documentReport.jsp?delDocumentNo=<%=Encode.forUriComponent(curdoc.getDocId())%>&function=<%=Encode.forUriComponent(module)%>&functionid=<%=Encode.forUriComponent(moduleid)%>&viewstatus=<%=Encode.forUriComponent(viewstatus)%>','<%=Encode.forJavaScriptAttribute(curdoc.getDescription())%>')"
                                            class="btn btn-link" title="Delete">
                                             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
                                                  fill="currentColor" class="bi bi-trash" viewBox="0 0 16 16">
@@ -588,7 +588,7 @@
                                         <security:oscarSec roleName="<%=roleName$%>"
                                                            objectName="_admin,_admin.edocdelete" rights="r">
                                             <% if (curdoc.getStatus() == 'D') {%>
-                                            <a href="documentReport.jsp?undelDocumentNo=<%=curdoc.getDocId()%>&function=<%=UtilMisc.htmlEscape(module)%>&functionid=<%=UtilMisc.htmlEscape(moduleid)%>&viewstatus=<%=UtilMisc.htmlEscape(viewstatus)%>"
+                                            <a href="documentReport.jsp?undelDocumentNo=<%=Encode.forUriComponent(curdoc.getDocId())%>&function=<%=Encode.forUriComponent(module)%>&functionid=<%=Encode.forUriComponent(moduleid)%>&viewstatus=<%=Encode.forUriComponent(viewstatus)%>"
                                                title="<fmt:setBundle basename="oscarResources"/><fmt:message key="dms.documentReport.btnUnDelete"/>"
                                                class="btn btn-link" style="padding:0;">
                                                 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
@@ -601,7 +601,7 @@
                                             </a>
                                             <% } else { // curdoc get status %>
                                             <a style="color:red;padding:0;"
-                                               href="javascript: checkDelete('documentReport.jsp?delDocumentNo=<%=UtilMisc.htmlEscape(curdoc.getDocId())%>&function=<%=UtilMisc.htmlEscape(module)%>&functionid=<%=UtilMisc.htmlEscape(moduleid)%>&viewstatus=<%=UtilMisc.htmlEscape(viewstatus)%>','<%=StringEscapeUtils.escapeJavaScript(curdoc.getDescription())%>')"
+                                               href="javascript: checkDelete('documentReport.jsp?delDocumentNo=<%=Encode.forUriComponent(curdoc.getDocId())%>&function=<%=Encode.forUriComponent(module)%>&functionid=<%=Encode.forUriComponent(moduleid)%>&viewstatus=<%=Encode.forUriComponent(viewstatus)%>','<%=Encode.forJavaScriptAttribute(curdoc.getDescription())%>')"
                                                class="btn btn-link" title="Delete">
                                                 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
                                                      fill="currentColor" class="bi bi-trash" viewBox="0 0 16 16">
@@ -617,7 +617,7 @@
                                         <% if (curdoc.getStatus() != 'D') {
                                             if (curdoc.getStatus() == 'H') { %>
                                         <a href="javascript:void(0)"
-                                           onclick="popup1(450, 600, 'addedithtmldocument.jsp?editDocumentNo=<%=UtilMisc.htmlEscape(curdoc.getDocId())%>&function=<%=UtilMisc.htmlEscape(module)%>&functionid=<%=UtilMisc.htmlEscape(moduleid)%>', 'EditDoc')"
+                                           onclick="popup1(450, 600, 'addedithtmldocument.jsp?editDocumentNo=<%=Encode.forJavaScriptAttribute(curdoc.getDocId())%>&function=<%=Encode.forJavaScriptAttribute(module)%>&functionid=<%=Encode.forJavaScriptAttribute(moduleid)%>', 'EditDoc')"
                                            title="<fmt:setBundle basename="oscarResources"/><fmt:message key="dms.documentReport.btnEdit"/>"
                                            class="btn btn-link" style="padding:0;">
                                             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
@@ -630,7 +630,7 @@
                                         </a>
                                         <%} else {%>
                                         <a href="javascript:void(0)"
-                                           onclick="popup1(350, 500, 'editDocument.jsp?editDocumentNo=<%=UtilMisc.htmlEscape(curdoc.getDocId())%>&function=<%=UtilMisc.htmlEscape(module)%>&functionid=<%=UtilMisc.htmlEscape(moduleid)%>', 'EditDoc')"
+                                           onclick="popup1(350, 500, 'editDocument.jsp?editDocumentNo=<%=Encode.forJavaScriptAttribute(curdoc.getDocId())%>&function=<%=Encode.forJavaScriptAttribute(module)%>&functionid=<%=Encode.forJavaScriptAttribute(moduleid)%>', 'EditDoc')"
                                            title="<fmt:setBundle basename="oscarResources"/><fmt:message key="dms.documentReport.btnEdit"/>"
                                            class="btn btn-link" style="padding:0;">
                                             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
@@ -647,7 +647,7 @@
 
                                         <% if (module.equals("demographic")) {%>
                                         <a href="javascript:void(0)" title="Annotation"
-                                           onclick="window.open('${ pageContext.request.contextPath }/annotation/annotation.jsp?display=<%=UtilMisc.htmlEscape(annotation_display)%>&table_id=<%=UtilMisc.htmlEscape(curdoc.getDocId())%>&demo=<%=UtilMisc.htmlEscape(moduleid)%>','anwin','width=400,height=500');"
+                                           onclick="window.open('${ pageContext.request.contextPath }/annotation/annotation.jsp?display=<%=Encode.forJavaScriptAttribute(annotation_display)%>&table_id=<%=Encode.forJavaScriptAttribute(curdoc.getDocId())%>&demo=<%=Encode.forJavaScriptAttribute(moduleid)%>','anwin','width=400,height=500');"
                                            class="btn btn-link" style="padding:0">
                                             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
                                                  fill="currentColor" class="bi bi-clipboard" viewBox="0 0 16 16">
@@ -658,11 +658,11 @@
                                         <% } %>
                                         <% if (!(moduleid.equals(session.getAttribute("user")) && module.equals("demographic"))) {
 
-                                            String tickler_url = request.getContextPath() + "/tickler/ForwardDemographicTickler.do?docType=DOC&docId=" + UtilMisc.htmlEscape(curdoc.getDocId()) + "&demographic_no=" + UtilMisc.htmlEscape(moduleid);
+                                            String tickler_url = request.getContextPath() + "/tickler/ForwardDemographicTickler.do?docType=DOC&docId=" + Encode.forUriComponent(curdoc.getDocId()) + "&demographic_no=" + Encode.forUriComponent(moduleid);
                                         %>
                                         <a href="javascript:void(0);" title="Tickler" class="btn btn-link"
                                            style="padding: 0;"
-                                           onclick="popup1(450,600,'<%=UtilMisc.htmlEscape(tickler_url)%>','tickler')">
+                                           onclick="popup1(450,600,'<%=Encode.forJavaScriptAttribute(tickler_url)%>','tickler')">
                                             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
                                                  fill="currentColor" class="bi bi-feather" viewBox="0 0 16 16">
                                                 <path d="M15.807.531c-.174-.177-.41-.289-.64-.363a3.765 3.765 0 0 0-.833-.15c-.62-.049-1.394 0-2.252.175C10.365.545 8.264 1.415 6.315 3.1c-1.95 1.686-3.168 3.724-3.758 5.423-.294.847-.44 1.634-.429 2.268.005.316.05.62.154.88.017.04.035.082.056.122A68.362 68.362 0 0 0 .08 15.198a.528.528 0 0 0 .157.72.504.504 0 0 0 .705-.16 67.606 67.606 0 0 1 2.158-3.26c.285.141.616.195.958.182.513-.02 1.098-.188 1.723-.49 1.25-.605 2.744-1.787 4.303-3.642l1.518-1.55a.528.528 0 0 0 0-.739l-.729-.744 1.311.209a.504.504 0 0 0 .443-.15c.222-.23.444-.46.663-.684.663-.68 1.292-1.325 1.763-1.892.314-.378.585-.752.754-1.107.163-.345.278-.773.112-1.188a.524.524 0 0 0-.112-.172ZM3.733 11.62C5.385 9.374 7.24 7.215 9.309 5.394l1.21 1.234-1.171 1.196a.526.526 0 0 0-.027.03c-1.5 1.789-2.891 2.867-3.977 3.393-.544.263-.99.378-1.324.39a1.282 1.282 0 0 1-.287-.018Zm6.769-7.22c1.31-1.028 2.7-1.914 4.172-2.6a6.85 6.85 0 0 1-.4.523c-.442.533-1.028 1.134-1.681 1.804l-.51.524-1.581-.25Zm3.346-3.357C9.594 3.147 6.045 6.8 3.149 10.678c.007-.464.121-1.086.37-1.806.533-1.535 1.65-3.415 3.455-4.976 1.807-1.561 3.746-2.36 5.31-2.68a7.97 7.97 0 0 1 1.564-.173Z"></path>

--- a/src/main/webapp/documentManager/documentReport.jsp
+++ b/src/main/webapp/documentManager/documentReport.jsp
@@ -40,7 +40,7 @@
     String demographicNo = (String) session.getAttribute("casemgmt_DemoNo");
 
     String annotation_display = org.oscarehr.casemgmt.model.CaseManagementNoteLink.DISP_DOCUMENT;
-    String appointment = request.getParameter("appointmentNo");
+    String appointment = UtilMisc.htmlEscape(request.getParameter("appointmentNo"));
     int appointmentNo = 0;
     if (appointment != null && !appointment.isEmpty()) {
         appointmentNo = Integer.parseInt(appointment);
@@ -82,20 +82,20 @@
 
 //if delete request is made
     if (request.getParameter("delDocumentNo") != null) {
-        EDocUtil.deleteDocument(request.getParameter("delDocumentNo"));
+        EDocUtil.deleteDocument(UtilMisc.htmlEscape(request.getParameter("delDocumentNo")));
     }
 
 //if undelete request is made
     if (request.getParameter("undelDocumentNo") != null) {
-        EDocUtil.undeleteDocument(request.getParameter("undelDocumentNo"));
+        EDocUtil.undeleteDocument(UtilMisc.htmlEscape(request.getParameter("undelDocumentNo")));
     }
 
 //view  - tabs
     String view = "all";
     if (request.getParameter("view") != null) {
-        view = request.getParameter("view");
+        view = UtilMisc.htmlEscape(request.getParameter("view"));
     } else if (request.getAttribute("view") != null) {
-        view = (String) request.getAttribute("view");
+        view = UtilMisc.htmlEscape((String) request.getAttribute("view"));
     }
 //preliminary JSP code
 
@@ -103,11 +103,11 @@
     String module = "";
     String moduleid = "";
     if (request.getParameter("function") != null) {
-        module = request.getParameter("function");
-        moduleid = request.getParameter("functionid");
+        module = UtilMisc.htmlEscape(request.getParameter("function"));
+        moduleid = UtilMisc.htmlEscape(request.getParameter("functionid"));
     } else if (request.getAttribute("function") != null) {
-        module = (String) request.getAttribute("function");
-        moduleid = (String) request.getAttribute("functionid");
+        module = UtilMisc.htmlEscape((String) request.getAttribute("function"));
+        moduleid = UtilMisc.htmlEscape((String) request.getAttribute("functionid"));
     }
 
     if (!"".equalsIgnoreCase(moduleid) && (demographicNo == null || demographicNo.equalsIgnoreCase("null"))) {
@@ -130,20 +130,20 @@
 //Retrieve encounter id for updating encounter navbar if info this page changes anything
     String parentAjaxId;
     if (request.getParameter("parentAjaxId") != null)
-        parentAjaxId = request.getParameter("parentAjaxId");
+        parentAjaxId = UtilMisc.htmlEscape(request.getParameter("parentAjaxId"));
     else if (request.getAttribute("parentAjaxId") != null)
-        parentAjaxId = (String) request.getAttribute("parentAjaxId");
+        parentAjaxId = UtilMisc.htmlEscape((String) request.getAttribute("parentAjaxId"));
     else
         parentAjaxId = "";
 
 
     String updateParent;
     if (request.getParameter("updateParent") != null)
-        updateParent = request.getParameter("updateParent");
+        updateParent = UtilMisc.htmlEscape(request.getParameter("updateParent"));
     else
         updateParent = "false";
 
-    String viewstatus = request.getParameter("viewstatus");
+    String viewstatus = UtilMisc.htmlEscape(request.getParameter("viewstatus"));
     if (viewstatus == null) {
         viewstatus = "active";
     }
@@ -357,7 +357,7 @@
         </h2>
 
         <% if (module.equals("demographic")) { %>
-        <oscar:nameage demographicNo="<%=moduleid%>"/>
+        <oscar:nameage demographicNo="<%=UtilMisc.htmlEscape(moduleid)%>"/>
         <%} %>
 
         <jsp:include page="addDocument.jsp">
@@ -367,8 +367,8 @@
 
 
         <form action="${pageContext.request.contextPath}/documentManager/combinePDFs.do" method="post">
-            <input type="hidden" name="curUser" value="<%=curUser%>">
-            <input type="hidden" name="demoId" value="<%=moduleid%>">
+            <input type="hidden" name="curUser" value="<%=UtilMisc.htmlEscape(curUser)%>">
+            <input type="hidden" name="demoId" value="<%=UtilMisc.htmlEscape(moduleid)%>">
             <div class="documentLists"><%-- STUFF TO DISPLAY --%> <%
                 ArrayList categories = new ArrayList();
                 ArrayList categoryKeys = new ArrayList();
@@ -408,7 +408,7 @@
                                 <div class="form-group">
                                         <%--      <label for="viewstatus"><fmt:setBundle basename="oscarResources"/><fmt:message key="dms.documentReport.msgViewStatus"/></label>--%>
                                     <select class="form-control" id="viewstatus" name="viewstatus"
-                                            onchange="window.location.href='?function=<%=module%>&functionid=<%=moduleid%>&view=<%=view%>&viewstatus='+this.options[this.selectedIndex].value;">
+                                            onchange="window.location.href='?function=<%=UtilMisc.htmlEscape(module)%>&functionid=<%=UtilMisc.htmlEscape(moduleid)%>&view=<%=UtilMisc.htmlEscape(view)%>&viewstatus='+this.options[this.selectedIndex].value;">
                                         <option value="all"
                                                 <%=viewstatus.equalsIgnoreCase("all") ? "selected" : ""%>><fmt:setBundle basename="oscarResources"/><fmt:message key="dms.documentReport.msgAll"/></option>
                                         <option value="deleted"
@@ -424,7 +424,7 @@
                                         <%--          <label for="view"><fmt:setBundle basename="oscarResources"/><fmt:message key="dms.documentReport.msgView"/></label>--%>
                                     <select id="viewdoctype<%=i%>" name="view" id="view"
                                             class="input-medium form-control"
-                                            onchange="window.location.href='?function=<%=module%>&functionid=<%=moduleid%>&view='+this.options[this.selectedIndex].value;">
+                                            onchange="window.location.href='?function=<%=UtilMisc.htmlEscape(module)%>&functionid=<%=UtilMisc.htmlEscape(moduleid)%>&view='+this.options[this.selectedIndex].value;">
                                         <option value="">All</option>
                                         <%
                                             for (int i3 = 0; i3 < doctypes.size(); i3++) {
@@ -439,7 +439,7 @@
                                 <%if (DocumentBrowserLink) {%>
                                 <div class="form-group">
                                     <a class="btn btn-link form-control"
-                                       href="${ pageContext.request.contextPath }/documentManager/documentBrowser.jsp?function=<%=module%>&functionid=<%=moduleid%>&categorykey=<%=Encode.forUri(currentkey)%>">
+                                       href="${ pageContext.request.contextPath }/documentManager/documentBrowser.jsp?function=<%=UtilMisc.htmlEscape(module)%>&functionid=<%=UtilMisc.htmlEscape(moduleid)%>&categorykey=<%=Encode.forUri(currentkey)%>">
                                         <fmt:setBundle basename="oscarResources"/><fmt:message key="dms.documentReport.msgBrowser"/>
                                     </a>
                                 </div>
@@ -559,7 +559,7 @@
                                             if (curdoc.getRemoteFacilityId() == null) {
                                                 if (curdoc.getCreatorId().equalsIgnoreCase(user_no)) {
                                                     if (curdoc.getStatus() == 'D') { %>
-                                        <a href="documentReport.jsp?undelDocumentNo=<%=curdoc.getDocId()%>&function=<%=module%>&functionid=<%=moduleid%>&viewstatus=<%=viewstatus%>"
+                                        <a href="documentReport.jsp?undelDocumentNo=<%=curdoc.getDocId()%>&function=<%=UtilMisc.htmlEscape(module)%>&functionid=<%=UtilMisc.htmlEscape(moduleid)%>&viewstatus=<%=viewstatus%>"
                                            class="btn btn-link" style="padding:0;"
                                            title="<fmt:setBundle basename="oscarResources"/><fmt:message key="dms.documentReport.btnUnDelete"/>">
                                             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
@@ -574,7 +574,7 @@
                                         } else { // curdoc get status
                                         %>
                                         <a style="color:red; padding:0;"
-                                           href="javascript: checkDelete('documentReport.jsp?delDocumentNo=<%=curdoc.getDocId()%>&function=<%=module%>&functionid=<%=moduleid%>&viewstatus=<%=viewstatus%>','<%=StringEscapeUtils.escapeJavaScript(curdoc.getDescription())%>')"
+                                           href="javascript: checkDelete('documentReport.jsp?delDocumentNo=<%=curdoc.getDocId()%>&function=<%=UtilMisc.htmlEscape(module)%>&functionid=<%=UtilMisc.htmlEscape(moduleid)%>&viewstatus=<%=viewstatus%>','<%=StringEscapeUtils.escapeJavaScript(curdoc.getDescription())%>')"
                                            class="btn btn-link" title="Delete">
                                             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
                                                  fill="currentColor" class="bi bi-trash" viewBox="0 0 16 16">
@@ -588,7 +588,7 @@
                                         <security:oscarSec roleName="<%=roleName$%>"
                                                            objectName="_admin,_admin.edocdelete" rights="r">
                                             <% if (curdoc.getStatus() == 'D') {%>
-                                            <a href="documentReport.jsp?undelDocumentNo=<%=curdoc.getDocId()%>&function=<%=module%>&functionid=<%=moduleid%>&viewstatus=<%=viewstatus%>"
+                                            <a href="documentReport.jsp?undelDocumentNo=<%=curdoc.getDocId()%>&function=<%=UtilMisc.htmlEscape(module)%>&functionid=<%=UtilMisc.htmlEscape(moduleid)%>&viewstatus=<%=UtilMisc.htmlEscape(viewstatus)%>"
                                                title="<fmt:setBundle basename="oscarResources"/><fmt:message key="dms.documentReport.btnUnDelete"/>"
                                                class="btn btn-link" style="padding:0;">
                                                 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
@@ -601,7 +601,7 @@
                                             </a>
                                             <% } else { // curdoc get status %>
                                             <a style="color:red;padding:0;"
-                                               href="javascript: checkDelete('documentReport.jsp?delDocumentNo=<%=curdoc.getDocId()%>&function=<%=module%>&functionid=<%=moduleid%>&viewstatus=<%=viewstatus%>','<%=StringEscapeUtils.escapeJavaScript(curdoc.getDescription())%>')"
+                                               href="javascript: checkDelete('documentReport.jsp?delDocumentNo=<%=UtilMisc.htmlEscape(curdoc.getDocId())%>&function=<%=UtilMisc.htmlEscape(module)%>&functionid=<%=UtilMisc.htmlEscape(moduleid)%>&viewstatus=<%=UtilMisc.htmlEscape(viewstatus)%>','<%=StringEscapeUtils.escapeJavaScript(curdoc.getDescription())%>')"
                                                class="btn btn-link" title="Delete">
                                                 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
                                                      fill="currentColor" class="bi bi-trash" viewBox="0 0 16 16">
@@ -617,7 +617,7 @@
                                         <% if (curdoc.getStatus() != 'D') {
                                             if (curdoc.getStatus() == 'H') { %>
                                         <a href="javascript:void(0)"
-                                           onclick="popup1(450, 600, 'addedithtmldocument.jsp?editDocumentNo=<%=curdoc.getDocId()%>&function=<%=module%>&functionid=<%=moduleid%>', 'EditDoc')"
+                                           onclick="popup1(450, 600, 'addedithtmldocument.jsp?editDocumentNo=<%=UtilMisc.htmlEscape(curdoc.getDocId())%>&function=<%=UtilMisc.htmlEscape(module)%>&functionid=<%=UtilMisc.htmlEscape(moduleid)%>', 'EditDoc')"
                                            title="<fmt:setBundle basename="oscarResources"/><fmt:message key="dms.documentReport.btnEdit"/>"
                                            class="btn btn-link" style="padding:0;">
                                             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
@@ -630,7 +630,7 @@
                                         </a>
                                         <%} else {%>
                                         <a href="javascript:void(0)"
-                                           onclick="popup1(350, 500, 'editDocument.jsp?editDocumentNo=<%=curdoc.getDocId()%>&function=<%=module%>&functionid=<%=moduleid%>', 'EditDoc')"
+                                           onclick="popup1(350, 500, 'editDocument.jsp?editDocumentNo=<%=UtilMisc.htmlEscape(curdoc.getDocId())%>&function=<%=UtilMisc.htmlEscape(module)%>&functionid=<%=UtilMisc.htmlEscape(moduleid)%>', 'EditDoc')"
                                            title="<fmt:setBundle basename="oscarResources"/><fmt:message key="dms.documentReport.btnEdit"/>"
                                            class="btn btn-link" style="padding:0;">
                                             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
@@ -647,7 +647,7 @@
 
                                         <% if (module.equals("demographic")) {%>
                                         <a href="javascript:void(0)" title="Annotation"
-                                           onclick="window.open('${ pageContext.request.contextPath }/annotation/annotation.jsp?display=<%=annotation_display%>&table_id=<%=curdoc.getDocId()%>&demo=<%=moduleid%>','anwin','width=400,height=500');"
+                                           onclick="window.open('${ pageContext.request.contextPath }/annotation/annotation.jsp?display=<%=UtilMisc.htmlEscape(annotation_display)%>&table_id=<%=UtilMisc.htmlEscape(curdoc.getDocId())%>&demo=<%=UtilMisc.htmlEscape(moduleid)%>','anwin','width=400,height=500');"
                                            class="btn btn-link" style="padding:0">
                                             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
                                                  fill="currentColor" class="bi bi-clipboard" viewBox="0 0 16 16">
@@ -658,11 +658,11 @@
                                         <% } %>
                                         <% if (!(moduleid.equals(session.getAttribute("user")) && module.equals("demographic"))) {
 
-                                            String tickler_url = request.getContextPath() + "/tickler/ForwardDemographicTickler.do?docType=DOC&docId=" + curdoc.getDocId() + "&demographic_no=" + moduleid;
+                                            String tickler_url = request.getContextPath() + "/tickler/ForwardDemographicTickler.do?docType=DOC&docId=" + UtilMisc.htmlEscape(curdoc.getDocId()) + "&demographic_no=" + UtilMisc.htmlEscape(moduleid);
                                         %>
                                         <a href="javascript:void(0);" title="Tickler" class="btn btn-link"
                                            style="padding: 0;"
-                                           onclick="popup1(450,600,'<%=tickler_url%>','tickler')">
+                                           onclick="popup1(450,600,'<%=UtilMisc.htmlEscape(tickler_url)%>','tickler')">
                                             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
                                                  fill="currentColor" class="bi bi-feather" viewBox="0 0 16 16">
                                                 <path d="M15.807.531c-.174-.177-.41-.289-.64-.363a3.765 3.765 0 0 0-.833-.15c-.62-.049-1.394 0-2.252.175C10.365.545 8.264 1.415 6.315 3.1c-1.95 1.686-3.168 3.724-3.758 5.423-.294.847-.44 1.634-.429 2.268.005.316.05.62.154.88.017.04.035.082.056.122A68.362 68.362 0 0 0 .08 15.198a.528.528 0 0 0 .157.72.504.504 0 0 0 .705-.16 67.606 67.606 0 0 1 2.158-3.26c.285.141.616.195.958.182.513-.02 1.098-.188 1.723-.49 1.25-.605 2.744-1.787 4.303-3.642l1.518-1.55a.528.528 0 0 0 0-.739l-.729-.744 1.311.209a.504.504 0 0 0 .443-.15c.222-.23.444-.46.663-.684.663-.68 1.292-1.325 1.763-1.892.314-.378.585-.752.754-1.107.163-.345.278-.773.112-1.188a.524.524 0 0 0-.112-.172ZM3.733 11.62C5.385 9.374 7.24 7.215 9.309 5.394l1.21 1.234-1.171 1.196a.526.526 0 0 0-.027.03c-1.5 1.789-2.891 2.867-3.977 3.393-.544.263-.99.378-1.324.39a1.282 1.282 0 0 1-.287-.018Zm6.769-7.22c1.31-1.028 2.7-1.914 4.172-2.6a6.85 6.85 0 0 1-.4.523c-.442.533-1.028 1.134-1.681 1.804l-.51.524-1.581-.25Zm3.346-3.357C9.594 3.147 6.045 6.8 3.149 10.678c.007-.464.121-1.086.37-1.806.533-1.535 1.65-3.415 3.455-4.976 1.807-1.561 3.746-2.36 5.31-2.68a7.97 7.97 0 0 1 1.564-.173Z"></path>

--- a/src/main/webapp/documentManager/documentReport.jsp
+++ b/src/main/webapp/documentManager/documentReport.jsp
@@ -533,7 +533,7 @@
                                             href="javascript:void(0);"
                                             title="<%=Encode.forHtmlAttribute(curdoc.getDescription())%>"
                                             style="word-break: break-word;overflow-wrap: anywhere;overflow: hidden;text-overflow: ellipsis;text-decoration: none;"
-                                            onclick="popupFocusPage(500,700,'<%=url%>','demographic_document');">
+                                            onclick="popupFocusPage(500,700,'<%=Encode.forJavaScriptAttribute(url)%>','demographic_document');">
                                         <%=Encode.forHtml(curdoc.getDescription())%>
                                     </a>
                                 </td>

--- a/src/main/webapp/documentManager/documentReport.jsp
+++ b/src/main/webapp/documentManager/documentReport.jsp
@@ -82,12 +82,12 @@
 
 //if delete request is made
     if (request.getParameter("delDocumentNo") != null) {
-        EDocUtil.deleteDocument(Encode.forHtml(request.getParameter("delDocumentNo")));
+        EDocUtil.deleteDocument(request.getParameter("delDocumentNo"));
     }
 
 //if undelete request is made
     if (request.getParameter("undelDocumentNo") != null) {
-        EDocUtil.undeleteDocument(Encode.forHtml(request.getParameter("undelDocumentNo")));
+        EDocUtil.undeleteDocument(request.getParameter("undelDocumentNo"));
     }
 
 //view  - tabs

--- a/src/main/webapp/documentManager/documentReport.jsp
+++ b/src/main/webapp/documentManager/documentReport.jsp
@@ -42,7 +42,7 @@
     String annotation_display = org.oscarehr.casemgmt.model.CaseManagementNoteLink.DISP_DOCUMENT;
     String appointment = Encode.forHtml(request.getParameter("appointmentNo"));
     int appointmentNo = 0;
-    if (appointment != null && !appointment.isEmpty()) {
+    if (appointment != null && !appointment.isEmpty() && !appointment.equalsIgnoreCase("null")) {
         appointmentNo = Integer.parseInt(appointment);
     }
 


### PR DESCRIPTION
This pull request focuses on enhancing security in documentManager jsp pages by encoding user input to prevent HTML injection vulnerabilities in the `addDocument.jsp`, `addedithtmldocument.jsp`, and `documentreport.jsp` files. The changes primarily involve using the `Encode.forHtml` and `UtilMisc.htmlEscape` methods to sanitize inputs that might contain XSS payload.

The XSS issue can be identified with the following two different URLs: the `alert(1)` hidden in the request parameter successfully altered the content of the page, and the popup is shown.
http://localhost:8080/oscar/documentManager/addedithtmldocument.jsp?function=%22%3E%3CscrIpt%3Ealert%281%29%3B%3C%2FscRipt%3E&functionid=999998&mode=addHtml
http://localhost:8080/oscar/documentManager/documentReport.jsp?function=provider&functionid=999998&curUser=%22%3E%3CscrIpt%3Ealert%281%29%3B%3C%2FscRipt%3E

After applying these updated commits, the HTML syntax around alert(1) will be escaped, thus protecting OSCAR from being attacked with XSS payloads.

## Summary by Sourcery

Bug Fixes:
- Escapes HTML syntax around user inputs to prevent XSS attacks.