### PR TITLE
Potential fix for code scanning alert no. 424: Unsafe hostname verification

### DIFF
--- a/src/main/java/oscar/OscarPingTalk.java
+++ b/src/main/java/oscar/OscarPingTalk.java
@@ -67,13 +67,7 @@ public class OscarPingTalk {
      * Creates a new instance of OscarPingTalk
      */
     public OscarPingTalk() {
-        HttpsURLConnection.setDefaultHostnameVerifier(new HostnameVerifier() {
-            public boolean verify(String urlHostName, SSLSession session) {
-                MiscUtils.getLogger().debug("Warning: URL: " + urlHostName + ", session host "
-                        + session.getPeerHost());
-                return true;
-            }
-        });
+        HttpsURLConnection.setDefaultHostnameVerifier(HttpsURLConnection.getDefaultHostnameVerifier());
     }
 
     public String connect(String username, String password) throws Exception {


### PR DESCRIPTION
Potential fix for [https://github.com/cc-ar-emr/Open-O/security/code-scanning/424](https://github.com/cc-ar-emr/Open-O/security/code-scanning/424)

To fix the problem, the `HostnameVerifier` implementation must be updated to properly verify the hostname against the certificate presented during the TLS handshake. This can be achieved by implementing a secure `HostnameVerifier` that checks the hostname against the certificate using standard Java APIs.

The best approach is to use the default hostname verification provided by Java, which is secure and widely used. Alternatively, a custom implementation can be created to perform the verification manually, but this is more error-prone and unnecessary in most cases.

The changes will be made in the `OscarPingTalk` constructor where the unsafe `HostnameVerifier` is defined. The new implementation will use the default hostname verifier provided by `HttpsURLConnection`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Replace the insecure custom HostnameVerifier that always returned true with the default Java HostnameVerifier.