### PR TITLE
Potential fix for code scanning alert no. 913: Uncontrolled data used in path expression

### DIFF
--- a/src/main/java/oscar/oscarLab/ca/all/upload/handlers/IHAPOIHandler.java
+++ b/src/main/java/oscar/oscarLab/ca/all/upload/handlers/IHAPOIHandler.java
@@ -72,6 +72,11 @@ public class IHAPOIHandler implements MessageHandler {
 
         try {
 
+            // Validate the fileName to prevent directory traversal
+            if (fileName.contains("..") || fileName.contains("/") || fileName.contains("\\")) {
+                throw new IllegalArgumentException("Invalid file name: " + fileName);
+            }
+
             is = new FileInputStream(fileName);
             hl7BodyMap = parse(is);
             Iterator<String> keySetIterator = null;


### PR DESCRIPTION
Potential fix for [https://github.com/cc-ar-emr/Open-O/security/code-scanning/913](https://github.com/cc-ar-emr/Open-O/security/code-scanning/913)

To fix the issue, we need to validate the `fileName` parameter before using it in the `FileInputStream` constructor. The validation should ensure that:
1. The `fileName` does not contain any path traversal sequences (`..`, `/`, or `\`).
2. The resolved path is within a specific safe directory, if applicable.

The best approach is to normalize the path and check that it remains within a predefined safe directory. If the `fileName` is expected to be a simple file name (not a full path), we can also reject inputs containing path separators.

Changes will be made in the `parse` method of `IHAPOIHandler.java` to validate the `fileName` parameter before using it.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Reject fileName inputs containing "..", '/' or '\\' to prevent directory traversal attacks in IHAPOIHandler.java