### PR TITLE
Potential fix for code scanning alert no. 944: OGNL Expression Language statement with user-controlled input

### DIFF
--- a/src/main/java/org/oscarehr/PMmodule/web/admin/ProgramManager2Action.java
+++ b/src/main/java/org/oscarehr/PMmodule/web/admin/ProgramManager2Action.java
@@ -431,7 +431,8 @@ public class ProgramManager2Action extends ActionSupport {
         pp.setRoleId(provider.getRoleId());
 
         programManager.saveProgramProvider(pp);
-        addActionMessage(getText("program.saved", program.getName()));
+        String sanitizedProgramName = sanitizeInput(program.getName());
+        addActionMessage(getText("program.saved", sanitizedProgramName));
 
         LogAction.log("write", "edit program - assign role", String.valueOf(program.getId()), request);
         this.setProvider(new ProgramProvider());
@@ -1716,5 +1717,9 @@ public class ProgramManager2Action extends ActionSupport {
 
     public void setVacancyOrTemplateId(String vacancyOrTemplateId) {
         this.vacancyOrTemplateId = vacancyOrTemplateId;
+    }
+    private String sanitizeInput(String input) {
+        // Example sanitization: Remove potentially dangerous characters or patterns
+        return input.replaceAll("[{}\\[\\]$]", "");
     }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/cc-ar-emr/Open-O/security/code-scanning/944](https://github.com/cc-ar-emr/Open-O/security/code-scanning/944)

To fix the issue, we need to ensure that the value returned by `program.getName()` is validated or sanitized before being passed to `addActionMessage()`. This can be achieved by implementing a validation or sanitization method that ensures the string does not contain malicious OGNL expressions. Additionally, if the framework supports it, enabling a security manager for OGNL expressions can provide an extra layer of protection.

Steps to fix:
1. Implement a validation or sanitization method to check the safety of the `program.getName()` value.
2. Use this method to validate or sanitize the value before passing it to `addActionMessage()`.
3. Optionally, enable a security manager for OGNL expressions by setting the system property `ognl.security.manager`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Sanitize user-controlled program names before passing them to OGNL-based messages to address a security code scanning alert

Bug Fixes:
- Validate and sanitize program.getName() before calling addActionMessage to prevent OGNL injection

Enhancements:
- Introduce a sanitizeInput helper method to strip potentially dangerous characters from input