### PR TITLE
Potential fix for code scanning alert no. 1023: User-controlled data in numeric cast

### DIFF
--- a/src/main/java/org/oscarehr/common/model/Hsfo2Visit.java
+++ b/src/main/java/org/oscarehr/common/model/Hsfo2Visit.java
@@ -827,6 +827,9 @@ public class Hsfo2Visit extends AbstractModel<Integer> implements Serializable {
     }
 
     public int getLDLP1() {
+        if (LDL < Integer.MIN_VALUE || LDL > Integer.MAX_VALUE) {
+            throw new IllegalArgumentException("LDL value is out of range for an integer.");
+        }
         return (int) LDL;
     }
 


### PR DESCRIPTION
Potential fix for [https://github.com/cc-ar-emr/Open-O/security/code-scanning/1023](https://github.com/cc-ar-emr/Open-O/security/code-scanning/1023)

To fix the issue, we need to validate the `LDL` value before casting it to an `int` in the `getLDLP1` method. The validation should ensure that the `LDL` value is within the range of valid integers and does not contain unexpected fractional parts. If the value is invalid, an exception should be thrown or a default value should be returned.

**Steps to fix:**
1. Modify the `getLDLP1` method in `Hsfo2Visit.java` to include a guard that checks the range and validity of the `LDL` value before performing the cast.
2. If the `LDL` value is invalid, handle it appropriately (e.g., throw an exception or return a default value).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Add range check for LDL in getLDLP1 to avoid integer overflow and throw IllegalArgumentException when out of range.