### PR TITLE
Fixed edit appointment label back button not working

### DIFF
--- a/src/main/webapp/appointment/editappointment.jsp
+++ b/src/main/webapp/appointment/editappointment.jsp
@@ -1329,10 +1329,10 @@
                              width="13">
                     </a>
                     <a class="btn"
-                       onClick="window.location='appointmentcontrol.jsp?displaymode=PrintCard&appointment_no=<%=appointment_no%>'">
+                       onClick="window.location='appointmentcontrol.jsp?displaymode=PrintCard&appointment_no=' + encodeURIComponent('<%=appointment_no%>')">
                         <i class="icon-print"></i>&nbsp;<fmt:setBundle basename="oscarResources"/><fmt:message key="appointment.editappointment.btnPrintCard"/></a>
                     <a class="btn"
-                       onClick="window.location='<%=request.getContextPath() %>/demographic/demographiclabelprintsetting.jsp?demographic_no='+document.EDITAPPT.demographic_no.value, 'labelprint','height=550,width=700,location=no,scrollbars=yes,menubars=no,toolbars=no'">
+                       onClick="window.location='<%=request.getContextPath() %>/demographic/demographiclabelprintsetting.jsp?demographic_no=' + encodeURIComponent(document.EDITAPPT.demographic_no.value), 'labelprint','height=550,width=700,location=no,scrollbars=yes,menubars=no,toolbars=no'">
                         <i class="icon-print"></i>&nbsp;<fmt:setBundle basename="oscarResources"/><fmt:message key="appointment.editappointment.btnLabelPrint"/></a>
                     <a class="btn"
                        onclick="document.forms['EDITAPPT'].displaymode.value='Cut';localStorage.setItem('copyPaste','1');document.forms['EDITAPPT'].submit();">

--- a/src/main/webapp/appointment/editappointment.jsp
+++ b/src/main/webapp/appointment/editappointment.jsp
@@ -1332,7 +1332,7 @@
                        onClick="window.location='appointmentcontrol.jsp?displaymode=PrintCard&appointment_no=<%=appointment_no%>'">
                         <i class="icon-print"></i>&nbsp;<fmt:setBundle basename="oscarResources"/><fmt:message key="appointment.editappointment.btnPrintCard"/></a>
                     <a class="btn"
-                       onClick="window.open('<%=request.getContextPath() %>/demographic/demographiclabelprintsetting.jsp?demographic_no='+document.EDITAPPT.demographic_no.value, 'labelprint','height=550,width=700,location=no,scrollbars=yes,menubars=no,toolbars=no' )">
+                       onClick="window.location='<%=request.getContextPath() %>/demographic/demographiclabelprintsetting.jsp?demographic_no='+document.EDITAPPT.demographic_no.value, 'labelprint','height=550,width=700,location=no,scrollbars=yes,menubars=no,toolbars=no'">
                         <i class="icon-print"></i>&nbsp;<fmt:setBundle basename="oscarResources"/><fmt:message key="appointment.editappointment.btnLabelPrint"/></a>
                     <a class="btn"
                        onclick="document.forms['EDITAPPT'].displaymode.value='Cut';localStorage.setItem('copyPaste','1');document.forms['EDITAPPT'].submit();">

--- a/src/main/webapp/appointment/editappointment.jsp
+++ b/src/main/webapp/appointment/editappointment.jsp
@@ -1332,7 +1332,7 @@
                        onClick="window.location='appointmentcontrol.jsp?displaymode=PrintCard&appointment_no=' + encodeURIComponent('<%=appointment_no%>')">
                         <i class="icon-print"></i>&nbsp;<fmt:setBundle basename="oscarResources"/><fmt:message key="appointment.editappointment.btnPrintCard"/></a>
                     <a class="btn"
-                       onClick="window.location='<%=request.getContextPath() %>/demographic/demographiclabelprintsetting.jsp?demographic_no=' + encodeURIComponent(document.EDITAPPT.demographic_no.value), 'labelprint','height=550,width=700,location=no,scrollbars=yes,menubars=no,toolbars=no'">
+                       onClick="window.open('<%=request.getContextPath() %>/demographic/demographiclabelprintsetting.jsp?demographic_no=' + encodeURIComponent(document.EDITAPPT.demographic_no.value), 'labelprint','height=550,width=700,location=no,scrollbars=yes,menubars=no,toolbars=no')">
                         <i class="icon-print"></i>&nbsp;<fmt:setBundle basename="oscarResources"/><fmt:message key="appointment.editappointment.btnLabelPrint"/></a>
                     <a class="btn"
                        onclick="document.forms['EDITAPPT'].displaymode.value='Cut';localStorage.setItem('copyPaste','1');document.forms['EDITAPPT'].submit();">

--- a/src/main/webapp/demographic/demographiclabelprintsetting.jsp
+++ b/src/main/webapp/demographic/demographiclabelprintsetting.jsp
@@ -308,7 +308,7 @@
                                                                        value="<fmt:setBundle basename='oscarResources'/><fmt:message key='demographic.demographiclabelprintsetting.btnPrintPreviewPrint'/>">
                         <input type="button" class="btn btn-link" name="button"
                                value="<fmt:setBundle basename='oscarResources'/><fmt:message key='global.btnBack'/>"
-                               onClick="javascript:history.go(-1);return false;"></td>
+                               onClick="history.go(-1);"></td>
                 </tr>
             </table>
         </div>

--- a/src/main/webapp/demographic/demographiclabelprintsetting.jsp
+++ b/src/main/webapp/demographic/demographiclabelprintsetting.jsp
@@ -308,7 +308,7 @@
                                                                        value="<fmt:setBundle basename='oscarResources'/><fmt:message key='demographic.demographiclabelprintsetting.btnPrintPreviewPrint'/>">
                         <input type="button" class="btn btn-link" name="button"
                                value="<fmt:setBundle basename='oscarResources'/><fmt:message key='global.btnBack'/>"
-                               onClick="history.go(-1);"></td>
+                               onClick="window.close();"></td>
                 </tr>
             </table>
         </div>


### PR DESCRIPTION
Edit appointment has an option called "Label". If you were to click on this it opens a window, there is a back button but it does not work, this is because it is a new window, i will set it so that it closes the window instead of trying to go back

## Summary by Sourcery

Fix navigation behavior and URL parameter encoding for print and label functions in the Edit Appointment workflow.

Bug Fixes:
- Change the Label Print button to redirect the current window to the demographic label print settings page instead of opening a popup
- Simplify the Back button handler in demographic label print settings to properly navigate back using history.go(-1)

Enhancements:
- Encode appointment_no and demographic_no parameters with encodeURIComponent in redirect URLs to ensure proper URL encoding