### PR TITLE
Fixed 500 error in the PHCP option in the admin panel

### DIFF
--- a/src/main/webapp/report/reportonbilledphcp.jsp
+++ b/src/main/webapp/report/reportonbilledphcp.jsp
@@ -43,33 +43,34 @@
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 
 <%
-    DBPreparedHandler dbObj = new DBPreparedHandler();
-    // select providers list
-    Properties prop = new Properties();
-    String sql = "select u.*, p.first_name, p.last_name from secUserRole u, providers p ";
+    try {
+        DBPreparedHandler dbObj = new DBPreparedHandler();
+        // select provider list
+        Properties prop = new Properties();
+        String sql = "select u.*, p.first_name, p.last_name from secUserRole u, provider p ";
 
-    sql += "where u.provider_no=p.provider_no  order by p.first_name, p.last_name";
+        sql += "where u.provider_no=p.provider_no  order by p.first_name, p.last_name";
 
-    ResultSet rs = dbObj.queryResults(sql);
+        ResultSet rs = dbObj.queryResults(sql);
 
-    while (rs.next()) {
-        prop = new Properties();
+        while (rs.next()) {
+            prop = new Properties();
 
-        prop.setProperty("providerNo", Misc.getString(rs, "provider_no"));
-        prop.setProperty("firstName", Misc.getString(rs, "first_name"));
-        prop.setProperty("lastName", Misc.getString(rs, "last_name"));
+            prop.setProperty("providerNo", Misc.getString(rs, "provider_no"));
+            prop.setProperty("firstName", Misc.getString(rs, "first_name"));
+            prop.setProperty("lastName", Misc.getString(rs, "last_name"));
 
-        String roleName = Misc.getString(rs, "role_name");
+            String roleName = Misc.getString(rs, "role_name");
 
-        for (int i = 0; i < ROLE.length; i++) {
-            if (ROLE[i].equals(roleName)) {
-                VEC_PROVIDER[i].add(prop);
+            for (int i = 0; i < ROLE.length; i++) {
+                if (ROLE[i].equals(roleName)) {
+                    VEC_PROVIDER[i].add(prop);
+                }
             }
-        }
 
-        if (Misc.getString(rs, "provider_no").equals(providerNo))
-            providerName = Misc.getString(rs, "first_name") + " " + Misc.getString(rs, "last_name");
-    }
+            if (Misc.getString(rs, "provider_no").equals(providerNo))
+                providerName = Misc.getString(rs, "first_name") + " " + Misc.getString(rs, "last_name");
+        }
 %>
 <%@page import="ca.openosp.openo.db.DBPreparedHandler" %>
 
@@ -102,7 +103,7 @@
                 if (document.myform.codeType.value == "" || document.myform.startDate.value == "" || document.myform.endDate.value == ""
                     || (document.myform.providerNoDoctor.value == "" && document.myform.providerNoResident.value == ""
                         && document.myform.providerNoNP.value == "" && document.myform.providerNoSW.value == "")) {
-                    alert("Please select the codeType/period/providers item(s) from the drop down list before query.");
+                    alert("Please select the codeType/period/provider item(s) from the drop down list before query.");
                     return false;
                 } else {
                     return true;
@@ -196,7 +197,6 @@
         </table>
     </form>
     <%
-        try {
             if (request.getParameter("submit") != null && providerNo != null) {
                 // set dx/serviceCode mode
                 boolean bDx = true;
@@ -910,6 +910,7 @@
         // Log the error to the console
         System.err.println("JSP Processing Error:");
         e.printStackTrace(System.err);
+        request.getRequestDispatcher("/error.jsp").forward(request, response);
         return;
     }
     %>


### PR DESCRIPTION
Fixed the 500 error log not showing in the tomcat logs, fixed the issue of "providers" table not existing error. 

NOTE: got back to the same result as in coyote (can submit the form, but it then gives an error that the "dxpchp" table doesn't exist

This means that the ticket will not be completed, but will be reworked back to its previous version in develop/coyote, which talked about the SQL error on the page and will be sent back into the "Known Issue" section on the project board, since this was set to be parked as per a previous discussion in the development chat, seen below:

<img width="1387" height="678" alt="image" src="https://github.com/user-attachments/assets/675697e0-7817-4215-af3d-b11dee95f3b7" />

## Summary by Sourcery

Fix 500 error in PHCP admin panel by correcting table references and improving error handling

Enhancements:
- Update SQL to query the correct "provider" table instead of non-existent "providers"
- Adjust client-side validation alert to reference "provider" items
- Wrap database retrieval logic in error handling and forward runtime exceptions to error.jsp
- Remove redundant try block around form submission logic

## Summary by Sourcery

Fix SQL reference and enhance error handling in PHCP report JSP to resolve missing logs and table errors

Bug Fixes:
- Correct the SQL query to reference the existing provider table instead of the non-existent providers table
- Update client-side validation alert to reference the singular provider drop-down item
- Forward database runtime exceptions to the error page to surface errors in the logs

Enhancements:
- Wrap database retrieval logic in a try-catch block and remove the redundant try around form submission