### PR TITLE
Potential fix for code scanning alert no. 904: Uncontrolled data used in path expression

### DIFF
--- a/src/main/java/oscar/oscarEncounter/oscarMeasurements/pageUtil/EctAddMeasurementStyleSheet2Action.java
+++ b/src/main/java/oscar/oscarEncounter/oscarMeasurements/pageUtil/EctAddMeasurementStyleSheet2Action.java
@@ -106,11 +106,20 @@ public class EctAddMeasurementStyleSheet2Action extends ActionSupport {
                 uploadPath += "/";
             }
 
-            // Build the full path for the file
-            String destinationPath = uploadPath + fileName;
+            // Validate the fileName to prevent path traversal
+            if (fileName.contains("..") || fileName.contains("/") || fileName.contains("\\")) {
+                throw new IllegalArgumentException("Invalid file name: " + fileName);
+            }
+
+            // Build the full path for the file and ensure it stays within the upload directory
+            Path uploadDir = Paths.get(uploadPath).normalize().toAbsolutePath();
+            Path destinationPath = uploadDir.resolve(fileName).normalize();
+            if (!destinationPath.startsWith(uploadDir)) {
+                throw new IllegalArgumentException("Invalid file path: " + destinationPath);
+            }
 
             // Write the file to the destination
-            Files.copy(new FileInputStream(file), Paths.get(destinationPath));
+            Files.copy(new FileInputStream(file), destinationPath);
 
         } catch (IOException e) {
             MiscUtils.getLogger().error("Error saving file", e);


### PR DESCRIPTION
Potential fix for [https://github.com/cc-ar-emr/Open-O/security/code-scanning/904](https://github.com/cc-ar-emr/Open-O/security/code-scanning/904)

To fix the issue, we need to validate the `fileName` and ensure that the constructed file path (`destinationPath`) is confined to a specific directory. This can be achieved by:
1. Normalizing the `fileName` and ensuring it does not contain any path traversal sequences (e.g., `..`, `/`, or `\`).
2. Resolving the `destinationPath` against a predefined safe directory and verifying that the resolved path remains within this directory.
3. Rejecting any invalid `fileName` or paths that attempt to escape the safe directory.

The changes will be made in the `saveFile` method to validate the `fileName` and ensure the `destinationPath` is safe.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Add filename validation and safe path resolution in saveFile to prevent path traversal and fix code scanning alert no. 904.

Bug Fixes:
- Reject filenames containing '..', '/' or '\\' and prevent paths escaping the upload directory.

Enhancements:
- Use java.nio.file.Path resolve and normalize methods to construct destination paths within the upload directory instead of manual string concatenation.