### PR TITLE
Potential fix for code scanning alert no. 571: DOM text reinterpreted as HTML

### DIFF
--- a/src/main/webapp/billing/CA/ON/billingONMRI.jsp
+++ b/src/main/webapp/billing/CA/ON/billingONMRI.jsp
@@ -160,7 +160,7 @@
             if (ret) {
                 ss = document.forms[0].billcenter[document.forms[0].billcenter.selectedIndex].value;
                 var su = document.forms[0].useProviderMOH.checked;
-                location.href = "onregenreport.jsp?diskId=" + si + "&billcenter=" + encodeURIComponent(ss) + "&useProviderMOH=" + su;
+                location.href = "onregenreport.jsp?diskId=" + encodeURIComponent(si) + "&billcenter=" + encodeURIComponent(ss) + "&useProviderMOH=" + encodeURIComponent(su);
             }
         }
 

--- a/src/main/webapp/billing/CA/ON/billingONMRI.jsp
+++ b/src/main/webapp/billing/CA/ON/billingONMRI.jsp
@@ -160,7 +160,7 @@
             if (ret) {
                 ss = document.forms[0].billcenter[document.forms[0].billcenter.selectedIndex].value;
                 var su = document.forms[0].useProviderMOH.checked;
-                location.href = "onregenreport.jsp?diskId=" + si + "&billcenter=" + ss + "&useProviderMOH=" + su;
+                location.href = "onregenreport.jsp?diskId=" + si + "&billcenter=" + encodeURIComponent(ss) + "&useProviderMOH=" + su;
             }
         }
 


### PR DESCRIPTION
Potential fix for [https://github.com/cc-ar-emr/Open-O/security/code-scanning/571](https://github.com/cc-ar-emr/Open-O/security/code-scanning/571)

To fix the issue, the value of `document.forms[0].billcenter[document.forms[0].billcenter.selectedIndex].value` (stored in `ss`) must be sanitized or encoded before being used in the URL. A safe approach is to use JavaScript's `encodeURIComponent` function, which ensures that special characters in the value are properly escaped, preventing them from being interpreted as part of the HTML or JavaScript.

The fix involves:
1. Replacing the direct use of `ss` in the URL with `encodeURIComponent(ss)`.
2. Ensuring that all other dynamic values (`si` and `su`) are also sanitized or encoded if necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Escape the billcenter value with encodeURIComponent to sanitize user input in the redirect URL.