### PR TITLE
Struts action cleanup

### DIFF
--- a/src/main/webapp/WEB-INF/classes/struts.xml
+++ b/src/main/webapp/WEB-INF/classes/struts.xml
@@ -2261,7 +2261,6 @@
             <result name="showInbox">/billing/CA/ON/viewMOHFiles.jsp</result>
         </action-->
         <action name="billing/ca/on/DisplayInvoiceLogo" class="ca.openosp.openo.billing.CA.ON.util.DisplayInvoiceLogo2Action"/>
-        <action name="cvc" class="org.oscarehr.integration.born.CVCTester2Action"/>
         <action name="admin/AuditLogPurge" class="ca.openosp.openo.admin.web.AuditLogPurge2Action">
             <result name="success">/admin/auditLogPurge.jsp</result>
         </action>


### PR DESCRIPTION
## Changes made
Removed Struts actions in `struts.xml` that reference deleted action classes.

### Deleted Actions
#### Eyeform
- oscar.oscarEncounter.pageUtil.EctDisplayOcularProcedure2Action.java
- oscar.oscarEncounter.pageUtil.EctDisplaySpecsHistory2Action.java
- oscar.oscarEncounter.pageUtil.EctDisplayMacro2Action.java
- oscar.oscarEncounter.pageUtil.EctDisplayConReport2Action.java
- oscar.oscarEncounter.pageUtil.EctDisplayExaminationHistory2Action.java
#### BORN
- org.oscarehr.integration.born.CVCTester2Action.java

## Summary by Sourcery

Remove references to deleted Struts action classes from the configuration to prevent broken mappings

Enhancements:
- Clean up struts.xml by removing stale action mappings for deleted classes

Chores:
- Remove Eyeform module actions (EctDisplayOcularProcedure2Action, EctDisplaySpecsHistory2Action, EctDisplayMacro2Action, EctDisplayConReport2Action, EctDisplayExaminationHistory2Action)
- Remove BORN integration action (CVCTester2Action)