### PR TITLE
Potential fix for code scanning alert no. 768: Resolving XML external entity in user-controlled data

### DIFF
--- a/src/main/java/oscar/oscarReport/reportByTemplate/ReportManager.java
+++ b/src/main/java/oscar/oscarReport/reportByTemplate/ReportManager.java
@@ -276,6 +276,8 @@ public class ReportManager {
 
     public Document readXml(String xml) throws Exception {
         SAXBuilder parser = new SAXBuilder();
+        parser.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        parser.setFeature("http://xml.org/sax/features/external-general-entities", false);
         xml = UtilXML.escapeXML(xml); //escapes anomalies such as "date >= {mydate}" the '>' character
         //xml  UtilXML.escapeAllXML(xml, "<param-list>");  //escapes all markup in <report> tag, otherwise can't retrieve element.getText()
         Document doc = parser.build(new java.io.ByteArrayInputStream(xml.getBytes()));


### PR DESCRIPTION
Potential fix for [https://github.com/cc-ar-emr/Open-O/security/code-scanning/768](https://github.com/cc-ar-emr/Open-O/security/code-scanning/768)

To fix the issue, the `SAXBuilder` instance should be configured to disable DTD processing and external entity resolution. This can be achieved by setting the appropriate features on the underlying XML parser. Specifically:
1. Disable DTD processing by setting the feature `http://apache.org/xml/features/disallow-doctype-decl` to `true`.
2. Disable external entity resolution by setting the feature `http://xml.org/sax/features/external-general-entities` to `false`.

These changes should be applied in the `readXml` method of `ReportManager` where the `SAXBuilder` instance is created.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Disable XML external entities and DTD processing in ReportManager.readXml to mitigate XXE vulnerabilities

Bug Fixes:
- Disable DTD processing by setting SAXBuilder feature disallow-doctype-decl to true
- Disable external entity resolution by setting SAXBuilder feature external-general-entities to false