### PR TITLE
Fixed the SESSION CASEMANAGEMENT NOTE LOCK NULL issue when clicking 'Sign Save & Bill' icon in EChart -> encounter note

### DIFF
--- a/src/main/java/org/oscarehr/casemgmt/web/CaseManagementEntry2Action.java
+++ b/src/main/java/org/oscarehr/casemgmt/web/CaseManagementEntry2Action.java
@@ -512,17 +512,29 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
 
         String[] filterRoles = request.getParameterValues("filter_roles");
         if (filterRoles != null) {
-            session.setAttribute("filter_roles", filterRoles);
+            if (filterRoles.length > 0) {
+                session.setAttribute("filter_roles", filterRoles);
+            } else {
+                session.removeAttribute("filter_roles");
+            }
         }
 
         String[] filterProviders = request.getParameterValues("filter_providers");
         if (filterProviders != null) {
-            session.setAttribute("filter_provider", filterProviders);
+            if (filterProviders.length > 0) {
+                session.setAttribute("filter_provider", filterProviders);
+            } else {
+                session.removeAttribute("filter_provider");
+            }
         }
 
         String[] issues = request.getParameterValues("issues");
         if (issues != null) {
-            session.setAttribute("issues", issues);
+            if (issues.length > 0) {
+                session.setAttribute("issues", issues);
+            } else {
+                session.removeAttribute("issues");
+            }
         }
 
         return fwd;


### PR DESCRIPTION
Added null check when getting session attributes in the `edit()` method, so it will not delete session attributes due to null parameters → preventing the lock object from being lost, and saving parameters submitted from the front-end into the session) is still preserved.

Issue described in #436

## Summary by Sourcery

Prevent loss of session-based case management note lock and related parameters when clicking 'Sign Save & Bill' by only saving non-null request parameters in the edit() method and cleaning up commented-out code

Bug Fixes:
- Preserve existing session attributes (note_sort, filter_roles, filter_provider, issues and lock object) by adding null checks before setting them

Enhancements:
- Remove extensive commented-out and unused code in CaseManagementEntry2Action for clarity