### PR TITLE
Struts 1 to 2 refactor of MsgViewMessageByPosition2Action

### DIFF
--- a/src/main/webapp/WEB-INF/classes/struts.xml
+++ b/src/main/webapp/WEB-INF/classes/struts.xml
@@ -155,9 +155,10 @@
             <result name="success">/messenger/ViewMessage.jsp</result>
             <result name="viewFromEncounter">/messenger/ViewMessageFromEncounter.jsp</result>
         </action>
-        <!--action name="messenger/ViewMessageByPosition" class="oscar.messenger.pageUtil.MsgViewMessageByPosition2Action">
+        <!-- DEPRECATED: This action is used by the legacy encounter page (oscarEncounter/Index.jsp) -->
+        <action name="messenger/ViewMessageByPosition" class="ca.openosp.openo.messenger.pageUtil.MsgViewMessageByPosition2Action">
             <result name="success">/messenger/ViewMessage.do</result>
-        </action-->
+        </action>
         <action name="messenger/Doc2PDF" class="ca.openosp.openo.messenger.pageUtil.MsgAttachPDF2Action">
             <result name="success">/messenger/selfCloseAndRefreshOpener.jsp</result>
             <result name="attaching">/messenger/generatePreviewPDF.jsp</result>

--- a/src/main/webapp/oscarEncounter/Index.jsp
+++ b/src/main/webapp/oscarEncounter/Index.jsp
@@ -24,6 +24,12 @@
 
 --%>
 
+<%--
+    DEPRECATED: This is the legacy encounter page.
+    It is displayed for users who are not enabled for the new encounter page (Index2.jsp).
+    The selection logic is in ca.openosp.openo.encounter.pageUtil.EctIncomingEncounter2Action.java
+--%>
+
 <%@page import="ca.openosp.openo.utility.LoggedInInfo" %>
 <%@page import="ca.openosp.openo.prescript.data.RxPatientData" %>
 <%@ taglib uri="/WEB-INF/caisi-tag.tld" prefix="caisi" %>

--- a/src/main/webapp/oscarEncounter/Index2.jsp
+++ b/src/main/webapp/oscarEncounter/Index2.jsp
@@ -24,6 +24,12 @@
 
 --%>
 
+<%--
+    This is the new encounter page.
+    It is enabled via the 'useNewEchart' and 'newDocArr' settings.
+    The selection logic is in ca.openosp.openo.encounter.pageUtil.EctIncomingEncounter2Action.java
+--%>
+
 <%@page import="ca.openosp.openo.utility.LoggedInInfo" %>
 <%@page import="ca.openosp.openo.prescript.data.RxPatientData" %>
 <%@ taglib uri="/WEB-INF/caisi-tag.tld" prefix="caisi" %>


### PR DESCRIPTION
## Changes made
Finished struts 1 to 2 migration for MsgViewMessageByPosition2Action. This means one less false positive shown in `./scripts/validate_struts_actions.sh`]

_Note:_ This action was only used by the old encounter page. I have added comments in `MsgViewMessageByPosition2Action`, `struts.xml`, `oscarEncounter/Index.jsp`, and `oscarEncounter/Index2.jsp` to clarify this.

## Summary by Sourcery

Finalize migration of MsgViewMessageByPosition2Action from Struts 1 to Struts 2 by replacing the stubbed implementation with a fully functional execute() method that retrieves a message ID by its position using JPA, restores security checks, and forwards to MsgViewMessage2Action. Deprecate the legacy encounter page action, update struts.xml and JSPs with deprecation notes, and remove outdated Struts 1 artifacts to clear false positives in the Struts validation script.

Enhancements:
- Implement execute() logic in MsgViewMessageByPosition2Action to query and set a message ID by its position using EntityManager and native SQL.
- Introduce Struts2 properties, getters/setters, security privilege checks, and error handling for the migrated action.
- Deprecate MsgViewMessageByPosition2Action with @Deprecated annotation and update version metadata.

Documentation:
- Add deprecation comments in Index.jsp, Index2.jsp, and struts.xml to clarify legacy and new encounter page usage.

Chores:
- Remove legacy Struts 1 code stubs and update action mapping to eliminate false positives in validate_struts_actions.sh.