### PR TITLE
Potential fix for code scanning alert no. 569: DOM text reinterpreted as HTML

### DIFF
--- a/src/main/webapp/billing/CA/BC/privateBilling/viewStatement.jsp
+++ b/src/main/webapp/billing/CA/BC/privateBilling/viewStatement.jsp
@@ -245,7 +245,7 @@
 
         function handleFilterByProvider() {
             var providerId = $("select#providerList").val();
-            window.location.href = "${ctx}/PrivateBillingController?action=listPrivateBills&providerId=" + providerId;
+            window.location.href = "${ctx}/PrivateBillingController?action=listPrivateBills&providerId=" + encodeURIComponent(providerId);
         }
 
         $(function () {


### PR DESCRIPTION
Potential fix for [https://github.com/cc-ar-emr/Open-O/security/code-scanning/569](https://github.com/cc-ar-emr/Open-O/security/code-scanning/569)

To fix the issue, the value retrieved from `$("select#providerList").val()` should be sanitized or encoded before being appended to the URL. A safe approach is to use `encodeURIComponent()` to encode the `providerId` value. This ensures that any special characters in the value are properly escaped, preventing them from being interpreted as part of the URL or as executable code.

The fix involves modifying line 248 to apply `encodeURIComponent()` to the `providerId` value before appending it to the URL. This change ensures that the URL is safe and prevents XSS attacks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Apply encodeURIComponent to providerId when constructing the redirect URL to mitigate DOM text reinterpreted as HTML vulnerability.