### PR TITLE
Fixed some bugs in develop/dogfish

### DIFF
--- a/src/main/java/ca/openosp/openo/casemgmt/web/CaseManagementEntry2Action.java
+++ b/src/main/java/ca/openosp/openo/casemgmt/web/CaseManagementEntry2Action.java
@@ -3292,10 +3292,17 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
         boolean programSet = false;
 
         if (note.getProgram_no() != null && note.getProgram_no().length() > 0 && !"null".equals(note.getProgram_no())) {
-            ProgramProvider pp = programProviderDao.getProgramProvider(note.getProviderNo(), Long.valueOf(note.getProgram_no()));
-            if (pp != null) {
-                note.setReporter_caisi_role(String.valueOf(pp.getRoleId()));
-                programSet = true;
+            try {
+                Long programId = Long.valueOf(note.getProgram_no());
+                if (programId > 0) {
+                    ProgramProvider pp = programProviderDao.getProgramProvider(note.getProviderNo(), programId);
+                    if (pp != null) {
+                        note.setReporter_caisi_role(String.valueOf(pp.getRoleId()));
+                        programSet = true;
+                    }
+                }
+            } catch (NumberFormatException e) {
+                // Invalid program number format, skip program provider lookup
             }
         }
 

--- a/src/main/webapp/WEB-INF/classes/struts.xml
+++ b/src/main/webapp/WEB-INF/classes/struts.xml
@@ -1462,6 +1462,9 @@
         <action name="oscarResearch/oscarDxResearch/setupDxResearch" class="ca.openosp.openo.dxresearch.pageUtil.dxSetupResearch2Action">
             <result name="success">/oscarResearch/oscarDxResearch/dxResearch.jsp</result>
         </action>
+        <action name="oscarResearch/dxresearch/setupDxResearch" class="ca.openosp.openo.dxresearch.pageUtil.dxSetupResearch2Action">
+            <result name="success">/oscarResearch/oscarDxResearch/dxResearch.jsp</result>
+        </action>
         <action name="oscarResearch/oscarDxResearch/dxResearch" class="ca.openosp.openo.dxresearch.pageUtil.dxResearch2Action">
             <result name="codeSearch">/oscarResearch/oscarDxResearch/dxcodeSearch.do</result>
             <result name="success">/oscarResearch/oscarDxResearch/setupDxResearch.do</result>
@@ -1471,6 +1474,9 @@
             <result name="success">/oscarResearch/oscarDxResearch/dxResearchCodeSearch.jsp</result>
         </action>
         <action name="oscarResearch/oscarDxResearch/dxResearchUpdate" class="ca.openosp.openo.dxresearch.pageUtil.dxResearchUpdate2Action">
+            <result name="success">/oscarResearch/oscarDxResearch/setupDxResearch.do</result>
+        </action>
+        <action name="oscarResearch/dxresearch/dxResearchUpdate" class="ca.openosp.openo.dxresearch.pageUtil.dxResearchUpdate2Action">
             <result name="success">/oscarResearch/oscarDxResearch/setupDxResearch.do</result>
         </action>
         <action name="oscarResearch/oscarDxResearch/dxResearchLoadQuickList" class="ca.openosp.openo.dxresearch.pageUtil.dxResearchLoadQuickList2Action">

--- a/src/main/webapp/oscarResearch/oscarDxResearch/dxResearch.jsp
+++ b/src/main/webapp/oscarResearch/oscarDxResearch/dxResearch.jsp
@@ -97,7 +97,7 @@
               href="${pageContext.servletContext.contextPath}/library/bootstrap/3.0.0/css/bootstrap.min.css"/>
         <link rel="stylesheet" type="text/css" media="all"
               href="${pageContext.servletContext.contextPath}/library/bootstrap/3.0.0/css/bootstrap-theme.min.css"/>
-        <link rel="stylesheet" type="text/css" href="dxResearch.css">
+        <link rel="stylesheet" type="text/css" href="${pageContext.servletContext.contextPath}/oscarResearch/oscarDxResearch/dxResearch.css">
 
         <script type="text/javascript">
             //<!--

--- a/src/main/webapp/oscarResearch/oscarDxResearch/dxResearchCustomization.jsp
+++ b/src/main/webapp/oscarResearch/oscarDxResearch/dxResearchCustomization.jsp
@@ -34,7 +34,7 @@
         <title><fmt:setBundle basename="oscarResources"/><fmt:message key="oscarResearch.oscarDxResearch.dxCustomization.title"/></title>
         <script type="text/javascript" src="${pageContext.servletContext.contextPath}/js/global.js"></script>
         <base href="<%= request.getScheme() + "://" + request.getServerName() + ":" + request.getServerPort() + request.getContextPath() + "/" %>">
-        <link rel="stylesheet" type="text/css" href="dxResearch.css"/>
+        <link rel="stylesheet" type="text/css" href="${pageContext.servletContext.contextPath}/oscarResearch/oscarDxResearch/dxResearch.css"/>
 
     </head>
 

--- a/src/main/webapp/oscarResearch/oscarDxResearch/dxResearchEditQuickList.jsp
+++ b/src/main/webapp/oscarResearch/oscarDxResearch/dxResearchEditQuickList.jsp
@@ -34,7 +34,7 @@
     int Count = 0;
 %>
 
-<link rel="stylesheet" type="text/css" href="dxResearch.css">
+<link rel="stylesheet" type="text/css" href="${pageContext.servletContext.contextPath}/oscarResearch/oscarDxResearch/dxResearch.css">
 <html>
     <head>
         <script type="text/javascript" src="<%= request.getContextPath() %>/js/global.js"></script>

--- a/src/main/webapp/oscarResearch/oscarDxResearch/dxResearchNewQuickList.jsp
+++ b/src/main/webapp/oscarResearch/oscarDxResearch/dxResearchNewQuickList.jsp
@@ -29,7 +29,7 @@
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 
 
-<link rel="stylesheet" type="text/css" href="dxResearch.css">
+<link rel="stylesheet" type="text/css" href="${pageContext.servletContext.contextPath}/oscarResearch/oscarDxResearch/dxResearch.css">
 <html>
     <head>
         <script type="text/javascript" src="<%= request.getContextPath() %>/js/global.js"></script>

--- a/src/main/webapp/oscarResearch/oscarDxResearch/dxResearchSelectAssociations.jsp
+++ b/src/main/webapp/oscarResearch/oscarDxResearch/dxResearchSelectAssociations.jsp
@@ -25,7 +25,7 @@
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 <html>
     <head>
-        <link rel="stylesheet" type="text/css" href="dxResearch.css">
+        <link rel="stylesheet" type="text/css" href="${pageContext.servletContext.contextPath}/oscarResearch/oscarDxResearch/dxResearch.css">
         <script type="text/javascript" src="<%= request.getContextPath() %>/js/global.js"></script>
         <link rel="stylesheet" type="text/css" href="<%= request.getContextPath() %>/js/jquery_css/smoothness/jquery-ui-1.10.2.custom.min.css"/>
         <script type="text/javascript" src="<%= request.getContextPath() %>/js/jquery-1.9.1.js"></script>
@@ -99,7 +99,7 @@
         </script>
 
     </head>
-    <link rel="stylesheet" type="text/css" href="dxResearch.css">
+    <link rel="stylesheet" type="text/css" href="${pageContext.servletContext.contextPath}/oscarResearch/oscarDxResearch/dxResearch.css">
     <body class="BodyStyle" vlink="#0000FF" rightmargin="0" leftmargin="0"
           topmargin="0" marginwidth="0" marginheight="0" onload="setfocus()" bgcolor="#EEEEFF">
     <!--  -->

--- a/src/main/webapp/oscarResearch/oscarDxResearch/dxResearchSelectQuickList.jsp
+++ b/src/main/webapp/oscarResearch/oscarDxResearch/dxResearchSelectQuickList.jsp
@@ -29,7 +29,7 @@
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 
-<link rel="stylesheet" type="text/css" href="dxResearch.css">
+<link rel="stylesheet" type="text/css" href="${pageContext.servletContext.contextPath}/oscarResearch/oscarDxResearch/dxResearch.css">
 <html>
     <head>
         <script type="text/javascript" src="<%= request.getContextPath() %>/js/global.js"></script>


### PR DESCRIPTION
- Fixed 404 error, css style in EChart -> Disease Registry window, and the functionality of Resolve tab
- Fixed tickler note saving issue

## Summary by Sourcery

Fix 404 errors in Disease Registry, correct CSS loading path in dxResearch views, and handle invalid program numbers when saving tickler notes

Bug Fixes:
- Add Struts action mappings for oscarResearch/dxresearch URLs to prevent 404 errors
- Update dxResearch JSPs to reference CSS via the servlet context path
- Catch NumberFormatException for invalid program numbers to fix tickler note saving