### PR TITLE
Fix HRM document unlinking and provider linking by adding execute() method

### DIFF
--- a/src/main/java/ca/openosp/openo/hospitalReportManager/HRMModifyDocument2Action.java
+++ b/src/main/java/ca/openosp/openo/hospitalReportManager/HRMModifyDocument2Action.java
@@ -47,7 +47,7 @@ public class HRMModifyDocument2Action extends ActionSupport {
     HRMDocumentCommentDao hrmDocumentCommentDao = (HRMDocumentCommentDao) SpringUtils.getBean(HRMDocumentCommentDao.class);
     private SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
 
-    public String undefined() {
+    public String execute() {
         String method = request.getParameter("method");
 
         if (!securityInfoManager.hasPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), "_hrm", "w", null)) {


### PR DESCRIPTION
This PR fixes a Struts2 action mapping issue in HRMModifyDocument2Action.
The action class was missing the standard execute() method, preventing requests from being dispatched correctly.

Closes #575

## Summary by Sourcery

Bug Fixes:
- Replace undefined() method with execute() in HRMModifyDocument2Action to enable correct Struts2 dispatching