### PR TITLE
Enable remote debugging in VS Code

### DIFF
--- a/.devcontainer/development/Dockerfile
+++ b/.devcontainer/development/Dockerfile
@@ -4,6 +4,8 @@ FROM tomcat:9.0.97-jdk21-temurin
 ENV CATALINA_HOME /usr/local/tomcat
 ENV PATH $CATALINA_HOME/bin:$PATH
 ENV CATALINA_OPTS="--add-opens java.base/java.net=ALL-UNNAMED -Xdebug -Xrunjdwp:transport=dt_socket,address=8000,server=y,suspend=n"
+ENV JPDA_ADDRESS=8000
+ENV JPDA_TRANSPORT=dt_socket
 
 # Copy Tomcat installation from the official Tomcat image
 COPY --from=tomcat:9.0.97 /usr/local/tomcat $CATALINA_HOME

--- a/.devcontainer/development/scripts/server
+++ b/.devcontainer/development/scripts/server
@@ -8,7 +8,7 @@ case $command in
     ;;
 
   start)
-    catalina.sh start
+    catalina.sh jpda start
 
     sleep 2
     # Save PID to file tomcat.pid

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,12 @@
+{
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"type": "java",
+			"name": "Attach to Tomcat",
+			"request": "attach",
+			"hostName": "localhost",
+			"port": 8000
+		}
+	]
+}


### PR DESCRIPTION
## Changes made
- Set JPDA environment variables in Dockerfile.
- Add `jdpa` argument when calling `catalina.sh` in our server script.
- Add VS Code Debug launch option.

## Summary by Sourcery

Enable remote debugging in VS Code by configuring the Tomcat container and adding a launch profile

New Features:
- Configure JPDA environment variables in the Dockerfile and update the server script to start Tomcat with remote debugging
- Add a VS Code launch configuration to attach to the remote Tomcat debug port