### PR TITLE
Potential fix for code scanning alert no. 584: DOM text reinterpreted as HTML

### DIFF
--- a/src/main/webapp/eyeform/conreportprint.jsp
+++ b/src/main/webapp/eyeform/conreportprint.jsp
@@ -166,7 +166,7 @@
             }
 
             function faxNumSelect() {
-                document.getElementById("clinicFax").innerHTML = "Fax: " + document.getElementById("sendersFax").value;
+                document.getElementById("clinicFax").textContent = "Fax: " + document.getElementById("sendersFax").value;
             }
 
             function addressSelect() {


### PR DESCRIPTION
Potential fix for [https://github.com/cc-ar-emr/Open-O/security/code-scanning/584](https://github.com/cc-ar-emr/Open-O/security/code-scanning/584)

To fix the issue, the value of `document.getElementById("sendersFax").value` should be properly escaped or sanitized before being inserted into the DOM. Instead of using `innerHTML`, which interprets the input as HTML, we can use `textContent`, which treats the input as plain text and avoids interpreting it as HTML. This ensures that any potentially malicious characters are rendered harmless.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Use textContent instead of innerHTML to sanitize the fax number and prevent HTML injection