### PR TITLE
Potential fix for code scanning alert no. 577: DOM text reinterpreted as HTML

### DIFF
--- a/src/main/webapp/documentManager/documentReport.jsp
+++ b/src/main/webapp/documentManager/documentReport.jsp
@@ -435,7 +435,7 @@
                                         <%--          <label for="view"><fmt:setBundle basename="oscarResources"/><fmt:message key="dms.documentReport.msgView"/></label>--%>
                                     <select id="viewdoctype<%=i%>" name="view" id="view"
                                             class="input-medium form-control"
-                                            onchange="window.location.href='?function=<%=module%>&functionid=<%=moduleid%>&view='+this.options[this.selectedIndex].value;">
+                                            onchange="window.location.href='?function=<%=module%>&functionid=<%=moduleid%>&view='+encodeURIComponent(this.options[this.selectedIndex].value);">
                                         <option value="">All</option>
                                         <%
                                             for (int i3 = 0; i3 < doctypes.size(); i3++) {


### PR DESCRIPTION
Potential fix for [https://github.com/cc-ar-emr/Open-O/security/code-scanning/577](https://github.com/cc-ar-emr/Open-O/security/code-scanning/577)

To fix the issue, the user-controlled input (`this.options[this.selectedIndex].value`) must be properly encoded before being included in the URL. This can be achieved by using JavaScript's `encodeURIComponent` function, which ensures that special characters in the input are safely escaped. This prevents malicious input from being interpreted as executable code or HTML.

The fix involves wrapping `this.options[this.selectedIndex].value` with `encodeURIComponent` in the `onchange` attribute of the `<select>` element on line 438. This ensures that the dynamically constructed URL is safe.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Encode the view parameter in the documentReport.jsp select onchange URL using encodeURIComponent to prevent DOM text from being misinterpreted as HTML.