### PR TITLE
Potential fix for code scanning alert no. 769: Resolving XML external entity in user-controlled data

### DIFF
--- a/src/main/java/oscar/util/UtilXML.java
+++ b/src/main/java/oscar/util/UtilXML.java
@@ -124,7 +124,10 @@ public class UtilXML {
         Document document;
         try {
             InputSource is = new InputSource(new StringReader(xmlInput));
-            Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(is);
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            Document doc = factory.newDocumentBuilder().parse(is);
             Document document1 = doc;
             return document1;
         } catch (Exception e) {
@@ -136,7 +139,10 @@ public class UtilXML {
     public static Document parseXMLFile(String fileName)
             throws IOException, FileNotFoundException, Exception {
         InputSource is = new InputSource(new FileReader(fileName));
-        Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(is);
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+        Document doc = factory.newDocumentBuilder().parse(is);
         return doc;
     }
 


### PR DESCRIPTION
Potential fix for [https://github.com/cc-ar-emr/Open-O/security/code-scanning/769](https://github.com/cc-ar-emr/Open-O/security/code-scanning/769)

To fix the issue, the XML parser must be securely configured to prevent XXE attacks. Specifically:
1. Disable DTD processing by setting the feature `http://apache.org/xml/features/disallow-doctype-decl` to `true`.
2. Disable external entity processing by setting the feature `http://xml.org/sax/features/external-general-entities` to `false`.
3. Apply these configurations to all instances of `DocumentBuilderFactory` used for parsing XML.

The changes will be made in the `parseXML` and `parseXMLFile` methods in `UtilXML`. These methods will be updated to configure the `DocumentBuilderFactory` securely before creating the `DocumentBuilder`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Securely configure XML parser in UtilXML to prevent XXE vulnerabilities by disabling DTD processing and external entity resolution in parseXML and parseXMLFile methods.

Bug Fixes:
- Disable DTD processing by setting disallow-doctype-decl feature to true.
- Disable external entity processing by setting external-general-entities feature to false in XML parser configuration.