### PR TITLE
Potential fix for code scanning alert no. 920: Uncontrolled data used in path expression

### DIFF
--- a/src/main/java/oscar/oscarReport/pageUtil/printLabDaySheet2Action.java
+++ b/src/main/java/oscar/oscarReport/pageUtil/printLabDaySheet2Action.java
@@ -67,6 +67,9 @@ public class printLabDaySheet2Action extends ActionSupport {
         HashMap parameters = new HashMap();
         parameters.put("input_date", request.getParameter("input_date"));
         String xmlStyleFile = request.getParameter("xmlStyle");
+        if (xmlStyleFile == null || xmlStyleFile.contains("..") || xmlStyleFile.contains("/") || xmlStyleFile.contains("\\")) {
+            throw new IllegalArgumentException("Invalid xmlStyle parameter");
+        }
         ServletOutputStream sos = null;
         InputStream ins = null;
 


### PR DESCRIPTION
Potential fix for [https://github.com/cc-ar-emr/Open-O/security/code-scanning/920](https://github.com/cc-ar-emr/Open-O/security/code-scanning/920)

To fix the issue, the user-provided `xmlStyleFile` parameter must be validated before it is used to construct a file path. The validation should ensure that the input does not contain path traversal sequences (`..`), path separators (`/` or `\`), or other potentially dangerous characters. Additionally, an allowlist of acceptable file names can be implemented to restrict the input to known safe values.

The fix involves:
1. Adding validation logic to check the `xmlStyleFile` parameter.
2. Rejecting or sanitizing invalid input.
3. Ensuring that the constructed path remains within the intended directory.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Add null and path-separator checks on xmlStyleFile parameter to block path traversal exploits and throw an exception on invalid input