### PR TITLE
Fix package name in FrmRecordFactory

### DIFF
--- a/src/main/java/ca/openosp/openo/form/FrmRecordFactory.java
+++ b/src/main/java/ca/openosp/openo/form/FrmRecordFactory.java
@@ -33,7 +33,8 @@ public class FrmRecordFactory {
 
     public FrmRecord factory(String which) {
 
-        String fullName = "oscar.form.Frm" + which + "Record"; // keyword - form_name get reference to the class
+        // Build the full class name from the form name (the 'which' parameter).
+        String fullName = "ca.openosp.openo.form.Frm" + which + "Record"; // keyword - form_name get reference to the class
         FrmRecord myClass = null;
 
         try {


### PR DESCRIPTION
## Changes made
Fixed invalid `oscar` package name in `FrmRecordFactory`. This caused a 500 when adding/opening forms in a patient's e-chart.

## Summary by Sourcery

Bug Fixes:
- Correct the fully qualified class name in FrmRecordFactory to use the proper `ca.openosp.openo.form` package path, preventing 500 errors when opening or adding forms.