### PR TITLE
Potential fix for code scanning alert no. 576: DOM text reinterpreted as HTML

### DIFF
--- a/src/main/webapp/documentManager/documentReport.jsp
+++ b/src/main/webapp/documentManager/documentReport.jsp
@@ -419,7 +419,7 @@
                                 <div class="form-group">
                                         <%--      <label for="viewstatus"><fmt:setBundle basename="oscarResources"/><fmt:message key="dms.documentReport.msgViewStatus"/></label>--%>
                                     <select class="form-control" id="viewstatus" name="viewstatus"
-                                            onchange="window.location.href='?function=<%=module%>&functionid=<%=moduleid%>&view=<%=view%>&viewstatus='+this.options[this.selectedIndex].value;">
+                                            onchange="window.location.href='?function=<%=module%>&functionid=<%=moduleid%>&view=<%=view%>&viewstatus=' + encodeURIComponent(this.options[this.selectedIndex].value);">
                                         <option value="all"
                                                 <%=viewstatus.equalsIgnoreCase("all") ? "selected" : ""%>><fmt:setBundle basename="oscarResources"/><fmt:message key="dms.documentReport.msgAll"/></option>
                                         <option value="deleted"


### PR DESCRIPTION
Potential fix for [https://github.com/cc-ar-emr/Open-O/security/code-scanning/576](https://github.com/cc-ar-emr/Open-O/security/code-scanning/576)

To fix the issue, the user-controlled input (`this.options[this.selectedIndex].value`) must be sanitized or encoded before being used in the URL. A safe approach is to use JavaScript's `encodeURIComponent` function to encode the value, ensuring that any special characters are properly escaped. This prevents malicious input from being interpreted as executable code.

The fix involves modifying the `onchange` attribute in the `<select>` element on line 422 to use `encodeURIComponent` for the `this.options[this.selectedIndex].value` before appending it to the URL.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Encode the user-selected viewstatus parameter with encodeURIComponent before appending it to the URL to prevent DOM text reinterpreted as HTML.