### PR TITLE
Potential fix for code scanning alert no. 632: DOM text reinterpreted as HTML

### DIFF
--- a/src/main/webapp/survey/surveyManager/surveyManager.jsp
+++ b/src/main/webapp/survey/surveyManager/surveyManager.jsp
@@ -143,7 +143,7 @@
         var formId = selectObj.options[selectObj.selectedIndex].value;
         if (formId != "") {
             //alert('<%=request.getContextPath() %>/SurveyManager.do?method=export_csv&id=' + formId);
-            location.href = '<%=request.getContextPath() %>/SurveyManager.do?method=export_csv&id=' + formId;
+            location.href = '<%=request.getContextPath() %>/SurveyManager.do?method=export_csv&id=' + encodeURIComponent(formId);
         }
         //run the command
 
@@ -154,7 +154,7 @@
         var formId = selectObj.options[selectObj.selectedIndex].value;
         if (formId != "") {
             //alert('<%=request.getContextPath() %>/SurveyManager.do?method=export_csv&id=' + formId);
-            location.href = '<%=request.getContextPath() %>/SurveyManager.do?method=export_inverse_csv&id=' + formId;
+            location.href = '<%=request.getContextPath() %>/SurveyManager.do?method=export_inverse_csv&id=' + encodeURIComponent(formId);
         }
         //run the command
 
@@ -165,7 +165,7 @@
         var formId = selectObj.options[selectObj.selectedIndex].value;
         if (formId != "") {
             //alert('<%=request.getContextPath() %>/SurveyManager.do?method=export_csv&id=' + formId);
-            location.href = '<%=request.getContextPath() %>/SurveyManager.do?method=export_to_db&id=' + formId;
+            location.href = '<%=request.getContextPath() %>/SurveyManager.do?method=export_to_db&id=' + encodeURIComponent(formId);
         }
         //run the command
 


### PR DESCRIPTION
Potential fix for [https://github.com/cc-ar-emr/Open-O/security/code-scanning/632](https://github.com/cc-ar-emr/Open-O/security/code-scanning/632)

To fix the issue, the `formId` value must be sanitized or encoded before being used in the `location.href` assignment. This ensures that any potentially malicious characters are neutralized and cannot be interpreted as executable code. A common approach is to use JavaScript's `encodeURIComponent` function to encode the `formId` value, which escapes special characters and makes the URL safe.

The changes will be made in the JavaScript functions `export_csv`, `export_inverse_csv`, and `export_to_db` to apply `encodeURIComponent` to the `formId` value before concatenating it into the URL.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
