### PR TITLE
fix: unable to generate eforms

### DIFF
--- a/dependencies-lock.json
+++ b/dependencies-lock.json
@@ -707,11 +707,11 @@
   }, {
     "groupId" : "commons-beanutils",
     "artifactId" : "commons-beanutils",
-    "version" : "1.7.0",
+    "version" : "1.9.4",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:CynXj9capNSYn3hRixrqsRUqD/yqG3VGDGibfH3BVZRHvjK/k4ojDikkC//yeL/JFFiRYsyh5rqYC/tY7a9bBg=="
+    "integrity" : "sha512:d2KzSMrs6tSQOKOKiXVP99m+YZkyQxVJW6R88k9SwG+q35MG2SXI/kfFh1iak5yC5JHhxzAmf981QkOmjA+W/w=="
   }, {
     "groupId" : "commons-betwixt",
     "artifactId" : "commons-betwixt",
@@ -819,11 +819,11 @@
   }, {
     "groupId" : "commons-validator",
     "artifactId" : "commons-validator",
-    "version" : "1.3.1",
+    "version" : "1.9.0",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:rKQ0an19rrbbVjips4ZGZIwhYo0YFUPJJy+6r7qhIYUp6mRjKnAptYEPZFYrPxYUl02bGuRtPVqmnyHjomP5EA=="
+    "integrity" : "sha512:TwFPvvJ26/FjK4lf62j/EougiuxjxO31bxHm03M4W3DWzrtxzJWaGBclVXMCBl1azuLu6orRzlaDGuwbO2YKhQ=="
   }, {
     "groupId" : "displaytag",
     "artifactId" : "displaytag",
@@ -3425,14 +3425,6 @@
     "type" : "jar",
     "optional" : false,
     "integrity" : "sha512:nYKlrF2wKm0zGaoP6W0snVqzxznHnNj9EbQDlJk9h0ijYcmQ5x+hYLt41EAx9vFRtV3llxNGjjZD5LxKV0GdUg=="
-  }, {
-    "groupId" : "oro",
-    "artifactId" : "oro",
-    "version" : "2.0.8",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:mpjkk8TXcTIrEzHsBasONjqD2Kwq+AGNlqRN8r9b/JfTPr5vb5PkarEL8VNvDCnp2VaTGO1JvBi06Wsai0dtNw=="
   }, {
     "groupId" : "patientSiteVisit",
     "artifactId" : "patientSiteVisit",

--- a/pom.xml
+++ b/pom.xml
@@ -143,10 +143,11 @@
             <artifactId>commons-lang</artifactId>
             <version>2.4</version>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/commons-validator/commons-validator -->
         <dependency>
             <groupId>commons-validator</groupId>
             <artifactId>commons-validator</artifactId>
-            <version>1.3.1</version>
+            <version>1.9.0</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
@@ -1303,13 +1304,6 @@
             <groupId>org.apache.struts</groupId>
             <artifactId>struts2-spring-plugin</artifactId>
             <version>2.5.33</version>
-        </dependency>
-
-        <!-- https://mvnrepository.com/artifact/oro/oro/2.0.8 -->
-        <dependency>
-            <groupId>oro</groupId>
-            <artifactId>oro</artifactId>
-            <version>2.0.8</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Fixed issue with eforms giving 500 errors if accessed through a patient with an email field.

The issue was that a package called "oro" was not installed, which it was trying to find for regular expression matching

## Summary by Sourcery

Add oro library dependency to fix 500 errors when generating eforms for patients with email fields

Bug Fixes:
- Add oro:oro:2.0.8 dependency to resolve missing package error during eform generation

Build:
- Update pom.xml and dependencies-lock.json to include the new oro dependency