### PR TITLE
Potential fix for code scanning alert no. 603: DOM text reinterpreted as HTML

### DIFF
--- a/src/main/webapp/lab/CA/ALL/labDisplay.jsp
+++ b/src/main/webapp/lab/CA/ALL/labDisplay.jsp
@@ -1039,7 +1039,7 @@
                     ajaxcall: true
                 }
             })
-            jQuery("#labelspan_<%=Encode.forJavaScript(segmentID)%> i").html(jQuery("#label_<%=Encode.forJavaScript(segmentID)%>").val());
+            jQuery("#labelspan_<%=Encode.forJavaScript(segmentID)%> i").text(jQuery("#label_<%=Encode.forJavaScript(segmentID)%>").val());
             document.forms['acknowledgeForm_<%=Encode.forJavaScript(segmentID)%>'].label.value = "";
         });
     });


### PR DESCRIPTION
Potential fix for [https://github.com/cc-ar-emr/Open-O/security/code-scanning/603](https://github.com/cc-ar-emr/Open-O/security/code-scanning/603)

To fix the issue, the value retrieved from the input field should be treated as plain text and not as HTML. Instead of using `.html()`, which interprets the input as HTML, we should use `.text()`, which safely escapes any HTML meta-characters in the input. This ensures that the input is displayed as plain text, mitigating the risk of XSS.

The fix involves replacing the `.html()` method with `.text()` on line 1042. No additional imports or dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Replace .html() with .text() for the labelspan element to escape HTML and mitigate XSS risk.