### PR TITLE
Fix Caseload search filters

### DIFF
--- a/src/main/java/ca/openosp/openo/caseload/CaseloadContent2Action.java
+++ b/src/main/java/ca/openosp/openo/caseload/CaseloadContent2Action.java
@@ -268,8 +268,8 @@ public class CaseloadContent2Action extends ActionSupport {
                 clSearchParams[5] = caseloadDx;
                 clSearchParams[6] = facilityId.toString();
             } else if (!StringUtils.isNullOrEmpty(caseloadRoster)) {
-                // no dx filter
-                clSearchQuery = "search_allpg_provdemo_dxfilter";
+                // filter on roster status
+                clSearchQuery = "search_allpg_provdemo_rofilter";
                 clSearchParams = new String[6];
                 clSearchParams[0] = caseloadProv;
                 clSearchParams[1] = caseloadProv;
@@ -279,7 +279,7 @@ public class CaseloadContent2Action extends ActionSupport {
                 clSearchParams[5] = facilityId.toString();
             } else if (!StringUtils.isNullOrEmpty(caseloadDx)) {
                 // filter on dx
-                clSearchQuery = "search_allpg_provdemo_rofilter";
+                clSearchQuery = "search_allpg_provdemo_dxfilter";
                 clSearchParams = new String[6];
                 clSearchParams[0] = caseloadProv;
                 clSearchParams[1] = caseloadProv;
@@ -338,7 +338,7 @@ public class CaseloadContent2Action extends ActionSupport {
                 clSearchParams[5] = caseloadDx;
                 clSearchParams[6] = caseloadProgram;
             } else if (!StringUtils.isNullOrEmpty(caseloadRoster)) {
-                // no dx filter
+                // filter on roster status
                 clSearchQuery = "search_provdemo_rofilter";
                 clSearchParams = new String[6];
                 clSearchParams[0] = caseloadProv;


### PR DESCRIPTION
## Changes made
- Fixed filter logic in [CaseloadContent2Action.java](https://github.com/openo-beta/Open-O/compare/develop/dogfish...openo-beta:Open-O:issue-566-rostered-search?expand=1#diff-a9291949b5765ff822849f8d15ec592b1928b695bc56914f5b0d2e1769fd4caf).
  - Now we can filter with `Provider` and `Rostered` at the same time.

## Summary by Sourcery

Fix caseload search logic to correctly apply roster and diagnosis filters and support combined Provider and Roster filtering

Bug Fixes:
- Correct misassigned search query names for roster and diagnosis branches
- Enable simultaneous filtering by Provider and Roster status