### PR TITLE
Cleanup several class name references

### DIFF
--- a/src/main/java/ca/openosp/openo/commn/hl7/v2/oscar_to_oscar/DynamicHapiLoaderUtils.java
+++ b/src/main/java/ca/openosp/openo/commn/hl7/v2/oscar_to_oscar/DynamicHapiLoaderUtils.java
@@ -38,6 +38,13 @@ import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.Logger;
 import ca.openosp.openo.utility.MiscUtils;
 
+// Imported for class names.
+import ca.uhn.hl7v2.parser.PipeParser;
+import ca.uhn.hl7v2.model.Message;
+import ca.uhn.hl7v2.model.Segment;
+import ca.uhn.hl7v2.util.Terser;
+import ca.uhn.fhir.util.TerserUtil;
+
 public final class DynamicHapiLoaderUtils {
 
     private static final Logger logger = MiscUtils.getLogger();
@@ -68,11 +75,11 @@ public final class DynamicHapiLoaderUtils {
     private static void initialise() throws ClassNotFoundException, SecurityException, NoSuchMethodException, InstantiationException, IllegalAccessException, IllegalArgumentException, InvocationTargetException {
         hackedHapiClassLoader = getHackedUrlClassLoader();
 
-        hackedPipedParserClass = hackedHapiClassLoader.loadClass("ca.uhn.hl7v2.parser.PipeParser");
-        hackedMessageClass = hackedHapiClassLoader.loadClass("ca.uhn.hl7v2.model.Message");
-        hackedSegmentClass = hackedHapiClassLoader.loadClass("ca.uhn.hl7v2.model.Segment");
-        hackedTerserClass = hackedHapiClassLoader.loadClass("ca.uhn.hl7v2.util.Terser");
-        hackedTerserUtilsClass = hackedHapiClassLoader.loadClass("TerserUtils");
+        hackedPipedParserClass = hackedHapiClassLoader.loadClass(PipeParser.class.getName());
+        hackedMessageClass = hackedHapiClassLoader.loadClass(Message.class.getName());
+        hackedSegmentClass = hackedHapiClassLoader.loadClass(Segment.class.getName());
+        hackedTerserClass = hackedHapiClassLoader.loadClass(Terser.class.getName());
+        hackedTerserUtilsClass = hackedHapiClassLoader.loadClass(TerserUtil.class.getName());
 
         hackedParseMethod = hackedPipedParserClass.getMethod("parse", String.class);
         hackedEncodeMethod = hackedPipedParserClass.getMethod("encode", hackedMessageClass);

--- a/src/main/java/ca/openosp/openo/daos/security/SecProviderDaoImpl.java
+++ b/src/main/java/ca/openosp/openo/daos/security/SecProviderDaoImpl.java
@@ -86,7 +86,7 @@ public class SecProviderDaoImpl extends HibernateDaoSupport implements SecProvid
         logger.debug("getting Provider instance with id: " + id);
         try {
             SecProvider instance = (SecProvider) this.getHibernateTemplate().get(
-                    "com.quatro.model.sec.SecProvider", id);
+                    SecProvider.class, id);
             return instance;
         } catch (RuntimeException re) {
             logger.error("get failed", re);
@@ -117,7 +117,7 @@ public class SecProviderDaoImpl extends HibernateDaoSupport implements SecProvid
         Session session = currentSession();
         try {
             List results = session.createCriteria(
-                            "com.quatro.model.sec.SecProvider").add(
+                            SecProvider.class).add(
                             Example.create(instance))
                     .list();
             logger.debug("find by example successful, result size: "

--- a/src/main/java/ca/openosp/openo/webserv/rest/to/model/BookingProviderTransfer.java
+++ b/src/main/java/ca/openosp/openo/webserv/rest/to/model/BookingProviderTransfer.java
@@ -31,7 +31,11 @@ import java.util.Map;
 import org.apache.logging.log4j.Logger;
 import ca.openosp.openo.appointment.search.FilterDefinition;
 import ca.openosp.openo.appointment.search.Provider;
-
+import ca.openosp.openo.appointment.search.filters.ExistingAppointmentFilter;
+import ca.openosp.openo.appointment.search.filters.FutureApptFilter;
+import ca.openosp.openo.appointment.search.filters.MultiUnitFilter;
+import ca.openosp.openo.appointment.search.filters.OpenAccessFilter;
+import ca.openosp.openo.appointment.search.filters.SufficientContiguousTimeFilter;
 import ca.openosp.openo.utility.MiscUtils;
 
 
@@ -120,17 +124,17 @@ public class BookingProviderTransfer {
         providerTransfer.filters = new ArrayList<FilterDefinitionTransfer>();
         if (provider.getFilter() != null) {
             for (FilterDefinition f : provider.getFilter()) {
-                if ("org.oscarehr.appointment.search.filters.FutureApptFilter".equals(f.getFilterClassName())) {
+                if (FutureApptFilter.class.getName().equals(f.getFilterClassName())) {
                     providerTransfer.filterFAF = true;
                     providerTransfer.filterFAFbuffer = Integer.parseInt(f.getParams().get("buffer"));
-                } else if ("org.oscarehr.appointment.search.filters.ExistingAppointmentFilter".equals(f.getFilterClassName())) {
+                } else if (ExistingAppointmentFilter.class.getName().equals(f.getFilterClassName())) {
                     providerTransfer.filterEAF = true;
-                } else if ("org.oscarehr.appointment.search.filters.MultiUnitFilter".equals(f.getFilterClassName())) {
+                } else if (MultiUnitFilter.class.getName().equals(f.getFilterClassName())) {
                     providerTransfer.filterMUF = true;
-                } else if ("org.oscarehr.appointment.search.filters.OpenAccessFilter".equals(f.getFilterClassName())) {
+                } else if (OpenAccessFilter.class.getName().equals(f.getFilterClassName())) {
                     providerTransfer.filterOAF = true;
                     providerTransfer.filterOAFCodes = f.getParams().get("codes");
-                } else if ("org.oscarehr.appointment.search.filters.SufficientContiguousTimeFilter".equals(f.getFilterClassName())) {
+                } else if (SufficientContiguousTimeFilter.class.getName().equals(f.getFilterClassName())) {
                     providerTransfer.filterSCTF = true;
                 }
             }


### PR DESCRIPTION
## Changes made
Refactor several references to classes that use string literals so they use the `Class.class.getName()` convention.

## Summary by Sourcery

Refactor usages of class name string literals to use Class.getName() for safer and clearer class references

Enhancements:
- Replace hard-coded class name literals with PipeParser.class.getName(), Message.class.getName(), Segment.class.getName(), Terser.class.getName(), and TerserUtil.class.getName() in DynamicHapiLoaderUtils
- Update filter class name checks in BookingProviderTransfer to use FutureApptFilter.class.getName(), ExistingAppointmentFilter.class.getName(), MultiUnitFilter.class.getName(), OpenAccessFilter.class.getName(), and SufficientContiguousTimeFilter.class.getName()
- Change Hibernate entity and criteria references in SecProviderDaoImpl to use SecProvider.class instead of string-based class names