### PR TITLE
Potential fix for code scanning alert no. 564: DOM text reinterpreted as HTML

### DIFF
--- a/src/main/webapp/PMmodule/Admin/ProgramView/vacancies.jsp
+++ b/src/main/webapp/PMmodule/Admin/ProgramView/vacancies.jsp
@@ -126,8 +126,8 @@
 
     function filterByStatus() {
         var status = $("#statusFilter").val();
-        var id = $("#id").val();
-        var programId = $("#programId").val();
+        var id = encodeURIComponent($("#id").val());
+        var programId = encodeURIComponent($("#programId").val());
         var encodedStatus = encodeURIComponent(status);
         location.href = '<%=request.getContextPath()%>/PMmodule/ProgramManagerView.do?method=view&tab=Vacancies&subtab=Vacancies&status=Active&vacancyOrTemplateId=&id=' + id + "&programId=" + programId + "&statusFilter=" + encodedStatus;
     }

--- a/src/main/webapp/PMmodule/Admin/ProgramView/vacancies.jsp
+++ b/src/main/webapp/PMmodule/Admin/ProgramView/vacancies.jsp
@@ -128,7 +128,8 @@
         var status = $("#statusFilter").val();
         var id = $("#id").val();
         var programId = $("#programId").val();
-        location.href = '<%=request.getContextPath()%>/PMmodule/ProgramManagerView.do?method=view&tab=Vacancies&subtab=Vacancies&status=Active&vacancyOrTemplateId=&id=' + id + "&programId=" + programId + "&statusFilter=" + status;
+        var encodedStatus = encodeURIComponent(status);
+        location.href = '<%=request.getContextPath()%>/PMmodule/ProgramManagerView.do?method=view&tab=Vacancies&subtab=Vacancies&status=Active&vacancyOrTemplateId=&id=' + id + "&programId=" + programId + "&statusFilter=" + encodedStatus;
     }
 </script>
 


### PR DESCRIPTION
Potential fix for [https://github.com/cc-ar-emr/Open-O/security/code-scanning/564](https://github.com/cc-ar-emr/Open-O/security/code-scanning/564)

To fix the issue, the user-controlled input (`status`) should be properly encoded before being included in the URL. This ensures that any special characters in the input are safely escaped, preventing them from being interpreted as part of the URL or as executable code. The best way to achieve this is by using `encodeURIComponent`, a JavaScript function that encodes a URI component by replacing special characters with their percent-encoded equivalents.

The fix involves:
1. Modifying the `filterByStatus` function to encode the `status` value using `encodeURIComponent`.
2. Ensuring that the encoded value is used in the URL string.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Properly encode the `status` value in the `filterByStatus` function using `encodeURIComponent` before including it in the redirect URL to mitigate code scanning alert no. 564