### PR TITLE
Potential fix for code scanning alert no. 420: Resolving XML external entity in user-controlled data

### DIFF
--- a/src/main/java/org/oscarehr/util/XmlUtils.java
+++ b/src/main/java/org/oscarehr/util/XmlUtils.java
@@ -115,6 +115,9 @@ public final class XmlUtils {
 
     public static Document toDocument(InputStream is) throws ParserConfigurationException, SAXException, IOException {
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+        factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
         DocumentBuilder builder = factory.newDocumentBuilder();
         Document document = builder.parse(is);
         return document;

--- a/src/main/java/org/oscarehr/ws/rest/SurveillanceService.java
+++ b/src/main/java/org/oscarehr/ws/rest/SurveillanceService.java
@@ -538,7 +538,7 @@ public class SurveillanceService extends AbstractServiceImpl {
                 //Need to migrate participants from the running surviellance
 
                 Survey currentSurvey = Survey.createSurvey(resourceStorage.getFileContents());
-                Survey newSurvey = Survey.createSurvey(jSONObject.getString("xml"));//resource.getBytes());
+                Survey newSurvey = Survey.createSurvey(jSONObject.getString("xml")); // Ensure Survey.createSurvey is secure.
                 newSurvey.setProviderList(currentSurvey.getProviderList());
 
 

--- a/src/main/java/oscar/oscarSurveillance/Survey.java
+++ b/src/main/java/oscar/oscarSurveillance/Survey.java
@@ -656,12 +656,12 @@ public class Survey {
 
 
     public static Survey createSurvey(byte[] bArray) throws IOException, SAXException, ParserConfigurationException {
-        Document doc = XmlUtils.toDocument(bArray);
+        Document doc = XmlUtils.toDocument(bArray); // Ensure XmlUtils.toDocument is secure.
         return fromDocument(doc);
     }
 
     public static Survey createSurvey(String str) throws IOException, SAXException, ParserConfigurationException {
-        Document doc = XmlUtils.toDocument(str);
+        Document doc = XmlUtils.toDocument(str); // Ensure XmlUtils.toDocument is secure.
         return fromDocument(doc);
     }
 


### PR DESCRIPTION
Potential fix for [https://github.com/cc-ar-emr/Open-O/security/code-scanning/420](https://github.com/cc-ar-emr/Open-O/security/code-scanning/420)

To fix the issue, the `DocumentBuilderFactory` should be configured to disable DTD processing and external entity resolution. This can be achieved by setting the following features:
- `"http://apache.org/xml/features/disallow-doctype-decl"` to `true` to disable DTD declarations.
- `"http://xml.org/sax/features/external-general-entities"` to `false` to disable external general entities.
- `"http://xml.org/sax/features/external-parameter-entities"` to `false` to disable external parameter entities.

These changes should be applied in the `toDocument` method in `XmlUtils` and any other methods that create a `DocumentBuilderFactory` instance.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Disable DTD declarations and external entity resolution in XML parsing to address a code scanning security alert.

Bug Fixes:
- Disable DOCTYPE declarations and external general/parameter entity resolution in XmlUtils.toDocument.

Enhancements:
- Add comments in Survey.createSurvey and SurveillanceService.updateSurveyFromK2A to emphasize secure XML parsing.