### PR TITLE
Aider java security fixes #2

### DIFF
--- a/src/main/java/org/oscarehr/billing/CA/ON/web/MoveMOHFiles2Action.java
+++ b/src/main/java/org/oscarehr/billing/CA/ON/web/MoveMOHFiles2Action.java
@@ -90,6 +90,9 @@ public class MoveMOHFiles2Action extends ActionSupport {
         String filePath = file.getCanonicalPath();
         for(EDTFolder folder : EDTFolder.values()) {
             String edtFolderPath = new File(folder.getPath()).getCanonicalPath();
+            if (!edtFolderPath.endsWith(File.separator)) {
+                edtFolderPath += File.separator;
+            }
             if (filePath.startsWith(edtFolderPath)) {
                 result = true;
             }

--- a/src/main/java/org/oscarehr/billing/Clinicaid/util/ClinicaidCommunication.java
+++ b/src/main/java/org/oscarehr/billing/Clinicaid/util/ClinicaidCommunication.java
@@ -318,7 +318,7 @@ public class ClinicaidCommunication {
             }
             in.close();
 
-            Pattern p = Pattern.compile(".*\"nonce\":\"([a-zA-Z0-9-]*)\".*");
+            Pattern p = Pattern.compile("\"nonce\":\"([a-zA-Z0-9-]+)\"");
             Matcher m = p.matcher(output);
 
             if (!m.matches()) {

--- a/src/main/java/org/oscarehr/common/hl7/v2/oscar_to_oscar/SendingUtils.java
+++ b/src/main/java/org/oscarehr/common/hl7/v2/oscar_to_oscar/SendingUtils.java
@@ -117,7 +117,7 @@ public final class SendingUtils {
         HttpPost httpPost = new HttpPost(url);
         httpPost.setEntity(multipartEntity);
 
-        HttpClient httpClient = getTrustAllHttpClient();
+        HttpClient httpClient = getHttpClient();
         httpClient.getParams().setParameter("http.connection.timeout", CONNECTION_TIME_OUT);
         HttpResponse httpResponse = httpClient.execute(httpPost);
         int statusCode = httpResponse.getStatusLine().getStatusCode();
@@ -125,25 +125,9 @@ public final class SendingUtils {
         return (statusCode);
     }
 
-    private static HttpClient getTrustAllHttpClient() {
-        try {
-            SSLContext sslContext = SSLContext.getInstance("TLS");
-            TrustManager[] temp = new TrustManager[1];
-            temp[0] = new CxfClientUtilsOld.TrustAllManager();
-            sslContext.init(null, temp, null);
-
-            SSLSocketFactory sslSocketFactory = new SSLSocketFactory(sslContext);
-            sslSocketFactory.setHostnameVerifier(SSLSocketFactory.ALLOW_ALL_HOSTNAME_VERIFIER);
-
-            HttpClient httpClient = new DefaultHttpClient();
-            ClientConnectionManager connectionManager = httpClient.getConnectionManager();
-            SchemeRegistry schemeRegistry = connectionManager.getSchemeRegistry();
-            schemeRegistry.register(new Scheme("https", sslSocketFactory, 443));
-            return (new DefaultHttpClient(connectionManager, httpClient.getParams()));
-        } catch (Exception e) {
-            logger.error("Unexpected error", e);
-            return (null);
-        }
+    private static HttpClient getHttpClient() {
+        // Use default HttpClient with proper SSL certificate validation
+        return new DefaultHttpClient();
     }
 
     private static byte[] encryptEncryptionKey(SecretKey senderSecretKey, PublicKey receiverOscarKey) throws NoSuchAlgorithmException, NoSuchPaddingException, InvalidKeyException, IllegalBlockSizeException, BadPaddingException {

--- a/src/main/java/org/oscarehr/eyeform/web/Macro2Action.java
+++ b/src/main/java/org/oscarehr/eyeform/web/Macro2Action.java
@@ -163,10 +163,12 @@ public class Macro2Action extends ActionSupport {
             for (String test : tests.split("\n")) {
                 if (StringUtils.isBlank(test))
                     continue;
-                if (!test.matches(".*\\|(routine|ASAP|urgent)\\|.*")) {
+                // Check for valid urgency values without ReDoS vulnerability
+                if (!test.contains("|routine|") && !test.contains("|ASAP|") && !test.contains("|urgent|")) {
                     errors.append("<br/>Invalid test_urgency attribute in test bookings.");
                 }
-                if (!test.matches(".*\\|(OU|OD|OS)\\|.*")) {
+                // Check for valid eye values without ReDoS vulnerability  
+                if (!test.contains("|OU|") && !test.contains("|OD|") && !test.contains("|OS|")) {
                     errors.append("<br/>Invalid test_eye attribute in test bookings.");
                 }
                 sb.append(test.trim()).append("\n");

--- a/src/main/java/org/oscarehr/eyeform/web/Macro2Action.java
+++ b/src/main/java/org/oscarehr/eyeform/web/Macro2Action.java
@@ -164,11 +164,17 @@ public class Macro2Action extends ActionSupport {
                 if (StringUtils.isBlank(test))
                     continue;
                 // Check for valid urgency values without ReDoS vulnerability
-                if (!test.contains("|routine|") && !test.contains("|ASAP|") && !test.contains("|urgent|")) {
+                boolean hasValidUrgency = test.indexOf("|routine|") >= 0 || 
+                                        test.indexOf("|ASAP|") >= 0 || 
+                                        test.indexOf("|urgent|") >= 0;
+                if (!hasValidUrgency) {
                     errors.append("<br/>Invalid test_urgency attribute in test bookings.");
                 }
                 // Check for valid eye values without ReDoS vulnerability  
-                if (!test.contains("|OU|") && !test.contains("|OD|") && !test.contains("|OS|")) {
+                boolean hasValidEye = test.indexOf("|OU|") >= 0 || 
+                                    test.indexOf("|OD|") >= 0 || 
+                                    test.indexOf("|OS|") >= 0;
+                if (!hasValidEye) {
                     errors.append("<br/>Invalid test_eye attribute in test bookings.");
                 }
                 sb.append(test.trim()).append("\n");

--- a/src/main/java/org/oscarehr/learning/web/CourseManager2Action.java
+++ b/src/main/java/org/oscarehr/learning/web/CourseManager2Action.java
@@ -121,8 +121,8 @@ public class CourseManager2Action extends ActionSupport {
             programDao.saveProgram(p);
             result = "Course sucessfully created.";
         } catch (Exception e) {
-            logger.error("Error", e);
-            result = "Error Occured: " + e.getMessage();
+            logger.error("Error creating course", e);
+            result = "Error occurred while creating course. Please contact system administrator.";
         }
 
         response.getWriter().print(result);

--- a/src/main/java/org/oscarehr/phr/RegistrationHelper.java
+++ b/src/main/java/org/oscarehr/phr/RegistrationHelper.java
@@ -26,10 +26,10 @@
 
 package org.oscarehr.phr;
 
+import java.security.SecureRandom;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Random;
 import java.util.TreeMap;
 
 import javax.servlet.http.HttpServletRequest;
@@ -58,7 +58,7 @@ public final class RegistrationHelper {
     private static DemographicDao demographicDao = (DemographicDao) SpringUtils.getBean(DemographicDao.class);
     private static ProviderDao providerDao = (ProviderDao) SpringUtils.getBean(ProviderDao.class);
     private static PropertyDao propertyDao = (PropertyDao) SpringUtils.getBean(PropertyDao.class);
-    private static Random random = new Random();
+    private static SecureRandom random = new SecureRandom();
 
     public static String getDefaultUserName(int demographicId) {
         Demographic demographic = demographicDao.getDemographicById(demographicId);

--- a/src/main/java/org/oscarehr/phr/RegistrationHelper.java
+++ b/src/main/java/org/oscarehr/phr/RegistrationHelper.java
@@ -58,7 +58,12 @@ public final class RegistrationHelper {
     private static DemographicDao demographicDao = (DemographicDao) SpringUtils.getBean(DemographicDao.class);
     private static ProviderDao providerDao = (ProviderDao) SpringUtils.getBean(ProviderDao.class);
     private static PropertyDao propertyDao = (PropertyDao) SpringUtils.getBean(PropertyDao.class);
-    private static final SecureRandom random = new SecureRandom();
+    private static final SecureRandom random;
+    
+    static {
+        random = new SecureRandom();
+        random.nextBytes(new byte[1]); // Force seeding
+    }
 
     public static String getDefaultUserName(int demographicId) {
         Demographic demographic = demographicDao.getDemographicById(demographicId);

--- a/src/main/java/org/oscarehr/phr/RegistrationHelper.java
+++ b/src/main/java/org/oscarehr/phr/RegistrationHelper.java
@@ -101,7 +101,7 @@ public final class RegistrationHelper {
      */
     private static Object getRandomPasswordDigit() {
         // generate 0 to 7, then add 2, this will skip 0 and 1 so there's no ambiguity between 0/O and 1/I/l
-        int i = random.nextInt(6);
+        int i = random.nextInt(8);
         return (i + 2);
     }
 

--- a/src/main/java/org/oscarehr/phr/RegistrationHelper.java
+++ b/src/main/java/org/oscarehr/phr/RegistrationHelper.java
@@ -58,7 +58,7 @@ public final class RegistrationHelper {
     private static DemographicDao demographicDao = (DemographicDao) SpringUtils.getBean(DemographicDao.class);
     private static ProviderDao providerDao = (ProviderDao) SpringUtils.getBean(ProviderDao.class);
     private static PropertyDao propertyDao = (PropertyDao) SpringUtils.getBean(PropertyDao.class);
-    private static SecureRandom random = new SecureRandom();
+    private static final SecureRandom random = new SecureRandom();
 
     public static String getDefaultUserName(int demographicId) {
         Demographic demographic = demographicDao.getDemographicById(demographicId);

--- a/src/main/java/org/oscarehr/phr/RegistrationHelper.java
+++ b/src/main/java/org/oscarehr/phr/RegistrationHelper.java
@@ -106,7 +106,9 @@ public final class RegistrationHelper {
      */
     private static Object getRandomPasswordDigit() {
         // generate 0 to 7, then add 2, this will skip 0 and 1 so there's no ambiguity between 0/O and 1/I/l
-        int i = random.nextInt(8);
+        byte[] randomBytes = new byte[1];
+        random.nextBytes(randomBytes);
+        int i = Math.abs(randomBytes[0]) % 8;
         return (i + 2);
     }
 
@@ -114,7 +116,9 @@ public final class RegistrationHelper {
      * @return a lower case letter excluding i/l,o to prevent ambiguity with 1,0 respectively
      */
     private static char getRandomPasswordLetter() {
-        int i = random.nextInt('z' - 'a');
+        byte[] randomBytes = new byte[1];
+        random.nextBytes(randomBytes);
+        int i = Math.abs(randomBytes[0]) % ('z' - 'a');
         i = i + 'a';
 
         if (i == 'i' || i == 'l' || i == 'o') return (getRandomPasswordLetter());

--- a/src/main/java/org/oscarehr/phr/util/MyOscarUtils.java
+++ b/src/main/java/org/oscarehr/phr/util/MyOscarUtils.java
@@ -27,8 +27,8 @@ package org.oscarehr.phr.util;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import java.security.SecureRandom;
 import java.util.List;
-import java.util.Random;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -199,7 +199,8 @@ public final class MyOscarUtils {
      * that's already stored in the db as the password record.
      */
     public static String deterministicallyMangle(String s) {
-        Random random = new Random(s.length());
+        SecureRandom random = new SecureRandom();
+        random.setSeed(s.length());
 
         StringBuilder sb = new StringBuilder();
 

--- a/src/main/java/org/oscarehr/util/MiscUtils.java
+++ b/src/main/java/org/oscarehr/util/MiscUtils.java
@@ -232,18 +232,16 @@ public final class MiscUtils {
         }
     }
 
+    /**
+     * @deprecated This method is insecure as it disables SSL certificate validation,
+     * making the application vulnerable to man-in-the-middle attacks. 
+     * Use proper SSL certificate validation instead.
+     */
+    @Deprecated
     public static void setJvmDefaultSSLSocketFactoryAllowAllCertificates() throws NoSuchAlgorithmException, KeyManagementException {
-        TrustAllManager[] tam = new TrustAllManager[]{new TrustAllManager()};
-        SSLContext ctx = SSLContext.getInstance("TLS");
-        ctx.init((KeyManager[]) null, tam, new SecureRandom());
-        SSLSocketFactory sslSocketFactory = ctx.getSocketFactory();
-        HttpsURLConnection.setDefaultSSLSocketFactory(sslSocketFactory);
-        HostnameVerifier hostNameVerifier = new HostnameVerifier() {
-            public boolean verify(String host, SSLSession sslSession) {
-                return true;
-            }
-        };
-        HttpsURLConnection.setDefaultHostnameVerifier(hostNameVerifier);
+        throw new UnsupportedOperationException("This method has been disabled for security reasons. " +
+            "Disabling SSL certificate validation makes the application vulnerable to man-in-the-middle attacks. " +
+            "Please configure proper SSL certificates or use a secure trust manager implementation.");
     }
 
     public static boolean soundex(String s1, String s2) throws EncoderException {

--- a/src/main/java/oscar/eform/EFormUtil.java
+++ b/src/main/java/oscar/eform/EFormUtil.java
@@ -1290,7 +1290,7 @@ public class EFormUtil {
         Matcher m_return = null;
         if (StringUtils.isBlank(key) || StringUtils.isBlank(htmlTag)) return m_return;
 
-        Pattern p = Pattern.compile("\\b[^\\s'\"=>]+ *+= *+\"[^\"]*\"|\\b[^\\s'\"=>]+ *+= *+'[^']*'|\\b[^\\s'\"=>]+ *+= *+[^ >]*|\\b[^\\s>]+", Pattern.CASE_INSENSITIVE);
+        Pattern p = Pattern.compile("\\b[^\\s'\"=>]+\\s*=\\s*\"[^\"]*\"|\\b[^\\s'\"=>]+\\s*=\\s*'[^']*'|\\b[^\\s'\"=>]+\\s*=\\s*[^\\s>]*|\\b[^\\s>]+", Pattern.CASE_INSENSITIVE);
         Matcher m = p.matcher(htmlTag);
 
         while (m.find()) {

--- a/src/main/java/oscar/eform/EFormUtil.java
+++ b/src/main/java/oscar/eform/EFormUtil.java
@@ -1290,7 +1290,7 @@ public class EFormUtil {
         Matcher m_return = null;
         if (StringUtils.isBlank(key) || StringUtils.isBlank(htmlTag)) return m_return;
 
-        Pattern p = Pattern.compile("\\b[^\\s'\"=>]+[ ]*=[ ]*\"[^\"]*\"|\\b[^\\s'\"=>]+[ ]*=[ ]*'[^']*'|\\b[^\\s'\"=>]+[ ]*=[ ]*[^ >]*|\\b[^\\s>]+", Pattern.CASE_INSENSITIVE);
+        Pattern p = Pattern.compile("\\b[^\\s'\"=>]+ *+= *+\"[^\"]*\"|\\b[^\\s'\"=>]+ *+= *+'[^']*'|\\b[^\\s'\"=>]+ *+= *+[^ >]*|\\b[^\\s>]+", Pattern.CASE_INSENSITIVE);
         Matcher m = p.matcher(htmlTag);
 
         while (m.find()) {

--- a/src/main/java/oscar/form/graphic/FrmPdfGraphicRourke.java
+++ b/src/main/java/oscar/form/graphic/FrmPdfGraphicRourke.java
@@ -153,8 +153,8 @@ public class FrmPdfGraphicRourke extends FrmPdfGraphic {
 
             MiscUtils.getLogger().debug("sday, eday " + sday + ", " + eday);
 
-            smonth += (sday / startDate.getActualMaximum(Calendar.DAY_OF_MONTH));
-            emonth += (eday / curDate.getActualMaximum(Calendar.DAY_OF_MONTH));
+            smonth += (sday / (float) startDate.getActualMaximum(Calendar.DAY_OF_MONTH));
+            emonth += (eday / (float) curDate.getActualMaximum(Calendar.DAY_OF_MONTH));
 
             //don't forget to add years
             switch (xDateScale) {

--- a/src/main/java/oscar/form/graphic/FrmPdfGraphicRourke.java
+++ b/src/main/java/oscar/form/graphic/FrmPdfGraphicRourke.java
@@ -191,8 +191,8 @@ public class FrmPdfGraphicRourke extends FrmPdfGraphic {
 
             if (xyProp.containsKey(String.valueOf(xcoord))) {
                 StringBuilder yvalue = new StringBuilder(xyProp.getProperty(String.valueOf(xcoord)));
-                yvalue = yvalue.append(",");
-                yvalue = yvalue.append(String.valueOf(ycoord));
+                yvalue.append(",");
+                yvalue.append(String.valueOf(ycoord));
                 xyProp.setProperty(String.valueOf(xcoord), yvalue.toString());
             } else {
                 xyProp.setProperty(String.valueOf(xcoord), String.valueOf(ycoord));

--- a/src/main/java/oscar/form/pdfservlet/FrmCustomedPDFServlet.java
+++ b/src/main/java/oscar/form/pdfservlet/FrmCustomedPDFServlet.java
@@ -198,13 +198,12 @@ public class FrmCustomedPDFServlet extends HttpServlet {
                 sos.flush();
             }
         } catch (DocumentException dex) {
+            logger.error("PDF generation failed", dex);
             res.setContentType("text/html");
             PrintWriter writer = res.getWriter();
-            writer.println("Exception from: " + this.getClass().getName() + " " + dex.getClass().getName() + "<br>");
-            writer.println("<pre>");
-            writer.println(dex.getMessage());
-            writer.println("</pre>");
+            writer.println("An error occurred while generating the PDF document. Please contact support if the problem persists.");
         } catch (java.io.FileNotFoundException dex) {
+            logger.error("File not found during PDF generation", dex);
             res.setContentType("text/html");
             PrintWriter writer = res.getWriter();
             writer.println("<script>alert('Signature not found. Please sign the prescription.');</script>");

--- a/src/main/java/oscar/login/Logout2Action.java
+++ b/src/main/java/oscar/login/Logout2Action.java
@@ -82,6 +82,7 @@ public class Logout2Action extends ActionSupport {
             for (Cookie cookie : cookies) {
                 cookie.setMaxAge(0);
                 cookie.setPath("/");
+                cookie.setSecure(true);
                 response.addCookie(cookie);
             }
         }

--- a/src/main/java/oscar/oscarEncounter/oscarMeasurements/hl7/MeasurementHL7Uploader2Action.java
+++ b/src/main/java/oscar/oscarEncounter/oscarMeasurements/hl7/MeasurementHL7Uploader2Action.java
@@ -194,7 +194,7 @@ public class MeasurementHL7Uploader2Action extends ActionSupport {
             logger.error("Failed to parse HL7 ORU_R01 messages:\n" + hl7msg, e);
             response.setStatus(HttpStatus.SC_BAD_REQUEST);
             try {
-                response.getWriter().println("Invalid HL7 ORU_R01 format/request: " + e.getMessage());
+                response.getWriter().println("Invalid HL7 ORU_R01 format/request");
             } catch (IOException e1) {
                 // TODO Auto-generated catch blockMiscUtils.getLogger().error("Error", e1);
             }

--- a/src/main/java/oscar/oscarLab/ca/all/util/KeyPairGen.java
+++ b/src/main/java/oscar/oscarLab/ca/all/util/KeyPairGen.java
@@ -61,7 +61,7 @@ public final class KeyPairGen {
         // Generate an RSA key
         try {
             KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
-            keyGen.initialize(1024);
+            keyGen.initialize(2048);
             KeyPair key = keyGen.generateKeyPair();
 
             pubKey = base64.encode(key.getPublic().getEncoded());

--- a/src/main/java/oscar/oscarReport/data/RptReportCreator.java
+++ b/src/main/java/oscar/oscarReport/data/RptReportCreator.java
@@ -134,7 +134,7 @@ public final class RptReportCreator {
     public static Vector getVarVec(String value) {
         Vector ret = new Vector();
         // if no ${}, return original string
-        if (!value.matches(".*\\$\\{.*\\}.*"))
+        if (value.indexOf("${") == -1 || value.indexOf("}") == -1)
             return ret;
         String[] var = value.split("[^\\{\\}\\$]*\\$\\{|\\}[^\\{\\}\\$]*");
         for (int i = 0; i < var.length; i++) {

--- a/src/main/java/oscar/oscarReport/data/RptReportCreator.java
+++ b/src/main/java/oscar/oscarReport/data/RptReportCreator.java
@@ -106,9 +106,15 @@ public final class RptReportCreator {
     public static String getWhereValueClause(String value, Vector vec) {
         String ret = "";
         for (int i = 0; i < 100; i++) {
-            if (value.matches("[^\\{\\}\\$]*\\$\\{[^\\{\\}]+\\}.*")) {
-
-                value = value.replaceFirst("\\$\\{[^\\{\\}]+\\}", (vec.get(i) == null ? "" : ((String) vec.get(i))));
+            int startIndex = value.indexOf("${");
+            if (startIndex >= 0) {
+                int endIndex = value.indexOf("}", startIndex);
+                if (endIndex > startIndex) {
+                    value = value.replaceFirst("\\$\\{[^\\{\\}]+\\}", (vec.get(i) == null ? "" : ((String) vec.get(i))));
+                } else {
+                    ret = value;
+                    break;
+                }
             } else {
                 ret = value;
                 break;

--- a/src/main/java/oscar/oscarRx/util/RxInstructionPolicy.java
+++ b/src/main/java/oscar/oscarRx/util/RxInstructionPolicy.java
@@ -110,7 +110,7 @@ public class RxInstructionPolicy {
         addPolicy(new String[]{"\\s+(?i)q.?o.?d.?\\s+", "\\s+(?i)q.?o.?d.?$", "^(?i)q.?o.?d.?\\s+", "^(?i)q.?o.?d.?$"}, instr, errors, "q.o.d", "every other day");
 
         //q.d
-        addPolicy(new String[]{"\\s+(?i)qd.?\\s+", "\\s+(?i)qd.?$", "^s+(?i)qd.?\\s+", "^(?i)qd.?$", "\\s+(?i)q\\.\\.?d.?\\s+", "\\s+(?i)q\\.\\.?d.?$", "^s+(?i)q\\.\\.?d.?\\s+", "^(?i)q\\.\\.?d.?$"}, instr, errors, "q.d", "daily");
+        addPolicy(new String[]{"\\s+(?i)qd\\.?\\s+", "\\s+(?i)qd\\.?$", "^\\s+(?i)qd\\.?\\s+", "^(?i)qd\\.?$", "\\s+(?i)q\\.d\\.?\\s+", "\\s+(?i)q\\.d\\.?$", "^\\s+(?i)q\\.d\\.?\\s+", "^(?i)q\\.d\\.?$"}, instr, errors, "q.d", "daily");
 
         //o.d.
         addPolicy(new String[]{"\\s+(?i)o.?d.?\\s+", "\\s+(?i)o.?d.?$", "^(?i)o.?d.?\\s+", "^(?i)o.?d.?$"}, instr, errors, "o.d.", "daily");

--- a/src/main/java/oscar/oscarRx/util/RxUtil.java
+++ b/src/main/java/oscar/oscarRx/util/RxUtil.java
@@ -983,7 +983,7 @@ public class RxUtil {
 
     public static boolean isStringToNumber(String s) {//see if string contains decimal or integer
         boolean retBool = false;
-        Pattern p1 = Pattern.compile("\\d+(?:\\.\\d+)?");
+        Pattern p1 = Pattern.compile("\\d+(?:\\.\\d*)?");
         Matcher m1 = p1.matcher(s);
         if (m1.find()) {
             String numStr = s.substring(m1.start(), m1.end());

--- a/src/main/java/oscar/oscarRx/util/RxUtil.java
+++ b/src/main/java/oscar/oscarRx/util/RxUtil.java
@@ -670,7 +670,7 @@ public class RxUtil {
                 Pattern pF1 = Pattern.compile(method + "\\s*\\d*\\/*\\d+\\s+");
                 Matcher mF1 = pF1.matcher(instructions);
 
-                Pattern p4 = Pattern.compile(Pattern.quote(method) + "\\s*\\d+(?:\\.\\d*)?-\\s*\\d+(?:\\.\\d*)?\\s+");
+                Pattern p4 = Pattern.compile(Pattern.quote(method) + "\\s*\\d+(?:\\.\\d+)?-\\s*\\d+(?:\\.\\d+)?\\s+");
                 Matcher m4 = p4.matcher(instructions);
 
                 //since "\\s+[0-9]+-[0-9]+\\s+" is a case in "\\s+[0-9]+\\s+", check the latter regex first.

--- a/src/main/java/oscar/oscarRx/util/RxUtil.java
+++ b/src/main/java/oscar/oscarRx/util/RxUtil.java
@@ -983,7 +983,7 @@ public class RxUtil {
 
     public static boolean isStringToNumber(String s) {//see if string contains decimal or integer
         boolean retBool = false;
-        Pattern p1 = Pattern.compile("\\d+(?:\\.\\d*)?");
+        Pattern p1 = Pattern.compile("\\d+(?:\\.\\d*+)?");
         Matcher m1 = p1.matcher(s);
         if (m1.find()) {
             String numStr = s.substring(m1.start(), m1.end());

--- a/src/main/java/oscar/oscarRx/util/RxUtil.java
+++ b/src/main/java/oscar/oscarRx/util/RxUtil.java
@@ -670,7 +670,7 @@ public class RxUtil {
                 Pattern pF1 = Pattern.compile(method + "\\s*\\d*\\/*\\d+\\s+");
                 Matcher mF1 = pF1.matcher(instructions);
 
-                Pattern p4 = Pattern.compile(method + "\\s*\\d+(?:\\.\\d+)?-\\s*\\d+(?:\\.\\d+)?\\s+");
+                Pattern p4 = Pattern.compile(method + "\\s*+\\d+(?:\\.\\d+)?-\\s*+\\d+(?:\\.\\d+)?\\s++");
                 Matcher m4 = p4.matcher(instructions);
 
                 //since "\\s+[0-9]+-[0-9]+\\s+" is a case in "\\s+[0-9]+\\s+", check the latter regex first.

--- a/src/main/java/oscar/oscarRx/util/RxUtil.java
+++ b/src/main/java/oscar/oscarRx/util/RxUtil.java
@@ -599,13 +599,13 @@ public class RxUtil {
                 Pattern p2 = Pattern.compile("\\s*\\d+(?:\\.\\d+)?\\s+" + origFrequency); //allow to detect decimal number.
                 Matcher m2 = p2.matcher(instructions);
 
-                Pattern p4 = Pattern.compile("\\s*\\d+(?:\\.\\d+)?-\\s*\\d+(?:\\.\\d+)?\\s+" + frequency); //use * after the first \s because "1 OD", 1 doesn't have a space in front.
+                Pattern p4 = Pattern.compile("\\s*\\d+(?:\\.\\d+)?-\\s*\\d+(?:\\.\\d+)?\\s+" + Pattern.quote(frequency)); //use * after the first \s because "1 OD", 1 doesn't have a space in front.
                 Matcher m4 = p4.matcher(instructions);
                 //     p("here11", instructions);
                 //since "\\s+[0-9]+-[0-9]+\\s+" is a case in "\\s+[0-9]+\\s+", check the latter regex first.
                 if (m4.find()) {
                     String str2 = instructions.substring(m4.start(), m4.end());
-                    Pattern p5 = Pattern.compile("\\d+(?:\\.\\d+)?-\\s*\\d+(?:\\.\\d+)?");
+                    Pattern p5 = Pattern.compile("\\d+(?:\\.\\d*)?-\\s*\\d+(?:\\.\\d*)?");
                     Matcher m5 = p5.matcher(str2);
                     if (m5.find()) {
                         String str3 = str2.substring(m5.start(), m5.end());
@@ -670,14 +670,14 @@ public class RxUtil {
                 Pattern pF1 = Pattern.compile(method + "\\s*\\d*\\/*\\d+\\s+");
                 Matcher mF1 = pF1.matcher(instructions);
 
-                Pattern p4 = Pattern.compile(method + "\\s*+\\d+(?:\\.\\d+)?-\\s*+\\d+(?:\\.\\d+)?\\s++");
+                Pattern p4 = Pattern.compile(Pattern.quote(method) + "\\s*\\d+(?:\\.\\d*)?-\\s*\\d+(?:\\.\\d*)?\\s+");
                 Matcher m4 = p4.matcher(instructions);
 
                 //since "\\s+[0-9]+-[0-9]+\\s+" is a case in "\\s+[0-9]+\\s+", check the latter regex first.
                 if (m4.find()) {
                     p("else if 1");
                     String str2 = instructions.substring(m4.start(), m4.end());
-                    Pattern p5 = Pattern.compile("\\d+(?:\\.\\d+)?-\\s*\\d+(?:\\.\\d+)?");
+                    Pattern p5 = Pattern.compile("\\d+(?:\\.\\d*)?-\\s*\\d+(?:\\.\\d*)?");
                     Matcher m5 = p5.matcher(str2);
                     if (m5.find()) {
                         String str3 = str2.substring(m5.start(), m5.end());

--- a/src/main/java/oscar/oscarRx/util/RxUtil.java
+++ b/src/main/java/oscar/oscarRx/util/RxUtil.java
@@ -983,7 +983,7 @@ public class RxUtil {
 
     public static boolean isStringToNumber(String s) {//see if string contains decimal or integer
         boolean retBool = false;
-        Pattern p1 = Pattern.compile("\\d+(?:\\.\\d+)?");
+        Pattern p1 = Pattern.compile("\\d+(?:\\.\\d+)?+");
         Matcher m1 = p1.matcher(s);
         if (m1.find()) {
             String numStr = s.substring(m1.start(), m1.end());

--- a/src/main/java/oscar/oscarRx/util/RxUtil.java
+++ b/src/main/java/oscar/oscarRx/util/RxUtil.java
@@ -983,7 +983,7 @@ public class RxUtil {
 
     public static boolean isStringToNumber(String s) {//see if string contains decimal or integer
         boolean retBool = false;
-        Pattern p1 = Pattern.compile("\\d+(?:\\.\\d+)?+");
+        Pattern p1 = Pattern.compile("\\d+(?:\\.\\d+)?");
         Matcher m1 = p1.matcher(s);
         if (m1.find()) {
             String numStr = s.substring(m1.start(), m1.end());

--- a/src/main/java/oscar/oscarRx/util/RxUtil.java
+++ b/src/main/java/oscar/oscarRx/util/RxUtil.java
@@ -596,16 +596,16 @@ public class RxUtil {
                 frequency = changeToStandardFrequencyCode(frequency);
                 String origFrequency = (instructions.substring(matcher.start(), matcher.end())).trim();
 
-                Pattern p2 = Pattern.compile("\\s*\\d*\\.*\\d+\\s+" + origFrequency); //allow to detect decimal number.
+                Pattern p2 = Pattern.compile("\\s*(?:\\d+(?:\\.\\d+)?|\\d*\\.\\d+)\\s+" + origFrequency); //allow to detect decimal number.
                 Matcher m2 = p2.matcher(instructions);
 
-                Pattern p4 = Pattern.compile("\\s*\\d*\\.*\\d+-\\s*\\d*\\.*\\d+\\s+" + frequency); //use * after the first \s because "1 OD", 1 doesn't have a space in front.
+                Pattern p4 = Pattern.compile("\\s*(?:\\d+(?:\\.\\d+)?|\\d*\\.\\d+)-\\s*(?:\\d+(?:\\.\\d+)?|\\d*\\.\\d+)\\s+" + frequency); //use * after the first \s because "1 OD", 1 doesn't have a space in front.
                 Matcher m4 = p4.matcher(instructions);
                 //     p("here11", instructions);
                 //since "\\s+[0-9]+-[0-9]+\\s+" is a case in "\\s+[0-9]+\\s+", check the latter regex first.
                 if (m4.find()) {
                     String str2 = instructions.substring(m4.start(), m4.end());
-                    Pattern p5 = Pattern.compile("\\d*\\.*\\d+-\\s*\\d*\\.*\\d+");
+                    Pattern p5 = Pattern.compile("(?:\\d+(?:\\.\\d+)?|\\d*\\.\\d+)-\\s*(?:\\d+(?:\\.\\d+)?|\\d*\\.\\d+)");
                     Matcher m5 = p5.matcher(str2);
                     if (m5.find()) {
                         String str3 = str2.substring(m5.start(), m5.end());
@@ -615,7 +615,7 @@ public class RxUtil {
                     }
                 } else if (m2.find()) {
                     String str = instructions.substring(m2.start(), m2.end());
-                    Pattern p3 = Pattern.compile("\\d*\\.*\\d+");
+                    Pattern p3 = Pattern.compile("(?:\\d+(?:\\.\\d+)?|\\d*\\.\\d+)");
                     Matcher m3 = p3.matcher(str);
                     //     p("here22", str);
                     if (m3.find()) {
@@ -664,20 +664,20 @@ public class RxUtil {
                 p("must be here");
                 method = instructions.substring(m.start(), m.end());
 
-                Pattern p2 = Pattern.compile(method + "\\s*\\d*\\.*\\d+\\s+");
+                Pattern p2 = Pattern.compile(method + "\\s*(?:\\d+(?:\\.\\d+)?|\\d*\\.\\d+)\\s+");
                 Matcher m2 = p2.matcher(instructions);
 
                 Pattern pF1 = Pattern.compile(method + "\\s*\\d*\\/*\\d+\\s+");
                 Matcher mF1 = pF1.matcher(instructions);
 
-                Pattern p4 = Pattern.compile(method + "\\s*\\d*\\.*\\d+-\\s*\\d*\\.*\\d+\\s+");
+                Pattern p4 = Pattern.compile(method + "\\s*(?:\\d+(?:\\.\\d+)?|\\d*\\.\\d+)-\\s*(?:\\d+(?:\\.\\d+)?|\\d*\\.\\d+)\\s+");
                 Matcher m4 = p4.matcher(instructions);
 
                 //since "\\s+[0-9]+-[0-9]+\\s+" is a case in "\\s+[0-9]+\\s+", check the latter regex first.
                 if (m4.find()) {
                     p("else if 1");
                     String str2 = instructions.substring(m4.start(), m4.end());
-                    Pattern p5 = Pattern.compile("\\d*\\.*\\d+-\\s*\\d*\\.*\\d+");
+                    Pattern p5 = Pattern.compile("(?:\\d+(?:\\.\\d+)?|\\d*\\.\\d+)-\\s*(?:\\d+(?:\\.\\d+)?|\\d*\\.\\d+)");
                     Matcher m5 = p5.matcher(str2);
                     if (m5.find()) {
                         String str3 = str2.substring(m5.start(), m5.end());
@@ -689,7 +689,7 @@ public class RxUtil {
                     p("if 1");
                     String str = instructions.substring(m2.start(), m2.end());
                     p("str1 ", str);
-                    Pattern p3 = Pattern.compile("\\d*\\.*\\d+");
+                    Pattern p3 = Pattern.compile("(?:\\d+(?:\\.\\d+)?|\\d*\\.\\d+)");
                     Matcher m3 = p3.matcher(str);
                     if (m3.find()) {
                         p("found1");
@@ -983,7 +983,7 @@ public class RxUtil {
 
     public static boolean isStringToNumber(String s) {//see if string contains decimal or integer
         boolean retBool = false;
-        Pattern p1 = Pattern.compile("\\d*\\.*\\d+");
+        Pattern p1 = Pattern.compile("(?:\\d+(?:\\.\\d+)?|\\d*\\.\\d+)");
         Matcher m1 = p1.matcher(s);
         if (m1.find()) {
             String numStr = s.substring(m1.start(), m1.end());
@@ -1005,7 +1005,7 @@ public class RxUtil {
         }
 
         //remove Qty:num
-        String regex1 = "Qty:\\s*[0-9]*\\.?[0-9]*\\s*";
+        String regex1 = "Qty:\\s*(?:[0-9]+(?:\\.[0-9]+)?|[0-9]*\\.[0-9]+)?\\s*";
         String unitName = rx.getUnitName();
         if (unitName != null && special.indexOf(unitName) != -1) {
             regex1 += "\\Q" + unitName + "\\E";
@@ -1015,7 +1015,7 @@ public class RxUtil {
         special = m.replaceAll("");
 
         //remove Repeats:num from special
-        String regex2 = "Repeats:\\s*[0-9]*\\.?[0-9]*\\s*";
+        String regex2 = "Repeats:\\s*(?:[0-9]+(?:\\.[0-9]+)?|[0-9]*\\.[0-9]+)?\\s*";
         p = Pattern.compile(regex2);
         m = p.matcher(special);
         special = m.replaceAll("");
@@ -1255,21 +1255,21 @@ public class RxUtil {
         Pattern p;
         Matcher m;
         MiscUtils.getLogger().debug("in removeQuantityMitteRepeat s=" + s);
-        String regex2 = "Repeats:\\s*[0-9]*\\.?[0-9]*\\s*";
+        String regex2 = "Repeats:\\s*(?:[0-9]+(?:\\.[0-9]+)?|[0-9]*\\.[0-9]+)?\\s*";
         p = Pattern.compile(regex2);
         m = p.matcher(s);
         s = m.replaceAll("");
         MiscUtils.getLogger().debug("in removeQuantityMitteRepeat regex=" + regex2);
         MiscUtils.getLogger().debug("in removeQuantityMitteRepeat after remove repeat s=" + s);
 
-        String regex1 = "Qty:\\s*[0-9]*\\.?[0-9]*\\s*\\w*";
+        String regex1 = "Qty:\\s*(?:[0-9]+(?:\\.[0-9]+)?|[0-9]*\\.[0-9]+)?\\s*\\w*";
         p = Pattern.compile(regex1);
         m = p.matcher(s);
         s = m.replaceAll("");
         MiscUtils.getLogger().debug("in removeQuantityMitteRepeat regex=" + regex1);
         MiscUtils.getLogger().debug("in removeQuantityMitteRepeat after remove quantity =" + s);
 
-        String regex6 = "Mitte:\\s*[0-9]*\\.?[0-9]*\\s*\\w*";
+        String regex6 = "Mitte:\\s*(?:[0-9]+(?:\\.[0-9]+)?|[0-9]*\\.[0-9]+)?\\s*\\w*";
         p = Pattern.compile(regex6);
         m = p.matcher(s);
         s = m.replaceAll("");

--- a/src/main/java/oscar/oscarRx/util/RxUtil.java
+++ b/src/main/java/oscar/oscarRx/util/RxUtil.java
@@ -596,16 +596,16 @@ public class RxUtil {
                 frequency = changeToStandardFrequencyCode(frequency);
                 String origFrequency = (instructions.substring(matcher.start(), matcher.end())).trim();
 
-                Pattern p2 = Pattern.compile("\\s*(?:\\d+(?:\\.\\d+)?|\\d*\\.\\d+)\\s+" + origFrequency); //allow to detect decimal number.
+                Pattern p2 = Pattern.compile("\\s*\\d+(?:\\.\\d+)?\\s+" + origFrequency); //allow to detect decimal number.
                 Matcher m2 = p2.matcher(instructions);
 
-                Pattern p4 = Pattern.compile("\\s*(?:\\d+(?:\\.\\d+)?|\\d*\\.\\d+)-\\s*(?:\\d+(?:\\.\\d+)?|\\d*\\.\\d+)\\s+" + frequency); //use * after the first \s because "1 OD", 1 doesn't have a space in front.
+                Pattern p4 = Pattern.compile("\\s*\\d+(?:\\.\\d+)?-\\s*\\d+(?:\\.\\d+)?\\s+" + frequency); //use * after the first \s because "1 OD", 1 doesn't have a space in front.
                 Matcher m4 = p4.matcher(instructions);
                 //     p("here11", instructions);
                 //since "\\s+[0-9]+-[0-9]+\\s+" is a case in "\\s+[0-9]+\\s+", check the latter regex first.
                 if (m4.find()) {
                     String str2 = instructions.substring(m4.start(), m4.end());
-                    Pattern p5 = Pattern.compile("(?:\\d+(?:\\.\\d+)?|\\d*\\.\\d+)-\\s*(?:\\d+(?:\\.\\d+)?|\\d*\\.\\d+)");
+                    Pattern p5 = Pattern.compile("\\d+(?:\\.\\d+)?-\\s*\\d+(?:\\.\\d+)?");
                     Matcher m5 = p5.matcher(str2);
                     if (m5.find()) {
                         String str3 = str2.substring(m5.start(), m5.end());
@@ -615,7 +615,7 @@ public class RxUtil {
                     }
                 } else if (m2.find()) {
                     String str = instructions.substring(m2.start(), m2.end());
-                    Pattern p3 = Pattern.compile("(?:\\d+(?:\\.\\d+)?|\\d*\\.\\d+)");
+                    Pattern p3 = Pattern.compile("\\d+(?:\\.\\d+)?");
                     Matcher m3 = p3.matcher(str);
                     //     p("here22", str);
                     if (m3.find()) {
@@ -664,20 +664,20 @@ public class RxUtil {
                 p("must be here");
                 method = instructions.substring(m.start(), m.end());
 
-                Pattern p2 = Pattern.compile(method + "\\s*(?:\\d+(?:\\.\\d+)?|\\d*\\.\\d+)\\s+");
+                Pattern p2 = Pattern.compile(method + "\\s*\\d+(?:\\.\\d+)?\\s+");
                 Matcher m2 = p2.matcher(instructions);
 
                 Pattern pF1 = Pattern.compile(method + "\\s*\\d*\\/*\\d+\\s+");
                 Matcher mF1 = pF1.matcher(instructions);
 
-                Pattern p4 = Pattern.compile(method + "\\s*(?:\\d+(?:\\.\\d+)?|\\d*\\.\\d+)-\\s*(?:\\d+(?:\\.\\d+)?|\\d*\\.\\d+)\\s+");
+                Pattern p4 = Pattern.compile(method + "\\s*\\d+(?:\\.\\d+)?-\\s*\\d+(?:\\.\\d+)?\\s+");
                 Matcher m4 = p4.matcher(instructions);
 
                 //since "\\s+[0-9]+-[0-9]+\\s+" is a case in "\\s+[0-9]+\\s+", check the latter regex first.
                 if (m4.find()) {
                     p("else if 1");
                     String str2 = instructions.substring(m4.start(), m4.end());
-                    Pattern p5 = Pattern.compile("(?:\\d+(?:\\.\\d+)?|\\d*\\.\\d+)-\\s*(?:\\d+(?:\\.\\d+)?|\\d*\\.\\d+)");
+                    Pattern p5 = Pattern.compile("\\d+(?:\\.\\d+)?-\\s*\\d+(?:\\.\\d+)?");
                     Matcher m5 = p5.matcher(str2);
                     if (m5.find()) {
                         String str3 = str2.substring(m5.start(), m5.end());
@@ -689,7 +689,7 @@ public class RxUtil {
                     p("if 1");
                     String str = instructions.substring(m2.start(), m2.end());
                     p("str1 ", str);
-                    Pattern p3 = Pattern.compile("(?:\\d+(?:\\.\\d+)?|\\d*\\.\\d+)");
+                    Pattern p3 = Pattern.compile("\\d+(?:\\.\\d+)?");
                     Matcher m3 = p3.matcher(str);
                     if (m3.find()) {
                         p("found1");
@@ -983,7 +983,7 @@ public class RxUtil {
 
     public static boolean isStringToNumber(String s) {//see if string contains decimal or integer
         boolean retBool = false;
-        Pattern p1 = Pattern.compile("(?:\\d+(?:\\.\\d+)?|\\d*\\.\\d+)");
+        Pattern p1 = Pattern.compile("\\d+(?:\\.\\d+)?");
         Matcher m1 = p1.matcher(s);
         if (m1.find()) {
             String numStr = s.substring(m1.start(), m1.end());
@@ -1015,7 +1015,7 @@ public class RxUtil {
         special = m.replaceAll("");
 
         //remove Repeats:num from special
-        String regex2 = "Repeats:\\s*(?:[0-9]+(?:\\.[0-9]+)?|[0-9]*\\.[0-9]+)?\\s*";
+        String regex2 = "Repeats:\\s*[0-9]+(?:\\.[0-9]+)?\\s*";
         p = Pattern.compile(regex2);
         m = p.matcher(special);
         special = m.replaceAll("");
@@ -1255,21 +1255,21 @@ public class RxUtil {
         Pattern p;
         Matcher m;
         MiscUtils.getLogger().debug("in removeQuantityMitteRepeat s=" + s);
-        String regex2 = "Repeats:\\s*(?:[0-9]+(?:\\.[0-9]+)?|[0-9]*\\.[0-9]+)?\\s*";
+        String regex2 = "Repeats:\\s*[0-9]+(?:\\.[0-9]+)?\\s*";
         p = Pattern.compile(regex2);
         m = p.matcher(s);
         s = m.replaceAll("");
         MiscUtils.getLogger().debug("in removeQuantityMitteRepeat regex=" + regex2);
         MiscUtils.getLogger().debug("in removeQuantityMitteRepeat after remove repeat s=" + s);
 
-        String regex1 = "Qty:\\s*(?:[0-9]+(?:\\.[0-9]+)?|[0-9]*\\.[0-9]+)?\\s*\\w*";
+        String regex1 = "Qty:\\s*[0-9]+(?:\\.[0-9]+)?\\s*\\w*";
         p = Pattern.compile(regex1);
         m = p.matcher(s);
         s = m.replaceAll("");
         MiscUtils.getLogger().debug("in removeQuantityMitteRepeat regex=" + regex1);
         MiscUtils.getLogger().debug("in removeQuantityMitteRepeat after remove quantity =" + s);
 
-        String regex6 = "Mitte:\\s*(?:[0-9]+(?:\\.[0-9]+)?|[0-9]*\\.[0-9]+)?\\s*\\w*";
+        String regex6 = "Mitte:\\s*[0-9]+(?:\\.[0-9]+)?\\s*\\w*";
         p = Pattern.compile(regex6);
         m = p.matcher(s);
         s = m.replaceAll("");

--- a/src/main/java/oscar/oscarRx/util/RxUtil.java
+++ b/src/main/java/oscar/oscarRx/util/RxUtil.java
@@ -983,7 +983,7 @@ public class RxUtil {
 
     public static boolean isStringToNumber(String s) {//see if string contains decimal or integer
         boolean retBool = false;
-        Pattern p1 = Pattern.compile("\\d+(?:\\.\\d*+)?");
+        Pattern p1 = Pattern.compile("\\d+(?:\\.\\d*)?");
         Matcher m1 = p1.matcher(s);
         if (m1.find()) {
             String numStr = s.substring(m1.start(), m1.end());

--- a/src/main/java/oscar/oscarSecurity/CookieSecurity.java
+++ b/src/main/java/oscar/oscarSecurity/CookieSecurity.java
@@ -26,7 +26,7 @@
 
 package oscar.oscarSecurity;
 
-import java.util.Random;
+import java.security.SecureRandom;
 import java.util.zip.Adler32;
 
 import javax.servlet.http.Cookie;
@@ -35,7 +35,7 @@ public class CookieSecurity {
     public static String providerCookie = "oscprvid";
 
     public Cookie GiveMeACookie(String cookieName) {
-        Random rndGenerator = new Random();
+        SecureRandom rndGenerator = new SecureRandom();
         Adler32 adler32 = new Adler32();
         String cookieVal = "";
         for (int i = 0; i < 32; i++) {


### PR DESCRIPTION
List of all Rule ID's that were attempted to be addressed in this PR:
- java/partial-path-traversal-from-remote
- java/implicit-cast-in-compound-assignment
- java/insecure-randomness
- java/polynomial-redos
- java/insecure-trustmanager
- java/insufficient-key-size
- java/error-message-exposure
- java/insecure-cookie

Fixes were created though the Aider CLI with Claude using a python script, this was not included in this PR and resides currently in the branch: 185-security-fixes-automation

## Summary by Sourcery

Apply a comprehensive set of Java security fixes by replacing insecure randomness and SSL trust managers, strengthening regex and cryptographic parameters, hardening error handling and cookie settings, and correcting implicit casts.

Bug Fixes:
- Fix implicit integer division in graphic plotting by casting denominators to float.

Enhancements:
- Replace all usages of java.util.Random with SecureRandom for stronger randomness and seeding.
- Deprecate and disable insecure SSL bypass methods and switch to default HttpClient with proper certificate validation.
- Refactor regex patterns to use safe quantifiers and indexOf checks to mitigate polynomial ReDoS and path traversal risks.
- Increase RSA key sizes from 1024 to 2048 bits for stronger cryptographic security.
- Improve error handling by logging exceptions, sanitizing user-facing messages, and avoiding detailed exception dumps.
- Enforce the secure flag on cookies and strengthen file path validation by normalizing directory separators.