### PR TITLE
Update env variables in dev Dockerfile

### DIFF
--- a/.devcontainer/development/Dockerfile
+++ b/.devcontainer/development/Dockerfile
@@ -3,7 +3,9 @@ FROM tomcat:9.0.97-jdk21-temurin
 # Set environment variables for Tomcat
 ENV CATALINA_HOME /usr/local/tomcat
 ENV PATH $CATALINA_HOME/bin:$PATH
-ENV CATALINA_OPTS="--add-opens java.base/java.net=ALL-UNNAMED -Xdebug -Xrunjdwp:transport=dt_socket,address=8000,server=y,suspend=n"
+# ENV CATALINA_OPTS="--add-opens java.base/java.net=ALL-UNNAMED -agentlib:jdwp=transport=dt_socket,address=8000,server=y,suspend=n"
+ENV CATALINA_OPTS="--add-opens java.base/java.net=ALL-UNNAMED"
+ENV JPDA_OPTS="-agentlib:jdwp=transport=dt_socket,address=8000,server=y,suspend=n"
 ENV JPDA_ADDRESS=8000
 ENV JPDA_TRANSPORT=dt_socket
 


### PR DESCRIPTION
## Changes made
- Fix `CATALINA_OPTS` environment variable issue that breaks clean Devcontainer builds.
- Add `JPDA_OPTS` environment variable for remote debugging.