### PR TITLE
Potential fix for code scanning alert no. 582: DOM text reinterpreted as HTML

### DIFF
--- a/src/main/webapp/eform/eformGenerator.jsp
+++ b/src/main/webapp/eform/eformGenerator.jsp
@@ -401,7 +401,7 @@ and other liscences (MIT, LGPL etc) as indicated
             var ListItem = document.createElement("li");
             ListItem.setAttribute('name', 'UserSignatureListItem');
             var UserSignature = UserName + '|' + FileName;
-            ListItem.innerHTML = UserSignature;
+            ListItem.textContent = UserSignature;
             UserSignatureList.appendChild(ListItem);
         }
 


### PR DESCRIPTION
Potential fix for [https://github.com/cc-ar-emr/Open-O/security/code-scanning/582](https://github.com/cc-ar-emr/Open-O/security/code-scanning/582)

To fix the issue, the code should avoid directly assigning user-controlled input to `innerHTML`. Instead, use `textContent` to safely insert text into the DOM without interpreting it as HTML. This ensures that any special characters in the user input are treated as plain text rather than HTML. Specifically, replace the assignment to `innerHTML` on line 404 with an assignment to `textContent`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Use textContent instead of innerHTML when adding user signature list items to prevent HTML interpretation and possible injection