### PR TITLE
Adding prevention doesn't save

### DIFF
--- a/src/main/java/ca/openosp/openo/prevention/pageUtil/AddPrevention2Action.java
+++ b/src/main/java/ca/openosp/openo/prevention/pageUtil/AddPrevention2Action.java
@@ -112,8 +112,7 @@ public class AddPrevention2Action extends ActionSupport {
         String given = request.getParameter("given");
         String prevDate = request.getParameter("prevDate");
         String providerName = request.getParameter("providerName");
-        String providerNo = request.getParameter("providers");
-
+        String providerNo = request.getParameter("providerNo");
 
         String nextDate = request.getParameter("nextDate");
         String neverWarn = request.getParameter("neverWarn");
@@ -303,11 +302,6 @@ public class AddPrevention2Action extends ActionSupport {
                 result.add("Prevention record not found");
             }
         }
-
-//	  if(UtilDateUtilities.StringToDate(prevDate, "yyyy-MM-dd HH:mm") == null) {
-//		  result.add("Prevention date not valid");
-//	  }
-
 
         return result;
     }

--- a/src/main/webapp/oscarPrevention/AddPreventionData.jsp
+++ b/src/main/webapp/oscarPrevention/AddPreventionData.jsp
@@ -797,6 +797,7 @@
                 <form action="${pageContext.request.contextPath}/oscarPrevention/AddPrevention.do" method="post" onsubmit="return handleFormSubmission()">
                     <input type="hidden" name="prevention" value="<%=prevention%>"/>
                     <input type="hidden" name="demographic_no" value="<%=demographic_no%>"/>
+                    <input type="hidden" name="providerNo" value="<%=provider%>"/>
                     <%if (snomedId != null) {%>
                     <input type="hidden" name="snomedId" value="<%=snomedId %>"/>
                     <%} %>


### PR DESCRIPTION
Fixed SQL insert error due to missing providerNo parameter, this caused the database to not update since providerNo was required to not be null when inserting a new row

## Summary by Sourcery

Fix SQL insert failure by ensuring the providerNo parameter is correctly passed through the prevention addition process and remove unused date validation.

Bug Fixes:
- Retrieve the 'providerNo' request parameter instead of the incorrect 'providers' parameter in AddPrevention2Action
- Add hidden 'providerNo' input field in AddPreventionData.jsp to supply the required providerNo for database inserts

Enhancements:
- Remove obsolete commented-out date validation logic