### PR TITLE
Enable Struts dev mode in make script

### DIFF
--- a/.devcontainer/development/scripts/make
+++ b/.devcontainer/development/scripts/make
@@ -13,9 +13,11 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 # Function to handle the build and deploy logic
 # Takes a single argument ($1) which is a boolean indicating whether to run tests.
 # Takes a second argument ($2) which is a boolean indicating whether to compile JSPs.
+# Takes a third argument ($3) which is a boolean indicating whether to enable dev mode.
 build_and_deploy() {
   run_tests="$1"
   compile_jsps="$2"
+  dev_mode="$3"
 
   # Stop the Catalina server by calling the `server` script located in the same directory as this script.
   "$SCRIPT_DIR/server" stop
@@ -39,10 +41,15 @@ build_and_deploy() {
     jsp_profile="-Pjspc"
   fi
   
+  dev_mode_flag=""
+  if [ "$dev_mode" = true ]; then
+    dev_mode_flag="-Dstruts.devMode=true"
+  fi
+  
   if [ "$run_tests" = true ]; then
-    mvn clean -T 1C package war:exploded $jsp_profile
+    mvn clean -T 1C package war:exploded $jsp_profile $dev_mode_flag
   else
-    mvn clean -Dmaven.test.skip=true -T 1C package war:exploded $jsp_profile
+    mvn clean -Dmaven.test.skip=true -T 1C package war:exploded $jsp_profile $dev_mode_flag
   fi
 
   # Extract the version from the pom.xml file.
@@ -172,20 +179,22 @@ print_help() {
       echo "Usage: make [command] [flags]"
       echo ""
       echo "Commands:"
-      echo "  clean                           Clean the project and remove the target directory."
-      echo "  install [--run-tests] [--jspc]  Build and deploy the project. Run unit tests if --run-tests is specified."
-      echo "                                  Compile JSPs if --jspc is specified."
-      echo "  jspc                            Compile JSPs only (no deployment)."
-      echo "  docs                            Generate all documentation and build static site for production."
-      echo "  docs-serve                      Start Docusaurus development server (http://localhost:3000)."
-      echo "  lock                            Update the dependency lock file."
-      echo "  help                            Display this help message."
+      echo "  clean                                         Clean the project and remove the target directory."
+      echo "  install [--run-tests] [--jspc] [--dev-mode]   Build and deploy the project. Run unit tests if --run-tests is specified."
+      echo "                                                Compile JSPs if --jspc is specified."
+      echo "                                                Enable Struts dev mode if --dev-mode is specified."
+      echo "  jspc                                          Compile JSPs only (no deployment)."
+      echo "  docs                                          Generate all documentation and build static site for production."
+      echo "  docs-serve                                    Start Docusaurus development server (http://localhost:3000)."
+      echo "  lock                                          Update the dependency lock file."
+      echo "  help                                          Display this help message."
 }
 
 # Default behavior is to skip tests unless --run-tests is explicitly provided.
 # Default behavior is to skip JSP compilation unless --jspc is explicitly provided.
 run_tests=false
 compile_jsps=false
+dev_mode=false
 
 # If no arguments are provided, display usage instructions and exit.
 if [ $# -eq 0 ]; then
@@ -214,6 +223,10 @@ for arg in "$@"; do
             compile_jsps=true
             shift
             ;;
+          --dev-mode)
+            dev_mode=true
+            shift
+            ;;
           *)
             echo "Unknown flag: $1"
             print_help
@@ -222,7 +235,7 @@ for arg in "$@"; do
         esac
       done
       # Run the build and deploy process, passing in whether or not to run tests and compile JSPs.
-      build_and_deploy "$run_tests" "$compile_jsps"
+      build_and_deploy "$run_tests" "$compile_jsps" "$dev_mode"
       ;;
     jspc)
       # Compile JSPs only without deployment.

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
         <hapifhir.version>6.4.0</hapifhir.version>
         <!-- Apache CXF Version -->
         <cxf.version>3.5.11</cxf.version>
+        <struts.devMode>false</struts.devMode>
     </properties>
 
     <repositories>
@@ -1510,6 +1511,11 @@
                     <webResources>
                         <resource>
                             <directory>src/main/webapp</directory>
+                        </resource>
+                        <resource>
+                            <directory>src/main/webapp/WEB-INF/classes</directory>
+                            <filtering>true</filtering>
+                            <targetPath>WEB-INF/classes</targetPath>
                         </resource>
                     </webResources>
                 </configuration>

--- a/src/main/webapp/WEB-INF/classes/struts.xml
+++ b/src/main/webapp/WEB-INF/classes/struts.xml
@@ -3,6 +3,7 @@
 <struts>
     <constant name="struts.mapper.action.prefix.enabled" value="false"/>
 	<constant name="struts.action.extension" value="do" />
+    <constant name="struts.devMode" value="${struts.devMode}"/>
     <constant name="struts.objectFactory" value="spring"/>
     <constant name="struts.enable.SlashesInActionNames" value="true" />
     <constant name="struts.serve.static" value="true" />
@@ -2025,12 +2026,13 @@
             </result>
         </action>
         <action name="hospitalReportManager/Display" class="ca.openosp.openo.hospitalReportManager.HRMDisplayReport2Action">
-            <result name="display">/hospitalReportManager/displayHRMReport.jsp</result>
+            <result name="display" type="dispatcher">/hospitalReportManager/displayHRMReport.jsp</result>
         </action>
         <action name="hospitalReportManager/hrmKeyUploader" class="ca.openosp.openo.hospitalReportManager.HRMUploadKey2Action">
             <result name="success">/hospitalReportManager/hrmPreferences.jsp</result>
         </action>
         <action name="hospitalReportManager/UploadLab" class="ca.openosp.openo.hospitalReportManager.HRMUploadLab2Action">
+            <interceptor-ref name="defaultStack"/>
             <result name="success">/hospitalReportManager/hospitalReportManager.jsp</result>
         </action>
         <action name="hospitalReportManager/Modify" class="ca.openosp.openo.hospitalReportManager.HRMModifyDocument2Action">


### PR DESCRIPTION
## Changes made
- Add `make install --dev-mode` script flag to set struts.devMode to true.
- Add `src/main/webapp/WEB-INF/classes` to maven-war-plugin resources, so it can access struts.xml.
- Set `struts.devMode` to value of `${struts.devMode}`.
  - Example: `mvn clean -T 1C package war:exploded $jsp_profile -Dstruts.devMode=true`

## Summary by Sourcery

Enable toggling of Struts development mode via the make script and propagate the setting through the Maven build and Struts configuration

New Features:
- Add --dev-mode flag to the make install script to set struts.devMode

Enhancements:
- Introduce struts.devMode Maven property and include WEB-INF/classes in the WAR with filtering
- Update struts.xml to read the struts.devMode property
- Specify dispatcher result type for hospitalReportManager Display action and add defaultStack interceptor to the UploadLab action