### PR TITLE
Potential fix for code scanning alert no. 615: DOM text reinterpreted as HTML

### DIFF
--- a/src/main/webapp/location.jsp
+++ b/src/main/webapp/location.jsp
@@ -75,7 +75,7 @@
 <script type="text/javascript">
     function setLocation() {
         var programIdForLocation = jQuery("#programIdForLocation").val();
-        window.location.href = "provider/providercontrol.jsp?<%=org.oscarehr.util.SessionConstants.CURRENT_PROGRAM_ID%>=" + programIdForLocation;
+        window.location.href = "provider/providercontrol.jsp?<%=org.oscarehr.util.SessionConstants.CURRENT_PROGRAM_ID%>=" + encodeURIComponent(programIdForLocation);
     }
 </script>
 </html>


### PR DESCRIPTION
Potential fix for [https://github.com/cc-ar-emr/Open-O/security/code-scanning/615](https://github.com/cc-ar-emr/Open-O/security/code-scanning/615)

To fix the issue, the value of `programIdForLocation` should be sanitized or validated before being appended to the URL. A robust approach is to encode the value using `encodeURIComponent`, which ensures that any special characters in the value are safely escaped. This prevents malicious input from being interpreted as part of the URL or as executable code.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Encode programIdForLocation using encodeURIComponent to prevent malicious input from being interpreted as HTML or code.