### PR TITLE
Potential fix for code scanning alert no. 572: DOM text reinterpreted as HTML

### DIFF
--- a/src/main/webapp/billing/CA/ON/endYearStatement.jsp
+++ b/src/main/webapp/billing/CA/ON/endYearStatement.jsp
@@ -49,7 +49,7 @@
             url += '&search_mode=search_name';
             url += '&orderby=last_name, first_name';
             url += '&limit1=0&limit2=5';
-            url += '&keyword=' + search_param;
+            url += '&keyword=' + encodeURIComponent(search_param);
             popupPage(700, 1000, url, 'master');
             return false;
         }


### PR DESCRIPTION
Potential fix for [https://github.com/cc-ar-emr/Open-O/security/code-scanning/572](https://github.com/cc-ar-emr/Open-O/security/code-scanning/572)

To fix the issue, we need to ensure that any user-controlled input is properly sanitized or encoded before being used in a context where it could be interpreted as executable code or HTML. Specifically:
1. Use a function like `encodeURIComponent` to encode the `search_param` value before appending it to the `url`. This ensures that special characters in the user input are safely encoded.
2. Avoid directly assigning untrusted input to `window.location`. Instead, construct the URL safely and validate it if necessary.

The changes will be made in the `demographicSearch` function, specifically on line 52 where `search_param` is appended to the `url`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Encode the `keyword` query parameter with `encodeURIComponent` before appending it to the URL to sanitize user input and prevent potential XSS.