### PR TITLE
Potential fix for code scanning alert no. 628: DOM text reinterpreted as HTML

### DIFF
--- a/src/main/webapp/schedule/scheduletemplatesetting.jsp
+++ b/src/main/webapp/schedule/scheduletemplatesetting.jsp
@@ -88,7 +88,9 @@
             }
 
             function selectprovider(s) {
-                self.location.href = "scheduletemplateapplying.jsp?provider_no=" + s.options[s.selectedIndex].value + "&provider_name=" + urlencode(s.options[s.selectedIndex].text);
+                var providerNo = encodeURIComponent(s.options[s.selectedIndex].value);
+                var providerName = encodeURIComponent(s.options[s.selectedIndex].text);
+                self.location.href = "scheduletemplateapplying.jsp?provider_no=" + providerNo + "&provider_name=" + providerName;
             }
 
             function urlencode(str) {


### PR DESCRIPTION
Potential fix for [https://github.com/cc-ar-emr/Open-O/security/code-scanning/628](https://github.com/cc-ar-emr/Open-O/security/code-scanning/628)

To fix the issue, we need to ensure that any user-controlled data (e.g., `s.options[s.selectedIndex].value` and `s.options[s.selectedIndex].text`) is properly sanitized or encoded before being used in the URL. The best approach is to use `encodeURIComponent` to escape special characters in the values before concatenating them into the URL. This ensures that the resulting URL is safe and prevents XSS attacks.

The changes will be made to the `selectprovider` function on line 91. Specifically:
1. Wrap `s.options[s.selectedIndex].value` and `s.options[s.selectedIndex].text` with `encodeURIComponent`.
2. Replace the concatenation logic with the sanitized values.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Encode provider number and provider name with encodeURIComponent in the selectprovider function to address the code scanning alert about DOM text reinterpreted as HTML.