### PR TITLE
Potential fix for code scanning alert no. 984: OGNL Expression Language statement with user-controlled input

### DIFF
--- a/src/main/java/oscar/oscarEncounter/oscarMeasurements/pageUtil/EctAddMeasurementType2Action.java
+++ b/src/main/java/oscar/oscarEncounter/oscarMeasurements/pageUtil/EctAddMeasurementType2Action.java
@@ -31,6 +31,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 import javax.servlet.ServletException;
+import org.apache.commons.text.StringEscapeUtils;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -103,8 +104,9 @@ public class EctAddMeasurementType2Action extends ActionSupport {
             isValid = false;
         }
 
-        String errorField = "The type " + type;
-        if (!validate.matchRegExp(regExp, type)) {
+        String escapedType = org.apache.commons.text.StringEscapeUtils.escapeHtml4(type);
+        String errorField = "The type " + escapedType;
+        if (!validate.matchRegExp(regExp, escapedType)) {
             addActionError(getText("errors.invalid", errorField));
             isValid = false;
         }


### PR DESCRIPTION
Potential fix for [https://github.com/cc-ar-emr/Open-O/security/code-scanning/984](https://github.com/cc-ar-emr/Open-O/security/code-scanning/984)

To fix the issue, we need to ensure that user-controlled input (`type`) is properly sanitized or escaped before being used in any context where it might be interpreted as an OGNL expression. The best approach is to escape the `type` variable to neutralize any special characters that could be interpreted as part of an OGNL expression. This can be achieved using a utility method to escape the input.

Additionally, we should validate the `type` variable more rigorously to ensure it conforms to expected patterns and does not contain malicious content.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Escape and validate the user-supplied `type` parameter in `EctAddMeasurementType2Action` to neutralize special characters and prevent OGNL expression injection.

Bug Fixes:
- Escape HTML in the `type` parameter using `StringEscapeUtils.escapeHtml4` before validation and error reporting to mitigate OGNL injection risks.
- Use the escaped `type` value when matching against the expected regex pattern to ensure rigorous validation.