### PR TITLE
Potential fix for code scanning alert no. 587: DOM text reinterpreted as HTML

### DIFF
--- a/src/main/webapp/eyeform/plan_new.jsp
+++ b/src/main/webapp/eyeform/plan_new.jsp
@@ -100,7 +100,8 @@
 
         function deleteTest(id) {
             var testId = jQuery("input[name='test_" + id + ".id']").val();
-            jQuery("form[name='eyeformPlanForm']").append("<input type=\"hidden\" name=\"test.delete\" value=\"" + testId + "\"/>");
+            var escapedTestId = jQuery('<div>').text(testId).html();
+            jQuery("form[name='eyeformPlanForm']").append("<input type=\"hidden\" name=\"test.delete\" value=\"" + escapedTestId + "\"/>");
             jQuery("#test_" + id).remove();
         }
 


### PR DESCRIPTION
Potential fix for [https://github.com/cc-ar-emr/Open-O/security/code-scanning/587](https://github.com/cc-ar-emr/Open-O/security/code-scanning/587)

To fix the issue, the `testId` value must be properly escaped or sanitized before being inserted into the HTML string. This can be achieved by using a library or function that ensures the value is safe for inclusion in HTML. In this case, we can use `jQuery`'s `text()` method to safely insert the value into a DOM element, or we can use a utility function to escape special HTML characters.

The best approach is to escape the `testId` value before concatenating it into the HTML string. This ensures that any special characters in `testId` (e.g., `<`, `>`, `&`, `"`) are properly encoded, preventing them from being interpreted as HTML or JavaScript.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Escape and sanitize the `testId` value using jQuery’s text() and html() methods before appending it to the form to prevent DOM text being reinterpreted as HTML or malicious injection.