### PR TITLE
Potential fix for code scanning alert no. 772: Failure to use secure cookies

### DIFF
--- a/src/main/java/oscar/login/Logout2Action.java
+++ b/src/main/java/oscar/login/Logout2Action.java
@@ -82,6 +82,7 @@ public class Logout2Action extends ActionSupport {
             for (Cookie cookie : cookies) {
                 cookie.setMaxAge(0);
                 cookie.setPath("/");
+                cookie.setSecure(true);
                 response.addCookie(cookie);
             }
         }


### PR DESCRIPTION
Potential fix for [https://github.com/cc-ar-emr/Open-O/security/code-scanning/772](https://github.com/cc-ar-emr/Open-O/security/code-scanning/772)

To fix the issue, the `secure` flag must be set for each cookie before adding it to the `HttpServletResponse`. This can be achieved by calling `cookie.setSecure(true)` for each cookie in the loop on lines 82–86. This ensures that the cookies are only sent over secure HTTPS connections.

**Steps to implement the fix:**
1. Modify the loop that iterates over the cookies in the `logout()` method.
2. Add a call to `cookie.setSecure(true)` before `response.addCookie(cookie)`.

No additional imports or dependencies are required to implement this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Add `cookie.setSecure(true)` when clearing cookies in `logout()` to address code scanning alert 772 and enforce secure cookie transmission