### PR TITLE
Potential fix for code scanning alert no. 662: Code injection

### DIFF
--- a/src/main/webapp/dojoAjax/src/io/RepubsubIO.js
+++ b/src/main/webapp/dojoAjax/src/io/RepubsubIO.js
@@ -106,9 +106,9 @@ dojo.io.repubsub = new function () {
             var opts = [];
             for (var x in pairs) {
                 var sp = pairs[x].split("=");
-                // FIXME: is this eval dangerous?
                 try {
-                    opts[sp[0]] = eval(sp[1]);
+                    // Decode the parameter value safely
+                    opts[sp[0]] = decodeURIComponent(sp[1]);
                 } catch (e) {
                     opts[sp[0]] = sp[1];
                 }


### PR DESCRIPTION
Potential fix for [https://github.com/cc-ar-emr/Open-O/security/code-scanning/662](https://github.com/cc-ar-emr/Open-O/security/code-scanning/662)

To fix the issue, we need to eliminate the use of `eval` and replace it with a safer alternative. Specifically:
1. Parse the query string parameters manually or use a library to safely decode them.
2. Avoid executing the values as code. Instead, treat them as plain strings or numbers, depending on the expected input.

The changes will be made in the `parseGetStr` function:
- Replace the `eval` call with logic to decode and handle the parameter values safely.
- Ensure that the function returns a dictionary of key-value pairs without executing any code.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Replace eval call in parseGetStr with decodeURIComponent to safely handle query parameters and prevent code injection