### PR TITLE
Potential fix for code scanning alert no. 1102: Partial path traversal vulnerability from remote

### DIFF
--- a/src/main/java/org/oscarehr/billing/CA/ON/web/MoveMOHFiles2Action.java
+++ b/src/main/java/org/oscarehr/billing/CA/ON/web/MoveMOHFiles2Action.java
@@ -87,10 +87,10 @@ public class MoveMOHFiles2Action extends ActionSupport {
     private boolean validateFileLocation(File file) {
     boolean result = false;
     try {
-        String filePath = file.getCanonicalPath();
-        for(EDTFolder folder : EDTFolder.values()) {
-            String edtFolderPath = new File(folder.getPath()).getCanonicalPath();
-            if (filePath.startsWith(edtFolderPath)) {
+        Path filePath = file.toPath().normalize();
+        for (EDTFolder folder : EDTFolder.values()) {
+            Path edtFolderPath = new File(folder.getPath()).toPath().normalize();
+            if (filePath.startsWith(edtFolderPath) && !filePath.equals(edtFolderPath)) {
                 result = true;
             }
         }


### PR DESCRIPTION
Potential fix for [https://github.com/cc-ar-emr/Open-O/security/code-scanning/1102](https://github.com/cc-ar-emr/Open-O/security/code-scanning/1102)

To fix the issue, we need to ensure that the `startsWith` check in `validateFileLocation` strictly verifies that `filePath` is a child of `edtFolderPath`. This can be achieved by converting both paths to `Path` objects and using the `startsWith` method of the `Path` class, which correctly handles hierarchical relationships. Additionally, we should normalize the paths to ensure they are canonical and free of traversal elements.

Changes will be made in the `validateFileLocation` method to replace the `startsWith` check with a safer `Path`-based check.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Use NIO Path API in validateFileLocation to normalize paths and strictly verify that input files reside within allowed directories, preventing partial path traversal vulnerabilities.

Bug Fixes:
- Fix partial path traversal vulnerability by ensuring file paths are strictly children of configured EDT folder paths.

Enhancements:
- Replace string-based canonical path and startsWith checks with Path.normalize and Path.startsWith including child-only check.