### PR TITLE
Potential fix for code scanning alert no. 946: OGNL Expression Language statement with user-controlled input

### DIFF
--- a/src/main/java/org/oscarehr/PMmodule/web/admin/ProgramManager2Action.java
+++ b/src/main/java/org/oscarehr/PMmodule/web/admin/ProgramManager2Action.java
@@ -32,7 +32,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-
+import org.apache.commons.text.StringEscapeUtils;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.xml.ws.WebServiceException;
@@ -474,7 +474,8 @@ public class ProgramManager2Action extends ActionSupport {
 
         admissionManager.saveAdmission(ad);
         if (isValidProgramName(program.getName())) {
-            addActionMessage(getText("program.saved", program.getName()));
+            String safeProgramName = StringEscapeUtils.escapeHtml4(program.getName());
+            addActionMessage(getText("program.saved", safeProgramName));
         } else {
             addActionMessage(getText("program.saved", "Invalid Program Name"));
         }


### PR DESCRIPTION
Potential fix for [https://github.com/cc-ar-emr/Open-O/security/code-scanning/946](https://github.com/cc-ar-emr/Open-O/security/code-scanning/946)

To fix the issue, the user-provided input (`program.getName()`) must be validated or sanitized before being used in `addActionMessage()`. This can be achieved by implementing a validation method that ensures the input does not contain malicious OGNL expressions or unexpected code. Additionally, sandboxing OGNL evaluation can be enforced globally to mitigate risks.

**Steps to fix:**
1. Implement a validation method (`isValidProgramName`) to check the safety of `program.getName()`.
2. Use the validation method before calling `addActionMessage()` to ensure only safe input is processed.
3. Optionally, enforce OGNL sandboxing globally by setting the system property `ognl.security.manager`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Validate program names before displaying action messages to mitigate OGNL injection risk and address code scanning alert 946.

Bug Fixes:
- Prevent OGNL expression injection by validating user-provided program names before calling addActionMessage.

Enhancements:
- Introduce isValidProgramName helper method with regex-based validation and provide a fallback message for invalid names.