### PR TITLE
Add Gemini CLI to dev environment

### DIFF
--- a/.devcontainer/development/Dockerfile
+++ b/.devcontainer/development/Dockerfile
@@ -53,6 +53,9 @@ RUN go install github.com/dburkart/javadoc2md/cmd/javadoc2md@latest
 # Install Claude Code CLI and Docusaurus
 RUN npm install -g @anthropic-ai/claude-code @docusaurus/core @docusaurus/preset-classic
 
+# Install Gemini CLI.
+RUN npm install -g @google/gemini-cli
+
 # Install pipx and Aider AI coding assistant
 RUN apt-get update && apt-get install -y pipx && \
     pipx install aider-chat && \


### PR DESCRIPTION
## Changes made
Install Gemini CLI in Devcontainer.

Gemini CLI has a pretty generous free tier with access to Gemini 2.5 pro.

_Note 1:_ Will not integrate with the `Gemini CLI Companion` VS Code extension inside the Devcontainer.

_Note 2:_ Should be used with a non-magentahealth.ca Google account because business Google accounts require additional Google Cloud Project setup in order to use Gemini CLI.