### PR TITLE
Potential fix for code scanning alert no. 618: DOM text reinterpreted as HTML

### DIFF
--- a/src/main/webapp/oscarEncounter/oscarMeasurements/DiabFlowSheet.jsp
+++ b/src/main/webapp/oscarEncounter/oscarMeasurements/DiabFlowSheet.jsp
@@ -244,13 +244,14 @@
 
                 //get scroll position
                 var ycoord = $('input[name=ycoord]').val();
+                var encodedYcoord = encodeURIComponent(ycoord);
 
                 $.ajax({
                     url: link,
                     method: 'POST',
                     data: deletevalue,
                     success: function (returnData) {
-                        window.location = "<%=request.getContextPath()%>/oscarEncounter/oscarMeasurements/TemplateFlowSheet.jsp?ycoord=" + ycoord + "&demographic_no=<%=demographic_no%>&template=diab3";
+                        window.location = "<%=request.getContextPath()%>/oscarEncounter/oscarMeasurements/TemplateFlowSheet.jsp?ycoord=" + encodedYcoord + "&demographic_no=<%=demographic_no%>&template=diab3";
 
                     }
                 });


### PR DESCRIPTION
Potential fix for [https://github.com/cc-ar-emr/Open-O/security/code-scanning/618](https://github.com/cc-ar-emr/Open-O/security/code-scanning/618)

To fix the issue, the untrusted input (`$('input[name=ycoord]').val()`) must be sanitized or encoded before being used in the URL. This ensures that any potentially malicious characters are neutralized, preventing XSS attacks. The best approach is to use JavaScript's `encodeURIComponent` function to encode the `ycoord` value before appending it to the URL. This function ensures that special characters in the input are safely encoded for use in a URL.

The changes will be made in the JavaScript code block where the `ycoord` value is retrieved and used. Specifically:
1. Replace the direct use of `ycoord` in the URL with an encoded version using `encodeURIComponent(ycoord)`.
2. Ensure no other changes are made to preserve existing functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Use encodeURIComponent on the ycoord query parameter in the redirect URL to neutralize untrusted input and address code scanning alert no. 618.