### PR TITLE
Potential fix for code scanning alert no. 590: DOM text reinterpreted as HTML

### DIFF
--- a/src/main/webapp/js/bootstrap.js
+++ b/src/main/webapp/js/bootstrap.js
@@ -100,7 +100,11 @@
             selector = selector && selector.replace(/.*(?=#[^\s]*$)/, '') //strip for ie7
         }
 
-        $parent = $(selector)
+        try {
+            $parent = selector && document.querySelector(selector) ? $(selector) : $();
+        } catch (e) {
+            $parent = $();
+        }
 
         e && e.preventDefault()
 


### PR DESCRIPTION
Potential fix for [https://github.com/cc-ar-emr/Open-O/security/code-scanning/590](https://github.com/cc-ar-emr/Open-O/security/code-scanning/590)

To fix the issue, we need to ensure that the value of `selector` is sanitized or validated before it is used in the `$(selector)` function. A safer approach is to use `$.find(selector)` instead of `$(selector)`, as `$.find` interprets the input strictly as a CSS selector and does not execute it as HTML or JavaScript. Additionally, we should validate the `selector` to ensure it is a valid CSS selector and not malicious input.

Changes will be made to the `Alert.prototype.close` method to replace the use of `$(selector)` with a safer alternative.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Validate CSS selectors before using jQuery in Alert.prototype.close to address a code-scanning alert about DOM text being reinterpreted as HTML

Bug Fixes:
- Sanitize and validate the selector via document.querySelector before invoking $(selector) to prevent malicious input
- Fallback to an empty jQuery object when selector validation fails or throws an error instead of executing unsafe code

Enhancements:
- Replace direct $(selector) calls with a guard wrapped in try/catch for safer DOM querying