### PR TITLE
Fix ClassNotFoundException by loading `TerserUtils` from hacked HAPI jar

### DIFF
--- a/src/main/java/ca/openosp/openo/commn/hl7/v2/oscar_to_oscar/DynamicHapiLoaderUtils.java
+++ b/src/main/java/ca/openosp/openo/commn/hl7/v2/oscar_to_oscar/DynamicHapiLoaderUtils.java
@@ -79,7 +79,7 @@ public final class DynamicHapiLoaderUtils {
         hackedMessageClass = hackedHapiClassLoader.loadClass(Message.class.getName());
         hackedSegmentClass = hackedHapiClassLoader.loadClass(Segment.class.getName());
         hackedTerserClass = hackedHapiClassLoader.loadClass(Terser.class.getName());
-        hackedTerserUtilsClass = hackedHapiClassLoader.loadClass(TerserUtil.class.getName());
+        hackedTerserUtilsClass = hackedHapiClassLoader.loadClass("TerserUtils");
 
         hackedParseMethod = hackedPipedParserClass.getMethod("parse", String.class);
         hackedEncodeMethod = hackedPipedParserClass.getMethod("encode", hackedMessageClass);


### PR DESCRIPTION
Fix ClassNotFoundException and HL7 version error in DynamicHapiLoaderUtils

- Updated DynamicHapiLoaderUtils to load "TerserUtils" via hacked HAPI classloader instead of using ca.uhn.fhir.util.TerserUtil import
- Prevents ClassNotFoundException during Oscar-to-Oscar lab parsing
- Also fixes HL7Exception: "Can't process message of version '2.3.0' - version not recognized"
- Ensures proper initialization of message handlers in parsers.Factory

closes #524, #572, #573

## Summary by Sourcery

Fix ClassNotFoundException in Oscar-to-Oscar HL7 parsing by loading TerserUtils from the hacked HAPI jar, correct HL7 version recognition, and ensure parser message handlers initialize properly

Bug Fixes:
- Load TerserUtils via hacked HAPI classloader instead of importing ca.uhn.fhir.util.TerserUtil to prevent ClassNotFoundException during parsing
- Fix HL7Exception for unrecognized version '2.3.0' by correcting version handling

Enhancements:
- Ensure proper initialization of message handlers in parsers.Factory