### PR TITLE
Potential fix for code scanning alert no. 1027: User-controlled data in numeric cast

### DIFF
--- a/src/main/java/org/oscarehr/common/model/Hsfo2Visit.java
+++ b/src/main/java/org/oscarehr/common/model/Hsfo2Visit.java
@@ -1179,6 +1179,9 @@ public class Hsfo2Visit extends AbstractModel<Integer> implements Serializable {
     }
 
     public int getWeightP1() {
+        if (Weight < Integer.MIN_VALUE || Weight > Integer.MAX_VALUE) {
+            throw new IllegalArgumentException("Weight value is out of range for an int: " + Weight);
+        }
         return (int) Weight;
     }
 


### PR DESCRIPTION
Potential fix for [https://github.com/cc-ar-emr/Open-O/security/code-scanning/1027](https://github.com/cc-ar-emr/Open-O/security/code-scanning/1027)

To fix the issue, we need to validate the `Weight` field before performing the narrowing cast in the `getWeightP1` method. Specifically:
1. Add a guard to ensure that the `Weight` value is within the range of an `int` (i.e., between `Integer.MIN_VALUE` and `Integer.MAX_VALUE`) before casting.
2. If the value is out of range, throw an exception or handle the error appropriately to prevent incorrect behavior.
3. Ensure that the fix does not alter the existing functionality of the application.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Throw IllegalArgumentException when Weight is out of int range before narrowing cast