### PR TITLE
Potential fix for code scanning alert no. 659: Code injection

### DIFF
--- a/src/main/webapp/dojoAjax/iframe_history.html
+++ b/src/main/webapp/dojoAjax/iframe_history.html
@@ -23,7 +23,7 @@
                 for (var x = 0; x < sparams.length; x++) {
                     var tp = sparams[x].split("=");
                     if (typeof window[tp[0]] != "undefined") {
-                        window[tp[0]] = ((tp[1] == "true") || (tp[1] == "false")) ? eval(tp[1]) : tp[1];
+                        window[tp[0]] = (tp[1] === "true") ? true : (tp[1] === "false") ? false : tp[1];
                     }
                 }
             }


### PR DESCRIPTION
Potential fix for [https://github.com/cc-ar-emr/Open-O/security/code-scanning/659](https://github.com/cc-ar-emr/Open-O/security/code-scanning/659)

To fix the issue, we need to eliminate the use of `eval` and handle the user input in a safe manner. Specifically:
1. Replace the `eval` call with a safer alternative. For example, if the intent is to interpret `tp[1]` as a boolean, we can explicitly compare it to `"true"` or `"false"` and assign the corresponding boolean value.
2. Ensure that no arbitrary code execution can occur by sanitizing and validating all user input before using it.

The changes will be made in the `init` function, specifically on line 26, where `eval(tp[1])` is replaced with a safer alternative.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Replace unsafe eval call with explicit boolean checks and assignment to mitigate code injection