### PR TITLE
Potential fix for code scanning alert no. 921: Uncontrolled data used in path expression

### DIFF
--- a/src/main/java/oscar/oscarReport/reportByTemplate/actions/UploadTemplates2Action.java
+++ b/src/main/java/oscar/oscarReport/reportByTemplate/actions/UploadTemplates2Action.java
@@ -63,7 +63,12 @@ public class UploadTemplates2Action extends ActionSupport {
         String message = "Error: Improper request - Action param missing";
         String xml = "";
         try {
-            byte[] bytes = Files.readAllBytes(templateFile.toPath());
+            File safeDirectory = new File("/path/to/safe/directory").getCanonicalFile();
+            File resolvedFile = templateFile.getCanonicalFile();
+            if (!resolvedFile.toPath().startsWith(safeDirectory.toPath())) {
+                throw new SecurityException("Invalid file path: Access outside the safe directory is not allowed.");
+            }
+            byte[] bytes = Files.readAllBytes(resolvedFile.toPath());
             xml = new String(bytes);
         } catch (IOException ioe) {
             message = "Exception: File Not Found";


### PR DESCRIPTION
Potential fix for [https://github.com/cc-ar-emr/Open-O/security/code-scanning/921](https://github.com/cc-ar-emr/Open-O/security/code-scanning/921)

To fix the issue, we need to validate the `templateFile` path before using it in `Files.readAllBytes(templateFile.toPath())`. The validation should ensure that the path is within a specific safe directory and does not contain any malicious components like `..` or absolute paths. This can be achieved by resolving the path against a predefined safe directory and checking that the resolved path starts with the safe directory.

Steps to fix:
1. Define a safe directory (e.g., a directory where template files are expected to be stored).
2. Normalize and resolve the `templateFile` path against the safe directory.
3. Check that the resolved path starts with the safe directory. If not, throw an exception.
4. Use the validated path for file operations.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Resolve the template file to its canonical path and ensure it resides within a safe directory before reading its contents, throwing a SecurityException on violation.