### PR TITLE
Fixed error page when clicking set prevention preferences in provider settings

### DIFF
--- a/src/main/java/ca/openosp/openo/provider/web/ProviderProperty2Action.java
+++ b/src/main/java/ca/openosp/openo/provider/web/ProviderProperty2Action.java
@@ -2412,7 +2412,7 @@ public class ProviderProperty2Action extends ActionSupport {
         request.setAttribute("preventionISPAWarningProperty", prop2);
         request.setAttribute("preventionNonISPAWarningProperty", prop3);
 
-        request.setAttribute("providertitle", "providers.preventionPrefs.title");
+        request.setAttribute("providertitle", "provider.preventionPrefs.title");
         request.setAttribute("providermsgPrefs", "provider.preventionPrefs.msgPrefs"); //=Preferences
         request.setAttribute("providerbtnSubmit", "provider.preventionPrefs.btnSubmit"); //=Save
         request.setAttribute("providerbtnCancel", "provider.preventionPrefs.btnCancel"); //=Cancel
@@ -2479,7 +2479,7 @@ public class ProviderProperty2Action extends ActionSupport {
         request.setAttribute("preventionISPAWarningProperty", prop2);
         request.setAttribute("preventionNonISPAWarningProperty", prop3);
 
-        request.setAttribute("providertitle", "providers.preventionPrefs.title");
+        request.setAttribute("providertitle", "provider.preventionPrefs.title");
         request.setAttribute("providermsgPrefs", "provider.preventionPrefs.msgPrefs"); //=Preferences
         request.setAttribute("providerbtnClose", "provider.preventionPrefs.btnClose"); //=Close
 

--- a/src/main/resources/oscarResources_en.properties
+++ b/src/main/resources/oscarResources_en.properties
@@ -1744,7 +1744,7 @@ provider.btnViewBornPrefs=Set BORN Preferences (RBR/NDDS Prompts)
 provider.btnViewDashboardPrefs=Set Dashboard Preferences
 provider.btnViewPreventionPrefs=Set Prevention Preferences
 
-provider.preventionrefs.title=Prevention Preferences
+provider.preventionPrefs.title=Prevention Preferences
 provider.preventionPrefs.msgPrefs=Preferences
 provider.preventionPrefs.msgSuccess_selected=Prevention Preferences updated
 provider.preventionPrefs.msgSuccess_unselected=Prevention Preferences updated

--- a/src/main/resources/oscarResources_pt_BR.properties
+++ b/src/main/resources/oscarResources_pt_BR.properties
@@ -1874,7 +1874,7 @@ provider.btnViewBornPrefs=Definir prefer\u00EAncias NASCIMENTO (Prompts RBR/NDDS
 provider.btnViewDashboardPrefs=Definir prefer\u00EAncias do painel
 provider.btnViewPreventionPrefs=Definir prefer\u00EAncias de preven\u00E7\u00E3o
 
-provider.preventionrefs.title=Prefer\u00EAncias de preven\u00E7\u00E3o
+provider.preventionPrefs.title=Prefer\u00EAncias de preven\u00E7\u00E3o
 provider.preventionPrefs.msgPrefs=Prefer\u00EAncias
 provider.preventionPrefs.msgSuccess_selected=Prefer\u00EAncias de preven\u00E7\u00E3o atualizadas
 provider.preventionPrefs.msgSuccess_unselected=Prefer\u00EAncias de preven\u00E7\u00E3o atualizadas


### PR DESCRIPTION
Fixed error page popping up when clicking set prevention preferences

## Summary by Sourcery

Fix missing resource key error when opening the Prevention Preferences page by aligning Java attribute keys with resource bundle entries.

Bug Fixes:
- Rename 'providers.preventionPrefs.title' to 'provider.preventionPrefs.title' in viewPreventionPrefs and savePreventionPrefs actions
- Correct 'provider.preventionrefs.title' to 'provider.preventionPrefs.title' in English and Portuguese properties files