### PR TITLE
Potential fix for code scanning alert no. 565: DOM text reinterpreted as HTML

### DIFF
--- a/src/main/webapp/PMmodule/ClientManager/forms.jsp
+++ b/src/main/webapp/PMmodule/ClientManager/forms.jsp
@@ -104,12 +104,13 @@
         document.clientManagerForm.clientId.value = '<c:out value="${client.demographicNo}"/>';
         document.clientManagerForm.formId.value = formId;
         var id = document.getElementById('formInstanceId').value;
+        var sanitizedId = encodeURIComponent(id);
         if (methodId == 0)
             methodName = "survey";
         else
             methodName = "printPreview_survey";
 
-        location.href = "<%=request.getContextPath() %>/PMmodule/Forms/SurveyExecute.do?method=" + methodName + "&formId=" + formId + "&formInstanceId=" + id + "&clientId=" + '<c:out value="${client.demographicNo}"/>';
+        location.href = "<%=request.getContextPath() %>/PMmodule/Forms/SurveyExecute.do?method=" + methodName + "&formId=" + formId + "&formInstanceId=" + sanitizedId + "&clientId=" + '<c:out value="${client.demographicNo}"/>';
     }
 
     function createIntake(clientId, nodeId) {

--- a/src/main/webapp/PMmodule/ClientManager/forms.jsp
+++ b/src/main/webapp/PMmodule/ClientManager/forms.jsp
@@ -110,7 +110,7 @@
         else
             methodName = "printPreview_survey";
 
-        location.href = "<%=request.getContextPath() %>/PMmodule/Forms/SurveyExecute.do?method=" + methodName + "&formId=" + formId + "&formInstanceId=" + sanitizedId + "&clientId=" + '<c:out value="${client.demographicNo}"/>';
+        location.href = "<%=request.getContextPath() %>/PMmodule/Forms/SurveyExecute.do?method=" + methodName + "&formId=" + encodeURIComponent(formId) + "&formInstanceId=" + sanitizedId + "&clientId=" + '<c:out value="${client.demographicNo}"/>';
     }
 
     function createIntake(clientId, nodeId) {


### PR DESCRIPTION
Potential fix for [https://github.com/cc-ar-emr/Open-O/security/code-scanning/565](https://github.com/cc-ar-emr/Open-O/security/code-scanning/565)

To fix the issue, the value of `formInstanceId` should be sanitized or encoded before being used in the URL. This can be achieved by using a JavaScript function to encode the value, such as `encodeURIComponent`, which ensures that special characters are properly escaped. This prevents malicious input from being interpreted as part of the URL or as executable code.

The fix involves:
1. Replacing the direct concatenation of `id` into the URL with a sanitized version using `encodeURIComponent(id)`.
2. Ensuring that all dynamic values in the URL are properly encoded to prevent similar vulnerabilities.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Encode formInstanceId with encodeURIComponent in the SurveyExecute redirect URL to prevent DOM text from being reinterpreted as HTML