### PR TITLE
Select forms in administration panel buttons don't work

### DIFF
--- a/src/main/webapp/form/formselect.jsp
+++ b/src/main/webapp/form/formselect.jsp
@@ -41,7 +41,7 @@
 
     <div class="well">
 
-        <form action="${pageContext.request.contextPath}/form/select.do" method="post" styleId="selectForm">
+        <form action="${pageContext.request.contextPath}/form/select.do" method="post" id="selectForm" name="selectForm">
             <table id="scrollNumber1" name="encounterTable">
                 <tr>
                     <td class="MainTableLeftColumn"></td>

--- a/src/main/webapp/form/formselect.jsp
+++ b/src/main/webapp/form/formselect.jsp
@@ -62,7 +62,10 @@
                                         <td><select multiple="true" name="selectedAddTypes"
                                                          size="10" style="width:150">
                                             <c:forEach var="f" items="${formHiddenVector}">
-                                                <option value="${f.formName}" <c:if test="${fn:contains(param.savedAddSelection, f.formName)}">selected</c:if>>
+                                                <c:set var="searchIn" value=",${param.savedAddSelection}," />
+                                                <c:set var="searchFor" value=",${f.formName}," />
+                                                <option value="${f.formName}"
+                                                        <c:if test="${not empty param.savedAddSelection and (param.savedAddSelection eq f.formName or fn:contains(searchIn, searchFor))}">selected</c:if>>
                                                         ${f.formName}
                                                 </option>
                                             </c:forEach>
@@ -87,7 +90,10 @@
                                         <td><select multiple="true"
                                                          name="selectedDeleteTypes" size="10" style="width:150">
                                             <c:forEach var="f" items="${formShownVector}">
-                                                <option value="${f.formName}" <c:if test="${fn:contains(param.savedDeleteSelection, f.formName)}">selected</c:if>>
+                                                <c:set var="searchIn" value=",${param.savedDeleteSelection}," />
+                                                <c:set var="searchFor" value=",${f.formName}," />
+                                                <option value="${f.formName}" 
+                                                        <c:if test="${not empty param.savedDeleteSelection and (param.savedDeleteSelection eq f.formName or fn:contains(searchIn, searchFor))}">selected</c:if>>
                                                         ${f.formName}
                                                 </option>
                                             </c:forEach>
@@ -126,16 +132,27 @@
             var savedDelete = $("#savedDeleteSelection").val();
             
             if (savedAdd) {
-                $("select[name='selectedAddTypes']").val(savedAdd);
+                // Split comma-separated string back into array for multiple select
+                var addArray = savedAdd.split(',').filter(function(item) { 
+                    return item.trim() !== ''; 
+                });
+                $("select[name='selectedAddTypes']").val(addArray);
             }
             if (savedDelete) {
-                $("select[name='selectedDeleteTypes']").val(savedDelete);
+                // Split comma-separated string back into array for multiple select
+                var deleteArray = savedDelete.split(',').filter(function(item) { 
+                    return item.trim() !== ''; 
+                });
+                $("select[name='selectedDeleteTypes']").val(deleteArray);
             }
 
             $(".function").click(function () {
                 // Save current selections to hidden fields
-                $("#savedAddSelection").val($("select[name='selectedAddTypes']").val() || '');
-                $("#savedDeleteSelection").val($("select[name='selectedDeleteTypes']").val() || '');
+                var addSelections = $("select[name='selectedAddTypes']").val() || [];
+                var deleteSelections = $("select[name='selectedDeleteTypes']").val() || [];
+
+                $("#savedAddSelection").val(Array.isArray(addSelections) ? addSelections.join(',') : addSelections);
+                $("#savedDeleteSelection").val(Array.isArray(deleteSelections) ? deleteSelections.join(',') : deleteSelections);
 
                 $("#forward").val($(this).attr("id"));
                 $("#selectForm").submit();

--- a/src/main/webapp/form/formselect.jsp
+++ b/src/main/webapp/form/formselect.jsp
@@ -28,6 +28,7 @@
 <%@ page import="java.util.*,ca.openosp.openo.report.pageUtil.*" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %> 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>
 
 
 
@@ -42,6 +43,9 @@
     <div class="well">
 
         <form action="${pageContext.request.contextPath}/form/select.do" method="post" id="selectForm" name="selectForm">
+            <input type="hidden" id="savedAddSelection" name="savedAddSelection" value="${param.savedAddSelection}" />
+            <input type="hidden" id="savedDeleteSelection" name="savedDeleteSelection" value="${param.savedDeleteSelection}" />
+            
             <table id="scrollNumber1" name="encounterTable">
                 <tr>
                     <td class="MainTableLeftColumn"></td>
@@ -58,7 +62,7 @@
                                         <td><select multiple="true" name="selectedAddTypes"
                                                          size="10" style="width:150">
                                             <c:forEach var="f" items="${formHiddenVector}">
-                                                <option value="${f.formName}">
+                                                <option value="${f.formName}" <c:if test="${fn:contains(param.savedAddSelection, f.formName)}">selected</c:if>>
                                                         ${f.formName}
                                                 </option>
                                             </c:forEach>
@@ -83,7 +87,7 @@
                                         <td><select multiple="true"
                                                          name="selectedDeleteTypes" size="10" style="width:150">
                                             <c:forEach var="f" items="${formShownVector}">
-                                                <option value="${f.formName}">
+                                                <option value="${f.formName}" <c:if test="${fn:contains(param.savedDeleteSelection, f.formName)}">selected</c:if>>
                                                         ${f.formName}
                                                 </option>
                                             </c:forEach>
@@ -117,11 +121,23 @@
         registerFormSubmit('selectForm', 'dynamic-content');
 
         $(document).ready(function () {
+            // Restore selections on page load
+            var savedAdd = $("#savedAddSelection").val();
+            var savedDelete = $("#savedDeleteSelection").val();
+            
+            if (savedAdd) {
+                $("select[name='selectedAddTypes']").val(savedAdd);
+            }
+            if (savedDelete) {
+                $("select[name='selectedDeleteTypes']").val(savedDelete);
+            }
 
             $(".function").click(function () {
+                // Save current selections to hidden fields
+                $("#savedAddSelection").val($("select[name='selectedAddTypes']").val() || '');
+                $("#savedDeleteSelection").val($("select[name='selectedDeleteTypes']").val() || '');
+
                 $("#forward").val($(this).attr("id"));
-
-
                 $("#selectForm").submit();
             });
 


### PR DESCRIPTION
Options to Add/Delete/Move Up/Move Down don't work at all, this was fixed in this PR and I also went and fixed a form reset issue where selected options would reset and not have the correct selections when using any of the buttons. Now it is the same as production

## Summary by Sourcery

Fix non-functional select form buttons in the administration panel and retain chosen options across Add/Delete/Move actions

Bug Fixes:
- Re-enable Add/Delete/Move Up/Move Down buttons in the form selection interface and prevent selection reset on action

Enhancements:
- Persist selected options across form submissions by adding hidden inputs, JSTL fn:contains checks, and corresponding JavaScript to save and restore selections