### PR TITLE
Potential fix for code scanning alert no. 971: OGNL Expression Language statement with user-controlled input

### DIFF
--- a/src/main/java/org/oscarehr/PMmodule/web/admin/ProgramManager2Action.java
+++ b/src/main/java/org/oscarehr/PMmodule/web/admin/ProgramManager2Action.java
@@ -1270,7 +1270,14 @@ public class ProgramManager2Action extends ActionSupport {
         team.setProgramId(program.getId());
 
         if (programManager.teamNameExists(program.getId(), team.getName())) {
-            addActionMessage(getText("program_team.duplicate", team.getName()));
+            if (isValidTeamName(team.getName())) {
+                addActionMessage(getText("program_team.duplicate", team.getName()));
+            } else {
+                addActionMessage(getText("program_team.invalid_name"));
+                this.setTeam(new ProgramTeam());
+                setEditAttributes(request, String.valueOf(program.getId()));
+                return "edit";
+            }
             this.setTeam(new ProgramTeam());
             setEditAttributes(request, String.valueOf(program.getId()));
             return "edit";
@@ -1716,5 +1723,9 @@ public class ProgramManager2Action extends ActionSupport {
 
     public void setVacancyOrTemplateId(String vacancyOrTemplateId) {
         this.vacancyOrTemplateId = vacancyOrTemplateId;
+    }
+    private boolean isValidTeamName(String name) {
+        // Custom validation logic to ensure the name does not contain malicious OGNL expressions
+        return name != null && name.matches("^[a-zA-Z0-9_\\-\\s]+$"); // Example: Allow only alphanumeric, underscores, hyphens, and spaces
     }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/cc-ar-emr/Open-O/security/code-scanning/971](https://github.com/cc-ar-emr/Open-O/security/code-scanning/971)

To fix the issue, we need to ensure that the user-provided input (`team.getName()`) is validated before being used in the `getText()` method. This can be achieved by implementing a validation method that checks the input for malicious OGNL expressions or other unexpected code. Additionally, we can enable OGNL sandboxing globally to mitigate risks.

Steps to fix:
1. Add a validation method to check the `team.getName()` input for malicious content.
2. Validate the `team.getName()` input before passing it to the `getText()` method.
3. Optionally, enable OGNL sandboxing globally by setting the system property `ognl.security.manager`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Validate user-provided team names to mitigate OGNL injection risks by adding whitelist validation before invoking getText and handling invalid names gracefully.

Bug Fixes:
- Prevent potential OGNL injection by validating team.getName() before passing it to getText and rejecting invalid names.

Enhancements:
- Introduce isValidTeamName method to enforce a whitelist of allowed characters for team names.