### PR TITLE
Potential fix for code scanning alert no. 778: Cross-site scripting

### DIFF
--- a/src/main/java/oscar/form/pdfservlet/FrmCustomedPDFServlet.java
+++ b/src/main/java/oscar/form/pdfservlet/FrmCustomedPDFServlet.java
@@ -166,7 +166,8 @@ public class FrmCustomedPDFServlet extends HttpServlet {
 
                     if (validFaxNumber) {
                         LogAction.addLog(provider_no, LogConst.SENT, LogConst.CON_FAX, "PRESCRIPTION " + pdfFile);
-                        writer.println("<div id='fax-success' style='color:green;'><h3>Fax successfully generated</h3><p>" + pharmaName + " (" + faxNo + ")</p></div>");
+                        writer.println("<div id='fax-success' style='color:green;'><h3>Fax successfully generated</h3><p>" 
+                                + Encode.forHtml(pharmaName) + " (" + Encode.forHtml(faxNo) + ")</p></div>");
                     }
                 }
             } else {


### PR DESCRIPTION
Potential fix for [https://github.com/cc-ar-emr/Open-O/security/code-scanning/778](https://github.com/cc-ar-emr/Open-O/security/code-scanning/778)

To fix the cross-site scripting vulnerability, the untrusted user input (`pharmaFax`) must be properly encoded before being included in the HTML response. The OWASP Encoder library, which is already imported in the file, provides a secure and efficient way to encode user input for HTML contexts. Specifically, the `Encode.forHtml()` method should be used to encode the `pharmaFax` value before it is concatenated into the response.

The fix involves:
1. Replacing the direct use of `pharmaFax` in the HTML response on line 169 with its encoded version using `Encode.forHtml(pharmaFax)`.
2. Ensuring that all other user-provided values (`pharmaName`) in the same response are also encoded to prevent similar vulnerabilities.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Encode pharmaName and faxNo using OWASP Encoder's Encode.forHtml() before rendering to prevent XSS