### PR TITLE
Potential fix for code scanning alert no. 621: DOM text reinterpreted as HTML

### DIFF
--- a/src/main/webapp/oscarPrevention/PreventionListManager.jsp
+++ b/src/main/webapp/oscarPrevention/PreventionListManager.jsp
@@ -257,10 +257,10 @@
             if (n > 1) {
                 for (i = 0; i < n; i++) {
 
-                    $('#modalItems').append(preventions[i] + "<br>");
+                    $('#modalItems').append($('<div>').text(preventions[i]));
                 }
             } else {
-                $('#modalItems').append(bin.val() + "<br>");
+                $('#modalItems').append($('<div>').text(bin.val()));
             }
         } else {
             $('#modalItems').html("Make all preventions available.");


### PR DESCRIPTION
Potential fix for [https://github.com/cc-ar-emr/Open-O/security/code-scanning/621](https://github.com/cc-ar-emr/Open-O/security/code-scanning/621)

To fix the issue, we need to ensure that any user-controlled input is properly escaped before being inserted into the DOM. Instead of directly appending `preventions[i]` to the DOM, we should use a method that escapes HTML special characters to prevent them from being interpreted as HTML. A common approach is to use a utility function to escape the input or use jQuery's `.text()` method, which automatically escapes the input.

In this case, we will replace the use of `.append(preventions[i] + "<br>")` with `.append($('<div>').text(preventions[i]))`. This ensures that the input is treated as plain text and not as HTML, while still preserving the intended functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Replace raw HTML append with jQuery .text() wrapped in a div to prevent user input from being interpreted as HTML and address code scanning alert no. 621.