### PR TITLE
Potential fix for code scanning alert no. 570: DOM text reinterpreted as HTML

### DIFF
--- a/src/main/webapp/billing/CA/ON/billingONMRI.jsp
+++ b/src/main/webapp/billing/CA/ON/billingONMRI.jsp
@@ -147,7 +147,7 @@
             if (ret) {
                 ss = document.forms[0].billcenter[document.forms[0].billcenter.selectedIndex].value;
                 var su = document.forms[0].useProviderMOH.checked;
-                location.href = "onregenreport.jsp?diskId=" + si + "&billcenter=" + encodeURIComponent(ss) + "&useProviderMOH=" + su;
+                location.href = "onregenreport.jsp?diskId=" + encodeURIComponent(si) + "&billcenter=" + encodeURIComponent(ss) + "&useProviderMOH=" + encodeURIComponent(su);
             }
         }
 


### PR DESCRIPTION
Potential fix for [https://github.com/cc-ar-emr/Open-O/security/code-scanning/570](https://github.com/cc-ar-emr/Open-O/security/code-scanning/570)

To fix the issue, the value of `document.forms[0].billcenter[document.forms[0].billcenter.selectedIndex].value` (stored in `ss`) should be sanitized or encoded before being used in the URL. This can be achieved by using a JavaScript function to encode the value, such as `encodeURIComponent`, which ensures that special characters are properly escaped and prevents malicious input from being interpreted as executable code.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Sanitize the billcenter query parameter by applying encodeURIComponent before constructing the location.href URL to address the code scanning alert and prevent injection via special characters.