### PR TITLE
Fix namespace issue affecting lab upload and display

### DIFF
--- a/src/main/java/ca/openosp/openo/lab/ca/all/parsers/Factory.java
+++ b/src/main/java/ca/openosp/openo/lab/ca/all/parsers/Factory.java
@@ -151,7 +151,15 @@ public final class Factory {
                 msgType = element.getAttributeValue("name");
 
                 if (msgType.equalsIgnoreCase(type)) {
-                    msgHandler = element.getAttributeValue("className");
+                    String className = element.getAttributeValue("className");
+
+                    // in case we have dots in the handler class name (i.e. package
+                    // is specified), don't assume default package
+                    if (className.indexOf(".") != -1) {
+                        msgHandler = className;
+                    } else {
+                        msgHandler = "ca.openosp.openo.lab.ca.all.parsers." + className;
+                    }
                 }
             }
 


### PR DESCRIPTION
This PR fixes a namespace issue that was causing SOAP lab upload and lab display to fail.

This PR will fix this issue as well: https://github.com/openo-beta/Open-O/issues/524

## Summary by Sourcery

Bug Fixes:
- Differentiate between fully-qualified and simple handler class names and prefix the default package when missing