### PR TITLE
Fixed updating a tickler results in a 404

### DIFF
--- a/src/main/java/ca/openosp/openo/tickler/pageUtil/EditTickler2Action.java
+++ b/src/main/java/ca/openosp/openo/tickler/pageUtil/EditTickler2Action.java
@@ -68,9 +68,6 @@ public class EditTickler2Action extends ActionSupport {
 
         String providerNo = loggedInInfo.getLoggedInProviderNo();
 
-//        ActionMessages errors = this.getErrors(request);
-//        DynaValidatorForm editForm = (DynaValidatorForm) form;
-
         String ticklerNoStr = request.getParameter("ticklerNo");
         Integer ticklerNo = Integer.parseInt(ticklerNoStr);
 
@@ -221,6 +218,7 @@ public class EditTickler2Action extends ActionSupport {
                 textSuggestId = Integer.parseInt(activeTextStr);
             } catch (NumberFormatException e) {
                 //probably a new text suggestion then
+                logger.error("textSuggestId in activeText cannot be parsed as an int:", e);
             }
 
             TicklerTextSuggest ts = null;
@@ -247,6 +245,7 @@ public class EditTickler2Action extends ActionSupport {
                 textSuggestId = Integer.parseInt(inactiveTextStr);
             } catch (NumberFormatException e) {
                 //probably a new text suggestion then
+                logger.error("textSuggestId in inactiveText cannot be parsed as an int:", e);
             }
 
             TicklerTextSuggest ts = null;

--- a/src/main/java/ca/openosp/openo/tickler/pageUtil/EditTickler2Action.java
+++ b/src/main/java/ca/openosp/openo/tickler/pageUtil/EditTickler2Action.java
@@ -245,7 +245,7 @@ public class EditTickler2Action extends ActionSupport {
                 textSuggestId = Integer.parseInt(inactiveTextStr);
             } catch (NumberFormatException e) {
                 //probably a new text suggestion then
-                logger.error("textSuggestId in inactiveText cannot be parsed as an int:", e);
+                logger.error("textSuggestId in inactiveText cannot be parsed as an int. Value: '{}'", inactiveTextStr, e);
             }
 
             TicklerTextSuggest ts = null;

--- a/src/main/java/ca/openosp/openo/tickler/pageUtil/EditTickler2Action.java
+++ b/src/main/java/ca/openosp/openo/tickler/pageUtil/EditTickler2Action.java
@@ -218,7 +218,7 @@ public class EditTickler2Action extends ActionSupport {
                 textSuggestId = Integer.parseInt(activeTextStr);
             } catch (NumberFormatException e) {
                 //probably a new text suggestion then
-                logger.error("textSuggestId in activeText cannot be parsed as an int:", e);
+                logger.error("textSuggestId in activeText cannot be parsed as an int. Value: '{}'", activeTextStr, e);
             }
 
             TicklerTextSuggest ts = null;

--- a/src/main/webapp/WEB-INF/classes/struts.xml
+++ b/src/main/webapp/WEB-INF/classes/struts.xml
@@ -2054,12 +2054,12 @@
         </action>
         <action name="caseload/CaseloadContent" class="ca.openosp.openo.caseload.CaseloadContent2Action"/>
         <action name="tickler/EditTickler" class="ca.openosp.openo.tickler.pageUtil.EditTickler2Action">
-            <result name="close">/closenreload.html</result>
+            <result name="close">/closenreload.jsp</result>
             <result name="failure">/failure.jsp</result>
             <result name="error">/errorpage.jsp</result>
         </action>
         <action name="tickler/EditTicklerTextSuggest" class="ca.openosp.openo.tickler.pageUtil.EditTickler2Action">
-            <result name="close">/closenreload.html</result>
+            <result name="close">/closenreload.jsp</result>
             <result name="error">/errorpage.jsp</result>
         </action>
         <action name="CodeSearch" class="ca.openosp.openo.commn.web.CodeSearchService2Action"/>


### PR DESCRIPTION
Removed commented out code, added logging to NumberFormatExceptions, fixed struts actions not referencing the new closenreload jsp page that replaced closenreload.html in the previous Magenta merge

## Summary by Sourcery

Fix the 404 error when updating a tickler by correcting Struts result mappings, improve robustness with logging, and clean up unused code

Bug Fixes:
- Correct Struts action 'close' results to reference closenreload.jsp instead of closenreload.html to prevent 404 errors

Enhancements:
- Add error-level logging for NumberFormatExceptions when parsing active/inactive text suggestion IDs

Chores:
- Remove obsolete commented-out code from EditTickler2Action