### PR TITLE
Potential fix for code scanning alert no. 978: OGNL Expression Language statement with user-controlled input

### DIFF
--- a/src/main/java/oscar/facility/FacilityManager2Action.java
+++ b/src/main/java/oscar/facility/FacilityManager2Action.java
@@ -133,7 +133,7 @@ public class FacilityManager2Action extends ActionSupport {
             request.getSession().setAttribute(SessionConstants.CURRENT_FACILITY, facility);
             loggedInInfo.setCurrentFacility(facility);
         }
-        addActionMessage(getText("facility.saved", facility.getName()));
+        addActionMessage(getText("facility.saved", escapeOgnl(facility.getName())));
         request.setAttribute("id", facility.getId());
 
         integratorControlDao.saveRemoveDemographicIdentity(facility.getId(), rdid);
@@ -158,5 +158,13 @@ public class FacilityManager2Action extends ActionSupport {
 
     public void setRemoveDemographicIdentity(boolean removeDemographicIdentity) {
         this.removeDemographicIdentity = removeDemographicIdentity;
+    }
+
+    private String escapeOgnl(String input) {
+        if (input == null) {
+            return null;
+        }
+        // Escape OGNL special characters to prevent injection
+        return org.apache.commons.text.StringEscapeUtils.escapeHtml4(input);
     }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/cc-ar-emr/Open-O/security/code-scanning/978](https://github.com/cc-ar-emr/Open-O/security/code-scanning/978)

To fix the issue, we need to sanitize or validate the `facility.getName()` value before passing it to `addActionMessage()`. This ensures that any malicious OGNL expressions in the user-controlled input are neutralized. A simple and effective approach is to escape special characters in the string to prevent OGNL evaluation. Alternatively, we can validate the input to ensure it conforms to expected patterns.

The best fix involves:
1. Escaping the `facility.getName()` value using a utility method that neutralizes OGNL expressions.
2. Adding a utility method to perform the escaping, if one does not already exist in the codebase.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Escape facility names passed to action messages to neutralize potential OGNL injections and address the code scanning alert.

Bug Fixes:
- Sanitize user-provided facility names before sending to addActionMessage to prevent OGNL expression injection.

Enhancements:
- Add escapeOgnl utility method leveraging Apache Commons Text to escape special characters in facility names.