### PR TITLE
Potential fix for code scanning alert no. 952: OGNL Expression Language statement with user-controlled input

### DIFF
--- a/src/main/java/org/oscarehr/PMmodule/web/admin/ProgramManager2Action.java
+++ b/src/main/java/org/oscarehr/PMmodule/web/admin/ProgramManager2Action.java
@@ -485,6 +485,10 @@ public class ProgramManager2Action extends ActionSupport {
     public String delete() {
         String id = request.getParameter("id");
         String name = request.getParameter("name");
+        if (!isValidName(name)) {
+            addActionMessage(getText("program.invalid.name"));
+            return list();
+        }
 
         if (id == null) {
             return list();
@@ -514,7 +518,7 @@ public class ProgramManager2Action extends ActionSupport {
         programManager.removeProgram(id);
         programManager.deleteProgramProviderByProgramId(Long.valueOf(id));
 
-        addActionMessage(getText("program.deleted", name));
+        addActionMessage(getText("program.deleted", escapeName(name)));
 
         LogAction.log("write", "delete program", String.valueOf(program.getId()), request);
 
@@ -1716,5 +1720,14 @@ public class ProgramManager2Action extends ActionSupport {
 
     public void setVacancyOrTemplateId(String vacancyOrTemplateId) {
         this.vacancyOrTemplateId = vacancyOrTemplateId;
+    }
+    private boolean isValidName(String name) {
+        // Validate the name against a whitelist of allowed characters (e.g., letters, numbers, spaces)
+        return name != null && name.matches("^[a-zA-Z0-9\\s]+$");
+    }
+
+    private String escapeName(String name) {
+        // Escape the name to neutralize any potentially harmful OGNL expressions
+        return org.apache.commons.text.StringEscapeUtils.escapeHtml4(name);
     }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/cc-ar-emr/Open-O/security/code-scanning/952](https://github.com/cc-ar-emr/Open-O/security/code-scanning/952)

To fix the issue, we need to ensure that the `name` parameter is validated or sanitized before being passed to `getText()`. This can be achieved by:
1. Validating the `name` parameter to ensure it does not contain any malicious or unexpected content.
2. Escaping the `name` parameter to neutralize any potentially harmful OGNL expressions.

The best approach is to validate the `name` parameter against a whitelist of allowed characters or patterns. If validation fails, the request should be rejected or the parameter should be sanitized.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Implement input validation and sanitization on the `name` parameter in the delete action to prevent OGNL injection.

Bug Fixes:
- Reject requests with invalid `name` values to mitigate OGNL expression vulnerabilities.

Enhancements:
- Add `isValidName` method to enforce a whitelist of allowed characters for `name`.
- Add `escapeName` method to HTML-escape the `name` before using it in messages.