### PR TITLE
Potential fix for code scanning alert no. 585: DOM text reinterpreted as HTML

### DIFF
--- a/src/main/webapp/eyeform/plan_new.jsp
+++ b/src/main/webapp/eyeform/plan_new.jsp
@@ -65,7 +65,8 @@
             //var deleteList = jQuery("input[name='followup.delete']").val();
             var followUpId = jQuery("input[name='followup_" + id + ".id']").val();
             //jQuery("input[name='followup.delete']").val(deleteList += ','+followUpId);
-            jQuery("form[name='eyeformPlanForm']").append("<input type=\"hidden\" name=\"followup.delete\" value=\"" + followUpId + "\"/>");
+            var escapedFollowUpId = jQuery('<div>').text(followUpId).html();
+            jQuery("form[name='eyeformPlanForm']").append("<input type=\"hidden\" name=\"followup.delete\" value=\"" + escapedFollowUpId + "\"/>");
             jQuery("#followup_" + id).remove();
 
         }


### PR DESCRIPTION
Potential fix for [https://github.com/cc-ar-emr/Open-O/security/code-scanning/585](https://github.com/cc-ar-emr/Open-O/security/code-scanning/585)

To fix the issue, the code should ensure that any user-controlled input is properly escaped before being inserted into the DOM. In this case, the `followUpId` value should be escaped to prevent the interpretation of special characters as HTML. The best approach is to use a library or function that safely escapes HTML, such as `jQuery('<div>').text(followUpId).html()` or a similar utility.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Escape followUpId using jQuery('<div>').text(...).html() before appending it as a hidden input to prevent DOM text reinterpreted as HTML.