### PR TITLE
Add DevSkim workflow for code scanning

### DIFF
--- a/.github/workflows/devskim.yml
+++ b/.github/workflows/devskim.yml
@@ -1,0 +1,34 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: DevSkim
+
+on:
+  push:
+    branches: [ "develop/dogfish" ]
+  pull_request:
+    branches: [ "develop/dogfish" ]
+  schedule:
+    - cron: '37 6 * * 3'
+
+jobs:
+  lint:
+    name: DevSkim
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run DevSkim scanner
+        uses: microsoft/DevSkim-Action@v1
+
+      - name: Upload DevSkim scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: devskim-results.sarif


### PR DESCRIPTION
## Summary by Sourcery

Add a new GitHub Actions workflow to run DevSkim static code scanning and publish results to the GitHub Security tab.

New Features:
- Introduce a DevSkim workflow file under .github/workflows to perform code scanning on push, pull_request to develop/dogfish branch
- Schedule weekly DevSkim scans at 06:37 UTC every Wednesday
- Checkout code, run microsoft/DevSkim-Action, and upload SARIF results using github/codeql-action to the Security tab