### PR TITLE
Potential fix for code scanning alert no. 634: DOM text reinterpreted as HTML

### DIFF
--- a/src/main/webapp/survey/surveyManager/surveyManager.jsp
+++ b/src/main/webapp/survey/surveyManager/surveyManager.jsp
@@ -143,7 +143,7 @@
         var formId = selectObj.options[selectObj.selectedIndex].value;
         if (formId != "") {
             //alert('<%=request.getContextPath() %>/SurveyManager.do?method=export_csv&id=' + formId);
-            location.href = '<%=request.getContextPath() %>/SurveyManager.do?method=export_csv&id=' + formId;
+            location.href = '<%=request.getContextPath() %>/SurveyManager.do?method=export_csv&id=' + encodeURIComponent(formId);
         }
         //run the command
 
@@ -154,7 +154,7 @@
         var formId = selectObj.options[selectObj.selectedIndex].value;
         if (formId != "") {
             //alert('<%=request.getContextPath() %>/SurveyManager.do?method=export_csv&id=' + formId);
-            location.href = '<%=request.getContextPath() %>/SurveyManager.do?method=export_inverse_csv&id=' + formId;
+            location.href = '<%=request.getContextPath() %>/SurveyManager.do?method=export_inverse_csv&id=' + encodeURIComponent(formId);
         }
         //run the command
 
@@ -165,7 +165,7 @@
         var formId = selectObj.options[selectObj.selectedIndex].value;
         if (formId != "") {
             //alert('<%=request.getContextPath() %>/SurveyManager.do?method=export_csv&id=' + formId);
-            location.href = '<%=request.getContextPath() %>/SurveyManager.do?method=export_to_db&id=' + formId;
+            location.href = '<%=request.getContextPath() %>/SurveyManager.do?method=export_to_db&id=' + encodeURIComponent(formId);
         }
         //run the command
 


### PR DESCRIPTION
Potential fix for [https://github.com/cc-ar-emr/Open-O/security/code-scanning/634](https://github.com/cc-ar-emr/Open-O/security/code-scanning/634)

To fix the issue, we need to ensure that the `formId` value is sanitized or validated before it is used in the `location.href` assignment. A simple and effective approach is to encode the `formId` value using `encodeURIComponent`, which ensures that any special characters in the value are safely escaped. This prevents malicious input from being interpreted as part of the URL or as executable code.

The changes will be made in the `export_to_db` function (and similar functions like `export_csv` and `export_inverse_csv` for consistency). Specifically:
1. Replace the direct concatenation of `formId` into the URL with a sanitized version using `encodeURIComponent(formId)`.
2. Ensure that no other functionality is affected.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Sanitize `formId` in `export_csv`, `export_inverse_csv`, and `export_to_db` functions by applying `encodeURIComponent` before assigning to `location.href`.