### PR TITLE
Potential fix for code scanning alert no. 983: OGNL Expression Language statement with user-controlled input

### DIFF
--- a/src/main/java/oscar/oscarEncounter/oscarMeasurements/pageUtil/EctAddMeasurementStyleSheet2Action.java
+++ b/src/main/java/oscar/oscarEncounter/oscarMeasurements/pageUtil/EctAddMeasurementStyleSheet2Action.java
@@ -72,8 +72,14 @@ public class EctAddMeasurementStyleSheet2Action extends ActionSupport {
                 return NONE;
             } else {
                 write2Database(fileName);
-                String msg = getText("oscarEncounter.oscarMeasurement.msgAddedStyleSheet", fileName);
-                messages.add(msg);
+                if (isValidFileName(fileName)) {
+                    String msg = getText("oscarEncounter.oscarMeasurement.msgAddedStyleSheet", fileName);
+                    messages.add(msg);
+                } else {
+                    addActionError(getText("errors.invalidFileName"));
+                    response.sendRedirect(contextPath + "/oscarEncounter/oscarMeasurements/AddMeasurementStyleSheet.jsp");
+                    return NONE;
+                }
                 request.setAttribute("messages", messages);
                 return SUCCESS;
             }
@@ -148,5 +154,16 @@ public class EctAddMeasurementStyleSheet2Action extends ActionSupport {
 
     public void setFileName(String fileName) {
         this.fileName = fileName;
+    }
+
+    /**
+     * Validates the file name to ensure it does not contain unexpected characters or patterns.
+     *
+     * @param fileName - the file name to validate
+     * @return true if the file name is valid, false otherwise
+     */
+    private boolean isValidFileName(String fileName) {
+        // Allow only alphanumeric characters, underscores, hyphens, and periods
+        return fileName != null && fileName.matches("^[a-zA-Z0-9._-]+$");
     }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/cc-ar-emr/Open-O/security/code-scanning/983](https://github.com/cc-ar-emr/Open-O/security/code-scanning/983)

To fix the issue, we need to ensure that the `fileName` variable is sanitized or validated before being passed to the `getText` method. This can be achieved by:
1. Validating the `fileName` to ensure it does not contain any malicious OGNL expressions or unexpected characters.
2. Escaping the `fileName` to treat it as a plain string rather than an OGNL expression.

The best approach is to validate the `fileName` using a custom validation method that checks for unexpected characters or patterns. If the `fileName` fails validation, the request should be rejected.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Mitigate OGNL injection vulnerability by validating the `fileName` input against a strict regex and rejecting invalid values before passing it to `getText`

Bug Fixes:
- Validate `fileName` to prevent malicious OGNL expressions before using it in `getText`

Enhancements:
- Add `isValidFileName` helper method with regex-based validation and redirect with error message on failure