### PR TITLE
Potential fix for code scanning alert no. 563: Exception text reinterpreted as HTML

### DIFF
--- a/src/main/webapp/library/bootstrap/3.0.0/assets/js/customizer.js
+++ b/src/main/webapp/library/bootstrap/3.0.0/assets/js/customizer.js
@@ -2,11 +2,20 @@ window.onload = function () { // wait for load in a dumb way because B-0
     var cw = '/*!\n * Bootstrap v3.0.0\n *\n * Copyright 2013 Twitter, Inc\n * Licensed under the Apache License v2.0\n * http://www.apache.org/licenses/LICENSE-2.0\n *\n * Designed and built with all the love in the world @twitter by @mdo and @fat.\n */\n\n'
 
     function showError(msg, err) {
+        function escapeHTML(str) {
+            return str.replace(/&/g, '&amp;')
+                      .replace(/</g, '&lt;')
+                      .replace(/>/g, '&gt;')
+                      .replace(/"/g, '&quot;')
+                     .replace(/'/g, '&#039;');
+        }
+        var sanitizedMsg = escapeHTML(msg);
+        var sanitizedExtract = err.extract ? err.extract.map(escapeHTML).join('\n') : '';
         $('<div id="bsCustomizerAlert" class="bs-customizer-alert">\
         <div class="container">\
           <a href="#bsCustomizerAlert" data-dismiss="alert" class="close pull-right">&times;</a>\
-          <p class="bs-customizer-alert-text"><span class="glyphicon glyphicon-warning-sign"></span>' + msg + '</p>' +
-            (err.extract ? '<pre class="bs-customizer-alert-extract">' + err.extract.join('\n') + '</pre>' : '') + '\
+          <p class="bs-customizer-alert-text"><span class="glyphicon glyphicon-warning-sign"></span>' + sanitizedMsg + '</p>' +
+            (sanitizedExtract ? '<pre class="bs-customizer-alert-extract">' + sanitizedExtract + '</pre>' : '') + '\
         </div>\
       </div>').appendTo('body').alert()
         throw err


### PR DESCRIPTION
Potential fix for [https://github.com/cc-ar-emr/Open-O/security/code-scanning/563](https://github.com/cc-ar-emr/Open-O/security/code-scanning/563)

To fix the issue, we need to ensure that any dynamic data inserted into the DOM is properly sanitized or escaped. Specifically:
1. Use a library like `DOMPurify` to sanitize the `msg` and `err.extract` values before inserting them into the DOM.
2. Alternatively, use a function to escape HTML special characters (`<`, `>`, `&`, etc.) in these values to prevent them from being interpreted as HTML.

The changes will be made in the `showError` function in `src/main/webapp/library/bootstrap/3.0.0/assets/js/customizer.js`. The `msg` and `err.extract` values will be sanitized or escaped before being concatenated into the HTML string.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Escape HTML special characters in error message and stack extract before injecting into the DOM