### PR TITLE
Replace Jettison with FasterXML Jackson for REST JSON handling

### DIFF
--- a/dependencies-lock.json
+++ b/dependencies-lock.json
@@ -1267,14 +1267,6 @@
     "optional" : false,
     "integrity" : "sha512:+ppatR+X4s1jtcHLF3W2Ox7cAZeu28wOirMRbf4n1HNlhl0k7vrxm2SFVLYPGh7OE+MZLRV8MZNEqXrVUcYoxA=="
   }, {
-    "groupId" : "javax.ws.rs",
-    "artifactId" : "jsr311-api",
-    "version" : "1.1.1",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:7t5Iykww/iUWBjbK0n/FcyExVD1nxZZ2KC5P0GjlbC4nIXHJBI3WtbwLDIiL28Oqj5wRfJfkLZMJzwSdC/iUuw=="
-  }, {
     "groupId" : "javax.xml.bind",
     "artifactId" : "jaxb-api",
     "version" : "2.3.1",

--- a/pom.xml
+++ b/pom.xml
@@ -857,6 +857,13 @@
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-client</artifactId>
             <version>2.39.1</version>
+            <!-- Exclude it to avoid conflict with the apache.cxf's jakarta.ws.rs-api -->
+            <exclusions>
+                <exclusion>
+                <groupId>jakarta.ws.rs</groupId>
+                <artifactId>jakarta.ws.rs-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- AXIS2 (for OLIS) -->
@@ -889,6 +896,11 @@
                 <exclusion>
                     <groupId>org.apache.ant</groupId>
                     <artifactId>ant</artifactId>
+                </exclusion>
+                <!-- Exclude old JAX-RS API to avoid conflict with jakarta.ws.rs -->
+                <exclusion>
+                    <groupId>javax.ws.rs</groupId>
+                    <artifactId>jsr311-api</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/src/main/java/ca/openosp/openo/webserv/csrf/CsrfTokenService.java
+++ b/src/main/java/ca/openosp/openo/webserv/csrf/CsrfTokenService.java
@@ -30,12 +30,15 @@ import ca.openosp.openo.webserv.oauth.AbstractServiceImpl;
 import org.owasp.csrfguard.CsrfGuard;
 import org.springframework.stereotype.Component;
 
+import javax.ws.rs.Consumes;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
 
 @Path("/csrf")
 @Component("csrfTokenService")
+@Consumes(MediaType.APPLICATION_JSON)
 public class CsrfTokenService extends AbstractServiceImpl {
 
     @POST

--- a/src/main/java/ca/openosp/openo/webserv/rest/AllergyService.java
+++ b/src/main/java/ca/openosp/openo/webserv/rest/AllergyService.java
@@ -26,10 +26,12 @@ package ca.openosp.openo.webserv.rest;
 
 import java.util.List;
 
+import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
 
 import ca.openosp.openo.commn.model.Allergy;
 import ca.openosp.openo.managers.AllergyManager;
@@ -42,6 +44,7 @@ import org.springframework.stereotype.Component;
 
 @Path("/allergies")
 @Component("allergyService")
+@Consumes(MediaType.APPLICATION_JSON)
 public class AllergyService extends AbstractServiceImpl {
 
     @Autowired

--- a/src/main/java/ca/openosp/openo/webserv/rest/AppService.java
+++ b/src/main/java/ca/openosp/openo/webserv/rest/AppService.java
@@ -36,9 +36,11 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
 
+import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
 
 import org.apache.logging.log4j.Logger;
 import ca.openosp.openo.managers.AppManager;
@@ -48,6 +50,7 @@ import ca.openosp.openo.webserv.rest.to.model.AppDefinitionTo1;
 import org.springframework.beans.factory.annotation.Autowired;
 
 @Path("/app")
+@Consumes(MediaType.APPLICATION_JSON)
 public class AppService extends AbstractServiceImpl {
     protected Logger logger = MiscUtils.getLogger();
 

--- a/src/main/java/ca/openosp/openo/webserv/rest/BillingService.java
+++ b/src/main/java/ca/openosp/openo/webserv/rest/BillingService.java
@@ -24,10 +24,12 @@
  */
 package ca.openosp.openo.webserv.rest;
 
+import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
 
 import ca.openosp.openo.managers.BillingManager;
 import ca.openosp.openo.webserv.rest.conversion.ServiceTypeConverter;
@@ -39,6 +41,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import ca.openosp.OscarProperties;
 
 @Path("/billing")
+@Consumes(MediaType.APPLICATION_JSON)
 public class BillingService extends AbstractServiceImpl {
 
     @Autowired

--- a/src/main/java/ca/openosp/openo/webserv/rest/ConsentService.java
+++ b/src/main/java/ca/openosp/openo/webserv/rest/ConsentService.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Date;
 
 import javax.ws.rs.Consumes;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -61,6 +62,7 @@ import org.springframework.stereotype.Component;
 @Component("ConsentService")
 @Path("/consentService/")
 @Produces("application/xml")
+@Consumes(MediaType.APPLICATION_JSON)
 public class ConsentService extends AbstractServiceImpl {
 
     private static final Logger logger = MiscUtils.getLogger();

--- a/src/main/java/ca/openosp/openo/webserv/rest/ConsultationWebService.java
+++ b/src/main/java/ca/openosp/openo/webserv/rest/ConsultationWebService.java
@@ -106,6 +106,7 @@ import ca.openosp.openo.util.ConversionUtils;
 
 @Path("/consults")
 @Component("consultationWebService")
+@Consumes(MediaType.APPLICATION_JSON)
 public class ConsultationWebService extends AbstractServiceImpl {
 
     Pattern namePtrn = Pattern.compile("sorting\\[(\\w+)\\]");

--- a/src/main/java/ca/openosp/openo/webserv/rest/DemographicMergeService.java
+++ b/src/main/java/ca/openosp/openo/webserv/rest/DemographicMergeService.java
@@ -27,12 +27,14 @@ package ca.openosp.openo.webserv.rest;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
 
 import ca.openosp.openo.commn.model.DemographicMerged;
 import ca.openosp.openo.managers.DemographicManager;
@@ -47,6 +49,7 @@ import org.springframework.stereotype.Component;
  */
 @Path("/demographics/merge")
 @Component("demographicMergeService")
+@Consumes(MediaType.APPLICATION_JSON)
 public class DemographicMergeService extends AbstractServiceImpl {
 
 

--- a/src/main/java/ca/openosp/openo/webserv/rest/DemographicService.java
+++ b/src/main/java/ca/openosp/openo/webserv/rest/DemographicService.java
@@ -109,6 +109,7 @@ import ca.openosp.openo.waitinglist.util.WLWaitingListUtil;
  */
 @Path("/demographics")
 @Component("demographicService")
+@Consumes(MediaType.APPLICATION_JSON)
 public class DemographicService extends AbstractServiceImpl {
 
     private enum IncludeType {

--- a/src/main/java/ca/openosp/openo/webserv/rest/DiseaseRegistryService.java
+++ b/src/main/java/ca/openosp/openo/webserv/rest/DiseaseRegistryService.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 
 import javax.ws.rs.*;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import ca.openosp.openo.casemgmt.dao.IssueDAO;
@@ -47,6 +48,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import ca.openosp.openo.log.LogAction;
 
 @Path("/dxRegisty")
+@Consumes(MediaType.APPLICATION_JSON)
 public class DiseaseRegistryService extends AbstractServiceImpl {
 
     @Autowired

--- a/src/main/java/ca/openosp/openo/webserv/rest/DocumentService.java
+++ b/src/main/java/ca/openosp/openo/webserv/rest/DocumentService.java
@@ -55,6 +55,7 @@ import java.util.Map;
 @Service
 @Path("/document")
 @Component("documentService")
+@Consumes(MediaType.APPLICATION_JSON)
 public class DocumentService extends AbstractServiceImpl {
     private static Logger logger = MiscUtils.getLogger();
 

--- a/src/main/java/ca/openosp/openo/webserv/rest/FormsService.java
+++ b/src/main/java/ca/openosp/openo/webserv/rest/FormsService.java
@@ -34,11 +34,13 @@ import java.util.Date;
 import java.util.List;
 import java.util.ResourceBundle;
 
+import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.logging.log4j.Logger;
@@ -72,6 +74,7 @@ import ca.openosp.openo.encounter.data.EctFormData;
  */
 @Path("/forms")
 @Component("formsService")
+@Consumes(MediaType.APPLICATION_JSON)
 public class FormsService extends AbstractServiceImpl {
     Logger logger = MiscUtils.getLogger();
 

--- a/src/main/java/ca/openosp/openo/webserv/rest/InboxService.java
+++ b/src/main/java/ca/openosp/openo/webserv/rest/InboxService.java
@@ -28,10 +28,12 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
+import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
 
 import ca.openosp.openo.commn.dao.ProviderLabRoutingDao;
 import ca.openosp.openo.inbox.InboxManagerQuery;
@@ -48,6 +50,7 @@ import ca.openosp.openo.lab.ca.on.LabResultData;
 
 @Path("/inbox")
 @Component("inboxService")
+@Consumes(MediaType.APPLICATION_JSON)
 public class InboxService extends AbstractServiceImpl {
 
     @Autowired

--- a/src/main/java/ca/openosp/openo/webserv/rest/LabService.java
+++ b/src/main/java/ca/openosp/openo/webserv/rest/LabService.java
@@ -37,6 +37,7 @@ import java.util.Optional;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.Consumes;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -65,6 +66,7 @@ import ca.openosp.openo.lab.ca.all.util.Utilities;
 
 @Path("/labs")
 @Component("labService")
+@Consumes(MediaType.APPLICATION_JSON)
 public class LabService extends AbstractServiceImpl {
 	private static Logger logger = MiscUtils.getLogger();
 

--- a/src/main/java/ca/openosp/openo/webserv/rest/MeasurementService.java
+++ b/src/main/java/ca/openosp/openo/webserv/rest/MeasurementService.java
@@ -85,6 +85,7 @@ import java.util.List;
  */
 @Path("/measurements")
 @Component("measurementService")
+@Consumes(MediaType.APPLICATION_JSON)
 public class MeasurementService extends AbstractServiceImpl {
     /** Security manager for OAuth authentication and authorization. */
     @Autowired

--- a/src/main/java/ca/openosp/openo/webserv/rest/MessagingService.java
+++ b/src/main/java/ca/openosp/openo/webserv/rest/MessagingService.java
@@ -26,10 +26,12 @@ package ca.openosp.openo.webserv.rest;
 
 import java.util.List;
 
+import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
 
 import ca.openosp.openo.commn.model.MessageList;
 import ca.openosp.openo.commn.model.Provider;
@@ -41,6 +43,7 @@ import org.springframework.stereotype.Component;
 
 @Path("/messaging")
 @Component("messagingService")
+@Consumes(MediaType.APPLICATION_JSON)
 public class MessagingService extends AbstractServiceImpl {
 
     @Autowired

--- a/src/main/java/ca/openosp/openo/webserv/rest/NotesService.java
+++ b/src/main/java/ca/openosp/openo/webserv/rest/NotesService.java
@@ -30,6 +30,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import javax.servlet.http.HttpSession;
 import javax.ws.rs.Consumes;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -104,6 +105,7 @@ import ca.openosp.openo.encounter.pageUtil.EctSessionBean;
 
 @Path("/notes")
 @Component("notesService")
+@Consumes(MediaType.APPLICATION_JSON)
 public class NotesService extends AbstractServiceImpl {
 
     public static String cppCodes[] = {"OMeds", "SocHistory", "MedHistory", "Concerns", "FamHistory", "Reminders", "RiskFactors", "OcularMedication", "TicklerNote"};

--- a/src/main/java/ca/openosp/openo/webserv/rest/OscarJobService.java
+++ b/src/main/java/ca/openosp/openo/webserv/rest/OscarJobService.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.concurrent.ScheduledFuture;
 
 import javax.ws.rs.Consumes;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -56,6 +57,7 @@ import org.springframework.stereotype.Component;
 
 @Path("/jobs")
 @Component("oscarJobService")
+@Consumes(MediaType.APPLICATION_JSON)
 public class OscarJobService extends AbstractServiceImpl {
 
     Logger logger = MiscUtils.getLogger();

--- a/src/main/java/ca/openosp/openo/webserv/rest/PatientDetailStatusService.java
+++ b/src/main/java/ca/openosp/openo/webserv/rest/PatientDetailStatusService.java
@@ -26,6 +26,7 @@ package ca.openosp.openo.webserv.rest;
 
 import java.util.List;
 
+import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -50,6 +51,7 @@ import ca.openosp.OscarProperties;
 
 @Path("/patientDetailStatusService")
 @Produces({MediaType.APPLICATION_JSON})
+@Consumes(MediaType.APPLICATION_JSON)
 public class PatientDetailStatusService extends AbstractServiceImpl {
     @Autowired
     private DemographicManager demographicManager;

--- a/src/main/java/ca/openosp/openo/webserv/rest/PersonaService.java
+++ b/src/main/java/ca/openosp/openo/webserv/rest/PersonaService.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.ResourceBundle;
 
 import javax.ws.rs.Consumes;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -74,6 +75,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 
 @Path("/persona")
+@Consumes(MediaType.APPLICATION_JSON)
 public class PersonaService extends AbstractServiceImpl {
     protected Logger logger = MiscUtils.getLogger();
 

--- a/src/main/java/ca/openosp/openo/webserv/rest/PharmacyService.java
+++ b/src/main/java/ca/openosp/openo/webserv/rest/PharmacyService.java
@@ -24,6 +24,7 @@
  */
 package ca.openosp.openo.webserv.rest;
 
+import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -31,6 +32,7 @@ import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
 
 import ca.openosp.openo.commn.dao.PharmacyInfoDao;
 import ca.openosp.openo.commn.model.PharmacyInfo;
@@ -47,6 +49,7 @@ import org.springframework.stereotype.Component;
  */
 @Path("/pharmacies/")
 @Component("pharmacyService")
+@Consumes(MediaType.APPLICATION_JSON)
 public class PharmacyService extends AbstractServiceImpl {
 
     @Autowired

--- a/src/main/java/ca/openosp/openo/webserv/rest/PreventionService.java
+++ b/src/main/java/ca/openosp/openo/webserv/rest/PreventionService.java
@@ -26,6 +26,7 @@ package ca.openosp.openo.webserv.rest;
 
 import java.util.List;
 
+import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -45,6 +46,7 @@ import javax.ws.rs.core.MediaType;
 
 @Path("/preventions/")
 @Component("preventionService")
+@Consumes(MediaType.APPLICATION_JSON)
 public class PreventionService extends AbstractServiceImpl {
 
     @Autowired

--- a/src/main/java/ca/openosp/openo/webserv/rest/ProductDispensingService.java
+++ b/src/main/java/ca/openosp/openo/webserv/rest/ProductDispensingService.java
@@ -27,6 +27,7 @@ package ca.openosp.openo.webserv.rest;
 import java.util.List;
 
 import javax.ws.rs.Consumes;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -56,6 +57,7 @@ import org.springframework.stereotype.Component;
 
 @Path("/productDispensing")
 @Component("productDispensingService")
+@Consumes(MediaType.APPLICATION_JSON)
 public class ProductDispensingService extends AbstractServiceImpl {
 
     @Autowired

--- a/src/main/java/ca/openosp/openo/webserv/rest/ProgramService.java
+++ b/src/main/java/ca/openosp/openo/webserv/rest/ProgramService.java
@@ -30,10 +30,12 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 
+import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
 
 import org.apache.commons.lang.time.DateFormatUtils;
 import org.apache.tools.ant.util.DateUtils;
@@ -48,6 +50,7 @@ import ca.openosp.openo.webserv.rest.to.model.ProgramTo1;
 import org.springframework.beans.factory.annotation.Autowired;
 
 @Path("/program")
+@Consumes(MediaType.APPLICATION_JSON)
 public class ProgramService extends AbstractServiceImpl {
 
 

--- a/src/main/java/ca/openosp/openo/webserv/rest/ProviderService.java
+++ b/src/main/java/ca/openosp/openo/webserv/rest/ProviderService.java
@@ -31,6 +31,7 @@ import java.util.Date;
 import java.util.List;
 
 import javax.ws.rs.Consumes;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -75,6 +76,7 @@ import org.springframework.stereotype.Component;
 @Component("ProviderService")
 @Path("/providerService/")
 @Produces("application/xml")
+@Consumes(MediaType.APPLICATION_JSON)
 public class ProviderService extends AbstractServiceImpl {
 
     private static final Logger logger = MiscUtils.getLogger();

--- a/src/main/java/ca/openosp/openo/webserv/rest/RecordUxService.java
+++ b/src/main/java/ca/openosp/openo/webserv/rest/RecordUxService.java
@@ -74,6 +74,7 @@ import net.sf.json.JSONObject;
 
 @Path("/recordUX/")
 @Component("recordUxService")
+@Consumes(MediaType.APPLICATION_JSON)
 public class RecordUxService extends AbstractServiceImpl {
     private static final Logger logger = MiscUtils.getLogger();
 

--- a/src/main/java/ca/openosp/openo/webserv/rest/ReportByTemplateService.java
+++ b/src/main/java/ca/openosp/openo/webserv/rest/ReportByTemplateService.java
@@ -24,7 +24,9 @@
  */
 package ca.openosp.openo.webserv.rest;
 
+import javax.ws.rs.Consumes;
 import javax.ws.rs.Path;
+import javax.ws.rs.core.MediaType;
 
 import ca.openosp.openo.commn.dao.AppDefinitionDao;
 import ca.openosp.openo.commn.dao.AppUserDao;
@@ -33,6 +35,7 @@ import ca.openosp.openo.managers.SecurityInfoManager;
 import org.springframework.beans.factory.annotation.Autowired;
 
 @Path("/reportByTemplate")
+@Consumes(MediaType.APPLICATION_JSON)
 public class ReportByTemplateService extends AbstractServiceImpl {
     @Autowired
     private SecurityInfoManager securityInfoManager;

--- a/src/main/java/ca/openosp/openo/webserv/rest/ReportingService.java
+++ b/src/main/java/ca/openosp/openo/webserv/rest/ReportingService.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.UUID;
 
 import javax.ws.rs.Consumes;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -65,6 +66,7 @@ import org.springframework.stereotype.Component;
 
 @Path("/reporting/")
 @Component
+@Consumes(MediaType.APPLICATION_JSON)
 public class ReportingService extends AbstractServiceImpl {
     private static Logger logger = MiscUtils.getLogger();
 

--- a/src/main/java/ca/openosp/openo/webserv/rest/ResourceService.java
+++ b/src/main/java/ca/openosp/openo/webserv/rest/ResourceService.java
@@ -27,10 +27,12 @@ package ca.openosp.openo.webserv.rest;
 import java.util.ResourceBundle;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
 
 import org.apache.logging.log4j.Logger;
 
@@ -50,6 +52,7 @@ import ca.openosp.openo.prevention.PreventionDS;
 
 
 @Path("/resources")
+@Consumes(MediaType.APPLICATION_JSON)
 public class ResourceService extends AbstractServiceImpl {
     private static final Logger logger = MiscUtils.getLogger();
 

--- a/src/main/java/ca/openosp/openo/webserv/rest/RxLookupService.java
+++ b/src/main/java/ca/openosp/openo/webserv/rest/RxLookupService.java
@@ -39,6 +39,7 @@ import ca.openosp.openo.prescript.data.RxPrescriptionData;
 import ca.openosp.openo.prescript.util.RxUtil;
 
 import javax.ws.rs.*;
+import javax.ws.rs.core.MediaType;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -50,6 +51,7 @@ import java.util.List;
 @Path("/rxlookup")
 @Component("rxLookupService")
 @Produces("application/xml")
+@Consumes(MediaType.APPLICATION_JSON)
 public class RxLookupService extends AbstractServiceImpl {
 
     private static Logger logger = MiscUtils.getLogger();

--- a/src/main/java/ca/openosp/openo/webserv/rest/RxWebService.java
+++ b/src/main/java/ca/openosp/openo/webserv/rest/RxWebService.java
@@ -82,6 +82,7 @@ import java.util.List;
 @Path("/rx")
 @Component("rxWebService")
 @Produces("application/xml")
+@Consumes(MediaType.APPLICATION_JSON)
 public class RxWebService extends AbstractServiceImpl {
 
     private static Logger logger = MiscUtils.getLogger();

--- a/src/main/java/ca/openosp/openo/webserv/rest/ScheduleService.java
+++ b/src/main/java/ca/openosp/openo/webserv/rest/ScheduleService.java
@@ -95,6 +95,7 @@ import org.w3c.dom.Document;
 
 @Path("/schedule")
 @Component("scheduleService")
+@Consumes(MediaType.APPLICATION_JSON)
 public class ScheduleService extends AbstractServiceImpl {
 
     Logger logger = MiscUtils.getLogger();

--- a/src/main/java/ca/openosp/openo/webserv/rest/StatusService.java
+++ b/src/main/java/ca/openosp/openo/webserv/rest/StatusService.java
@@ -24,15 +24,18 @@
  */
 package ca.openosp.openo.webserv.rest;
 
+import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
 
 import ca.openosp.openo.PMmodule.service.ProviderManager;
 import ca.openosp.openo.webserv.rest.to.GenericRESTResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 
 @Path("/status")
+@Consumes(MediaType.APPLICATION_JSON)
 public class StatusService extends AbstractServiceImpl {
 
     @Autowired

--- a/src/main/java/ca/openosp/openo/webserv/rest/TicklerWebService.java
+++ b/src/main/java/ca/openosp/openo/webserv/rest/TicklerWebService.java
@@ -29,6 +29,7 @@ import java.util.List;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.Consumes;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -60,6 +61,7 @@ import org.springframework.stereotype.Component;
 
 @Path("/tickler")
 @Component("ticklerWebService")
+@Consumes(MediaType.APPLICATION_JSON)
 public class TicklerWebService extends AbstractServiceImpl {
 
     @Autowired


### PR DESCRIPTION
This PR replaces the legacy Jettison JSON provider with FasterXML Jackson to improve performance and maintainability while preserving compatibility.