### PR TITLE
Potential fix for code scanning alert no. 943: OGNL Expression Language statement with user-controlled input

### DIFF
--- a/src/main/java/com/quatro/web/lookup/LookupCodeEdit2Action.java
+++ b/src/main/java/com/quatro/web/lookup/LookupCodeEdit2Action.java
@@ -139,7 +139,11 @@ public class LookupCodeEdit2Action extends ActionSupport {
             if ("SHL,OGN".indexOf(tableDef.getTableId()) >= 0) {
                 int clientCount = lookupManager.getCountOfActiveClient(tableDef.getTableId().substring(0, 1) + code);
                 if (clientCount > 0)
-                    addActionMessage(getText("error.lookup.client", tableDef.getDescription()));
+                    if (isValidDescription(tableDef.getDescription())) {
+                        addActionMessage(getText("error.lookup.client", tableDef.getDescription()));
+                    } else {
+                        addActionMessage(getText("error.lookup.invalidDescription"));
+                    }
             }
         }
         if (!getActionMessages().isEmpty()) {
@@ -198,5 +202,10 @@ public class LookupCodeEdit2Action extends ActionSupport {
 
     public void setErrMsg(String errMsg) {
         this.errMsg = errMsg;
+    }
+    private boolean isValidDescription(String description) {
+        // Custom validation logic to ensure the description is safe.
+        // For example, check for unexpected characters or patterns.
+        return description != null && description.matches("[a-zA-Z0-9\\s]+");
     }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/cc-ar-emr/Open-O/security/code-scanning/943](https://github.com/cc-ar-emr/Open-O/security/code-scanning/943)

To fix the issue, we need to validate or sanitize the user-controlled input (`tableDef.getDescription()`) before using it. This can be achieved by implementing a validation method that ensures the input does not contain malicious or unexpected content. Additionally, we can use a sandbox for OGNL evaluation if applicable.

**Steps to fix:**
1. Implement a validation method (`isValidDescription`) to check the safety of `tableDef.getDescription()`.
2. Validate the description before using it in `addActionMessage()` on line 142.
3. Reject or sanitize the input if it fails validation.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Validate and sanitize the user-controlled table description before using it in action messages to address an OGNL injection vulnerability

Bug Fixes:
- Fix OGNL Expression Language injection by validating `tableDef.getDescription()` before adding action messages

Enhancements:
- Add `isValidDescription` method to enforce alphanumeric and whitespace-only descriptions
- Display a generic invalid-description error message when validation fails