### PR TITLE
Fix NotesService /{demographicNo}/all endpoint session issue

### DIFF
--- a/src/main/java/ca/openosp/openo/webserv/rest/NotesService.java
+++ b/src/main/java/ca/openosp/openo/webserv/rest/NotesService.java
@@ -143,7 +143,7 @@ public class NotesService extends AbstractServiceImpl {
         LoggedInInfo loggedInInfo = getLoggedInInfo();
         logger.debug("The config " + jsonobject.toString());
 
-        HttpSession se = loggedInInfo.getSession();
+        HttpSession se = getHttpServletRequest().getSession();
         if (se.getAttribute("userrole") == null) {
             logger.error("An Error needs to be added to the returned result, remove this when fixed");
             return returnResult;


### PR DESCRIPTION
This PR fixes a session handling issue in the NotesService /{demographicNo}/all endpoint.

## Summary by Sourcery

Bug Fixes:
- Replace usage of loggedInInfo.getSession() with getHttpServletRequest().getSession() to ensure the correct HTTP session is accessed