### PR TITLE
Updated the version of edt-stubs in pom.xml and lock.json

### DIFF
--- a/dependencies-lock.json
+++ b/dependencies-lock.json
@@ -2988,7 +2988,7 @@
   }, {
     "groupId" : "org.oscarehr.integration.ebs",
     "artifactId" : "edt-stubs",
-    "version" : "0.0.1-SNAPSHOT",
+    "version" : "0.0.1-20140911.161211-1",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
@@ -2996,7 +2996,7 @@
   }, {
     "groupId" : "org.oscarehr.integration.ebs",
     "artifactId" : "hcv-stubs",
-    "version" : "0.0.1-SNAPSHOT",
+    "version" : "0.0.1-20140911.161502-1",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,

--- a/pom.xml
+++ b/pom.xml
@@ -1121,12 +1121,12 @@
         <dependency>
             <groupId>org.oscarehr.integration.ebs</groupId>
             <artifactId>edt-stubs</artifactId>
-            <version>0.0.1-SNAPSHOT</version>
+            <version>0.0.1-20140911.161211-1</version>
         </dependency>
         <dependency>
             <groupId>org.oscarehr.integration.ebs</groupId>
             <artifactId>hcv-stubs</artifactId>
-            <version>0.0.1-SNAPSHOT</version>
+            <version>0.0.1-20140911.161502-1</version>
         </dependency>
 
         <!-- Detected as "Unused dependency" but don't remove it, it's using actually -->


### PR DESCRIPTION
Issue described in #302 

The summary by Deepseek:
Root Cause:
The unpredictability of SNAPSHOT versions caused the hash verification to fail.

Fix Implemented:
Switched to timestamped versions + synchronized the lock file.

**Long-term Maintenance:**
If ebs-stubs is no longer maintained (last updated in 2014), we recommend the team to:
Internalize the relevant code (e.g., copy the source into the project and remove the dependency).

## Summary by Sourcery

Update EDB-stubs and HCV-stubs to timestamped releases to stabilize dependency hashes and regenerate the lock file

Bug Fixes:
- Fix hash verification failures caused by unpredictable SNAPSHOT versions

Enhancements:
- Bump edt-stubs and hcv-stubs from SNAPSHOT to timestamped 0.0.1-20140911… versions in pom.xml
- Synchronize dependencies-lock.json after version updates