### PR TITLE
Appointment error page and security issue prone error page reference removals

### DIFF
--- a/src/main/webapp/WEB-INF/classes/struts.xml
+++ b/src/main/webapp/WEB-INF/classes/struts.xml
@@ -431,7 +431,7 @@
             <result name="printLabReq">/form/formlabreqprint.jsp</result>
             <result name="save">/form/forwardname.jsp</result>
             <result name="graph">/form/createpdf</result>
-            <result name="failure">/errorpage.jspp</result>
+            <result name="failure">/errorpage.jsp</result>
         </action>
         <action name="form/forwardshortcutname" class="ca.openosp.openo.form.pageUtil.FormForward2Action"/>
         <action name="form/SetupForm" class="ca.openosp.openo.form.pageUtil.FrmSetupForm2Action"/>

--- a/src/main/webapp/WEB-INF/classes/struts.xml
+++ b/src/main/webapp/WEB-INF/classes/struts.xml
@@ -205,7 +205,7 @@
             <result name="error">/500.jsp</result>
         </action>
         <action name="oscarEncounter/IncomingEncounter" class="ca.openosp.openo.encounter.pageUtil.EctIncomingEncounter2Action">
-            <result name="failure">/oscarEncounter/error.jsp</result>
+            <result name="failure">/errorpage.jsp</result>
             <result name="success">/oscarEncounter/Index.jsp</result>
             <result name="success2">/oscarEncounter/Index2.jsp</result>
             <result name="domain-error">/casemgmt/domain-error.jsp</result>
@@ -431,7 +431,7 @@
             <result name="printLabReq">/form/formlabreqprint.jsp</result>
             <result name="save">/form/forwardname.jsp</result>
             <result name="graph">/form/createpdf</result>
-            <result name="failure">/oscarEncounter/error.jsp</result>
+            <result name="failure">/errorpage.jspp</result>
         </action>
         <action name="form/forwardshortcutname" class="ca.openosp.openo.form.pageUtil.FormForward2Action"/>
         <action name="form/SetupForm" class="ca.openosp.openo.form.pageUtil.FrmSetupForm2Action"/>
@@ -905,7 +905,7 @@
         </action>
         <action name="oscarEncounter/SaveEncounter" class="ca.openosp.openo.encounter.pageUtil.EctSaveEncounter2Action">
             <result name="saveAndStay">/oscarEncounter/Index.jsp?saved=true</result>
-            <result name="failure">/oscarEncounter/error.jsp</result>
+            <result name="failure">/errorpage.jsp</result>
             <result name="success">/oscarEncounter/TimeOut.jsp</result>
             <result name="bill">/billing.do</result>
             <result name="splitchart">/oscarEncounter/Index.jsp?saved=true&amp;splitchart=true</result>
@@ -914,7 +914,7 @@
         </action>
         <action name="oscarEncounter/SaveEncounter2" class="ca.openosp.openo.encounter.pageUtil.EctSaveEncounter2Action">
             <result name="saveAndStay">/oscarEncounter/Index2.jsp?saved=true</result>
-            <result name="failure">/oscarEncounter/error.jsp</result>
+            <result name="failure">/errorpage.jsp</result>
             <result name="success">/oscarEncounter/TimeOut.jsp</result>
             <result name="bill">/billing.do</result>
             <result name="splitchart">/oscarEncounter/Index2.jsp?saved=true&amp;splitchart=true</result>

--- a/src/main/webapp/admin/adminbackupdownload.jsp
+++ b/src/main/webapp/admin/adminbackupdownload.jsp
@@ -110,7 +110,7 @@
               if (backuppath == null || backuppath.isEmpty()) {
                   request.setAttribute("errorMessage",
                     "backup_path missing in properties; please configure.");
-                  request.getRequestDispatcher("/error.jsp")
+                  request.getRequestDispatcher("/errorpage.jsp")
                          .forward(request, response);
                   return;
               }

--- a/src/main/webapp/admin/admindisplaymygroup.jsp
+++ b/src/main/webapp/admin/admindisplaymygroup.jsp
@@ -47,7 +47,7 @@
     <%isSiteAccessPrivacy = true; %>
 </security:oscarSec>
 
-<%@ page import="java.util.*,java.sql.*" errorPage="../provider/errorpage.jsp" %>
+<%@ page import="java.util.*,java.sql.*" errorPage="/errorpage.jsp" %>
 
 <!DOCTYPE html>
 <html>

--- a/src/main/webapp/admin/adminnewgroup.jsp
+++ b/src/main/webapp/admin/adminnewgroup.jsp
@@ -28,7 +28,7 @@
 
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
 
-<%@ page import="java.util.*,java.sql.*,java.util.ResourceBundle" errorPage="../provider/errorpage.jsp" %>
+<%@ page import="java.util.*,java.sql.*,java.util.ResourceBundle" errorPage="/errorpage.jsp" %>
 <%@ page import="ca.openosp.openo.utility.SpringUtils" %>
 <%@ page import="ca.openosp.openo.commn.model.MyGroup" %>
 <%@ page import="ca.openosp.openo.commn.model.MyGroupPrimaryKey" %>

--- a/src/main/webapp/admin/adminsavemygroup.jsp
+++ b/src/main/webapp/admin/adminsavemygroup.jsp
@@ -28,7 +28,7 @@
 
 
 
-<%@ page import="java.sql.*, java.util.*, ca.openosp.MyDateFormat" errorPage="../errorpage.jsp" %>
+<%@ page import="java.sql.*, java.util.*, ca.openosp.MyDateFormat" errorPage="/errorpage.jsp" %>
 <%@ page import="ca.openosp.openo.utility.SpringUtils" %>
 <%@ page import="ca.openosp.openo.commn.model.MyGroup" %>
 <%@ page import="ca.openosp.openo.commn.model.MyGroupPrimaryKey" %>

--- a/src/main/webapp/admin/groupnoacl.jsp
+++ b/src/main/webapp/admin/groupnoacl.jsp
@@ -29,7 +29,7 @@
 
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
 
-<%@ page import="java.util.*,java.sql.*,java.util.ResourceBundle" errorPage="../provider/errorpage.jsp" %>
+<%@ page import="java.util.*,java.sql.*,java.util.ResourceBundle" errorPage="/errorpage.jsp" %>
 <%@ page import="ca.openosp.openo.utility.SpringUtils" %>
 <%@ page import="ca.openosp.openo.commn.model.MyGroup" %>
 <%@ page import="ca.openosp.openo.commn.model.MyGroupPrimaryKey" %>

--- a/src/main/webapp/admin/providerAddRole.jsp
+++ b/src/main/webapp/admin/providerAddRole.jsp
@@ -24,7 +24,7 @@
 
 --%>
 
-<%@ page errorPage="../errorpage.jsp" %>
+<%@ page errorPage="/errorpage.jsp" %>
 <%@ page import="java.util.*" %>
 <%@ page import="java.sql.*" %>
 <%@ page import="org.apache.commons.lang.StringEscapeUtils" %>

--- a/src/main/webapp/admin/providerPrivilege.jsp
+++ b/src/main/webapp/admin/providerPrivilege.jsp
@@ -41,7 +41,7 @@
 %>
 
 
-<%@ page errorPage="../errorpage.jsp" %>
+<%@ page errorPage="/errorpage.jsp" %>
 <%@ page import="java.util.*" %>
 <%@ page import="java.sql.BatchUpdateException" %>
 <%@ page import="java.sql.*" %>

--- a/src/main/webapp/admin/resourcebaseurl.jsp
+++ b/src/main/webapp/admin/resourcebaseurl.jsp
@@ -24,7 +24,7 @@
 
 --%>
 <%@ page import="java.util.*, java.sql.*, ca.openosp.*, java.text.*, java.lang.*,java.net.*"
-         errorPage="../appointment/errorpage.jsp" %>
+         errorPage="/errorpage.jsp" %>
 <%@ page import="ca.openosp.openo.utility.SpringUtils" %>
 <%@ page import="ca.openosp.openo.commn.model.UserProperty" %>
 <%@ page import="ca.openosp.openo.commn.dao.UserPropertyDAO" %>

--- a/src/main/webapp/admin/unLock.jsp
+++ b/src/main/webapp/admin/unLock.jsp
@@ -25,7 +25,7 @@
 --%>
 
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
-<%@ page errorPage="../errorpage.jsp" %>
+<%@ page errorPage="/errorpage.jsp" %>
 <%@ page import="java.util.*" %>
 <%@ page import="ca.openosp.openo.login.*" %>
 <%@ page import="ca.openosp.openo.log.*" %>

--- a/src/main/webapp/appointment/appointmentTypeList.jsp
+++ b/src/main/webapp/appointment/appointmentTypeList.jsp
@@ -34,7 +34,7 @@
         sError = "Error: " + request.getParameter("err");
 %>
 
-<%@ page errorPage="../errorpage.jsp" %>
+<%@ page errorPage="/errorpage.jsp" %>
 <%@ page import="java.util.*" %>
 <%@ page import="java.sql.*" %>
 <%@ page import="ca.openosp.openo.util.*" %>

--- a/src/main/webapp/apps/oauth1.jsp
+++ b/src/main/webapp/apps/oauth1.jsp
@@ -91,7 +91,7 @@
                 log.warn("Missing requestToken: {}", contextMsg);
                 session.setAttribute("oauthErrorMessage",
                     "Authentication failed: missing request token.");
-                response.sendRedirect(request.getContextPath() + "/error.jsp");
+                response.sendRedirect(request.getContextPath() + "/errorpage.jsp");
                 return;
             }
 

--- a/src/main/webapp/billing/CA/BC/billType_frag.jsp
+++ b/src/main/webapp/billing/CA/BC/billType_frag.jsp
@@ -1,4 +1,4 @@
-<%@page import="java.sql.*" errorPage="" %>
+<%@page import="java.sql.*" errorPage="/errorpage.jsp" %>
 <%@page
         import="java.math.*, java.util.*, java.sql.*, ca.openosp.*, java.net.*,ca.openosp.openo.billing.ca.bc.MSP.*,ca.openosp.openo.billing.ca.bc.data.*" %>
 <%@ page import="ca.openosp.openo.billings.ca.bc.data.BillingFormData" %>

--- a/src/main/webapp/billing/CA/BC/billingSVCTrayAssoc.jsp
+++ b/src/main/webapp/billing/CA/BC/billingSVCTrayAssoc.jsp
@@ -1,4 +1,4 @@
-<%@page import="java.sql.*" errorPage="" %>
+<%@page import="java.sql.*" errorPage="/errorpage.jsp" %>
 <%@taglib uri="http://displaytag.sf.net" prefix="display" %>
 <%@taglib uri="/WEB-INF/rewrite-tag.tld" prefix="rewrite" %>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>

--- a/src/main/webapp/billing/CA/BC/billingSim.jsp
+++ b/src/main/webapp/billing/CA/BC/billingSim.jsp
@@ -38,7 +38,7 @@
     String user_no = (String) session.getAttribute("user");
 %>
 
-<%@ page import="java.util.*, java.sql.*, ca.openosp.*, ca.openosp.openo.util.*, java.net.*" errorPage="../../../errorpage.jsp" %>
+<%@ page import="java.util.*, java.sql.*, ca.openosp.*, ca.openosp.openo.util.*, java.net.*" errorPage="/errorpage.jsp" %>
 <%@ include file="../../../admin/dbconnection.jsp" %>
 <%@ page import="ca.openosp.openo.utility.SpringUtils" %>
 <%@ page import="ca.openosp.openo.commn.model.Provider" %>

--- a/src/main/webapp/billing/CA/BC/genSimulation.jsp
+++ b/src/main/webapp/billing/CA/BC/genSimulation.jsp
@@ -37,7 +37,7 @@
 
 
 <%@ page import="java.math.*, java.util.*, java.sql.*, ca.openosp.*, ca.openosp.openo.billing.ca.bc.MSP.*, java.net.*"
-         errorPage="../../../errorpage.jsp" %>
+         errorPage="/errorpage.jsp" %>
 <%@ include file="../../../admin/dbconnection.jsp" %>
 <%@page import="ca.openosp.openo.utility.SpringUtils" %>
 <%@page import="ca.openosp.openo.commn.model.Provider" %>

--- a/src/main/webapp/billing/CA/BC/onAddEdit3rdAddr.jsp
+++ b/src/main/webapp/billing/CA/BC/onAddEdit3rdAddr.jsp
@@ -40,7 +40,7 @@
     String user_no = (String) session.getAttribute("user");
 
 %>
-<%@ page errorPage="../../../appointment/errorpage.jsp"
+<%@ page errorPage="/errorpage.jsp"
          import="java.util.*,java.sql.*,ca.openosp.*,java.text.*,java.net.*" %>
 <%@ page import="ca.openosp.openo.billing.ca.on.data.*" %>
 <%@ page import="org.apache.commons.lang.StringEscapeUtils" %>

--- a/src/main/webapp/billing/CA/BC/onSearch3rdBillAddr.jsp
+++ b/src/main/webapp/billing/CA/BC/onSearch3rdBillAddr.jsp
@@ -94,7 +94,7 @@
         }
     }
 %>
-<%@ page errorPage="../../../appointment/errorpage.jsp"
+<%@ page errorPage="/errorpage.jsp"
          import="java.util.*,java.sql.*,java.net.*" %>
 <%@ page import="org.apache.commons.lang.StringEscapeUtils" %>
 <%@ page import="org.apache.commons.lang.WordUtils" %>

--- a/src/main/webapp/billing/CA/CLINICAID/billingCalendarPopup.jsp
+++ b/src/main/webapp/billing/CA/CLINICAID/billingCalendarPopup.jsp
@@ -23,7 +23,7 @@
 
 <%@ page
         import="java.util.*, java.sql.*, ca.openosp.*, java.text.*, java.lang.*,java.net.*"
-        errorPage="../appointment/errorpage.jsp" %>
+        errorPage="/errorpage.jsp" %>
 <%@ page import="ca.openosp.DateInMonthTable" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 

--- a/src/main/webapp/billing/CA/ON/addEditRefDoc.jsp
+++ b/src/main/webapp/billing/CA/ON/addEditRefDoc.jsp
@@ -41,7 +41,7 @@
         response.sendRedirect("../logout.jsp");
     }
 %>
-<%@ page errorPage="../appointment/errorpage.jsp"
+<%@ page errorPage="/errorpage.jsp"
          import="java.util.*,
                  java.sql.*" %>
 <%@ page import="org.apache.commons.lang.StringEscapeUtils" %>

--- a/src/main/webapp/billing/CA/ON/addEditServiceCode.jsp
+++ b/src/main/webapp/billing/CA/ON/addEditServiceCode.jsp
@@ -23,7 +23,7 @@
         response.sendRedirect("../logout.jsp");
     }
 %>
-<%@ page errorPage="../../../appointment/errorpage.jsp"
+<%@ page errorPage="/errorpage.jsp"
          import="java.util.*,java.sql.*,ca.openosp.*,java.text.*, java.lang.*,java.net.*" %>
 
 <%@ page import="org.apache.commons.lang.StringEscapeUtils" %>

--- a/src/main/webapp/billing/CA/ON/billingCalendarPopup.jsp
+++ b/src/main/webapp/billing/CA/ON/billingCalendarPopup.jsp
@@ -23,7 +23,7 @@
 
 <%@ page
         import="java.util.*, java.sql.*, ca.openosp.*, java.text.*, java.lang.*,java.net.*"
-        errorPage="../appointment/errorpage.jsp" %>
+        errorPage="/errorpage.jsp" %>
 <%@ page import="ca.openosp.DateInMonthTable" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 

--- a/src/main/webapp/billing/CA/ON/billingCodeSearch.jsp
+++ b/src/main/webapp/billing/CA/ON/billingCodeSearch.jsp
@@ -20,7 +20,7 @@
 <%
     String user_no = (String) session.getAttribute("user");
 %>
-<%@ page import="java.util.*, java.sql.*, ca.openosp.*, java.net.*" errorPage="../errorpage.jsp" %>
+<%@ page import="java.util.*, java.sql.*, ca.openosp.*, java.net.*" errorPage="/errorpage.jsp" %>
 <%@ page import="ca.openosp.openo.utility.SpringUtils" %>
 <%@ page import="ca.openosp.openo.commn.dao.BillingServiceDao" %>
 <%@ page import="ca.openosp.openo.commn.model.BillingService" %>

--- a/src/main/webapp/billing/CA/ON/billingCodeUpdate.jsp
+++ b/src/main/webapp/billing/CA/ON/billingCodeUpdate.jsp
@@ -21,7 +21,7 @@
 
     String curUser_no = (String) session.getAttribute("user");
 %>
-<%@ page import="java.math.*, java.util.*, java.sql.*, ca.openosp.*, java.net.*" errorPage="../errorpage.jsp" %>
+<%@ page import="java.math.*, java.util.*, java.sql.*, ca.openosp.*, java.net.*" errorPage="/errorpage.jsp" %>
 <%@page import="ca.openosp.openo.utility.SpringUtils" %>
 <%@page import="ca.openosp.openo.commn.dao.BillingServiceDao" %>
 <%@page import="ca.openosp.openo.commn.model.BillingService" %>

--- a/src/main/webapp/billing/CA/ON/billingON.jsp
+++ b/src/main/webapp/billing/CA/ON/billingON.jsp
@@ -23,7 +23,7 @@
 
 
 <%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar" %>
-<%@ page errorPage="errorpage.jsp"%>
+<%@ page errorPage="/errorpage.jsp"%>
 
 <%@page import="java.util.*,java.net.*,java.sql.*,ca.openosp.*,ca.openosp.openo.util.*,ca.openosp.openo.appt.*" %>
 <%@page import="ca.openosp.openo.billing.ca.on.data.*" %>

--- a/src/main/webapp/billing/CA/ON/billingONEditPrivateCode.jsp
+++ b/src/main/webapp/billing/CA/ON/billingONEditPrivateCode.jsp
@@ -23,7 +23,7 @@
         response.sendRedirect("../logout.jsp");
     }
 %>
-<%@ page errorPage="../appointment/errorpage.jsp" import="java.util.*,java.sql.*" %>
+<%@ page errorPage="/errorpage.jsp" import="java.util.*,java.sql.*" %>
 <%@ page import="ca.openosp.openo.billing.ca.on.data.*" %>
 <%@ page import="org.apache.commons.lang.StringEscapeUtils" %>
 <%@ page import="ca.openosp.openo.utility.MiscUtils" %>

--- a/src/main/webapp/billing/CA/ON/billingONStatusERUpdateStatus.jsp
+++ b/src/main/webapp/billing/CA/ON/billingONStatusERUpdateStatus.jsp
@@ -24,7 +24,7 @@
 %>
 <%@ page
         import="ca.openosp.openo.billing.ca.on.data.*, java.sql.*, ca.openosp.*, java.net.*"
-        errorPage="../errorpage.jsp" %>
+        errorPage="/errorpage.jsp" %>
 <%@ page import="ca.openosp.openo.billings.ca.on.data.JdbcBillingErrorRepImpl" %>
 <%
     String id = request.getParameter("id");

--- a/src/main/webapp/billing/CA/ON/billingONfavourite.jsp
+++ b/src/main/webapp/billing/CA/ON/billingONfavourite.jsp
@@ -25,7 +25,7 @@
     String user_no = (String) session.getAttribute("user");
 
 %>
-<%@ page errorPage="${pageContext.request.contextPath}/appointment/errorpage.jsp"
+<%@ page errorPage="/errorpage.jsp"
          import="java.util.*,java.sql.*,ca.openosp.*,java.text.*,java.net.*" %>
 <%@ page import="ca.openosp.openo.billings.ca.on.data.JdbcBillingPageUtil" %>
 <%@ page import="ca.openosp.openo.billing.ca.on.data.*" %>

--- a/src/main/webapp/billing/CA/ON/billingResearchCodeSearch.jsp
+++ b/src/main/webapp/billing/CA/ON/billingResearchCodeSearch.jsp
@@ -20,7 +20,7 @@
 <%
     String user_no = (String) session.getAttribute("user");
 %>
-<%@ page import="java.util.*, java.sql.*, ca.openosp.*, java.net.*" errorPage="../errorpage.jsp" %>
+<%@ page import="java.util.*, java.sql.*, ca.openosp.*, java.net.*" errorPage="/errorpage.jsp" %>
 <%@ page import="ca.openosp.openo.utility.SpringUtils" %>
 <%@ page import="ca.openosp.openo.commn.model.Ichppccode" %>
 <%@ page import="ca.openosp.openo.commn.dao.IchppccodeDao" %>

--- a/src/main/webapp/billing/CA/ON/billingResearchCodeUpdate.jsp
+++ b/src/main/webapp/billing/CA/ON/billingResearchCodeUpdate.jsp
@@ -21,7 +21,7 @@
     String curUser_no = (String) session.getAttribute("user");
 
 %>
-<%@ page import="java.math.*, java.util.*, java.sql.*, ca.openosp.*, java.net.*" errorPage="../errorpage.jsp" %>
+<%@ page import="java.math.*, java.util.*, java.sql.*, ca.openosp.*, java.net.*" errorPage="/errorpage.jsp" %>
 
 <html>
 <head>

--- a/src/main/webapp/billing/CA/ON/billingReview.jsp
+++ b/src/main/webapp/billing/CA/ON/billingReview.jsp
@@ -23,7 +23,7 @@
 %>
 
 <%@ page import="java.math.*, java.util.*, java.sql.*, ca.openosp.*, java.net.*, ca.openosp.openo.dxresearch.bean.*"
-         errorPage="../errorpage.jsp" %>
+         errorPage="/errorpage.jsp" %>
 <%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar" %>
 <%@ include file="../../../admin/dbconnection.jsp" %>
 

--- a/src/main/webapp/billing/CA/ON/inr/dbUpdateINRbilling.jsp
+++ b/src/main/webapp/billing/CA/ON/inr/dbUpdateINRbilling.jsp
@@ -21,7 +21,7 @@
     String curUser_no = (String) session.getAttribute("user");
 %>
 
-<%@page import="java.sql.*, java.util.*,java.net.*, ca.openosp.MyDateFormat" errorPage="../../errorpage.jsp" %>
+<%@page import="java.sql.*, java.util.*,java.net.*, ca.openosp.MyDateFormat" errorPage="/errorpage.jsp" %>
 
 <%@page import="ca.openosp.openo.billing.CA.model.BillingInr" %>
 <%@page import="ca.openosp.openo.billing.CA.dao.BillingInrDao" %>

--- a/src/main/webapp/billing/CA/ON/inr/genINRbilling.jsp
+++ b/src/main/webapp/billing/CA/ON/inr/genINRbilling.jsp
@@ -20,7 +20,7 @@
 <%
     String user_no = (String) session.getAttribute("user");
 %>
-<%@ page import="java.util.*, java.sql.*, ca.openosp.*" errorPage="../../../errorpage.jsp" %>
+<%@ page import="java.util.*, java.sql.*, ca.openosp.*" errorPage="/errorpage.jsp" %>
 
 
 <jsp:useBean id="SxmlMisc" class="ca.openosp.SxmlMisc" scope="session"/>

--- a/src/main/webapp/billing/CA/ON/inr/onGenINRbilling.jsp
+++ b/src/main/webapp/billing/CA/ON/inr/onGenINRbilling.jsp
@@ -21,7 +21,7 @@
     String user_no = (String) session.getAttribute("user");
 %>
 <%@ page import="java.util.*,java.sql.*,ca.openosp.openo.util.*,ca.openosp.*,ca.openosp.openo.billing.ca.on.data.*"
-         errorPage="../../../errorpage.jsp" %>
+         errorPage="/errorpage.jsp" %>
 
 <%@page import="ca.openosp.openo.billing.CA.model.BillingInr" %>
 <%@page import="ca.openosp.openo.commn.model.Demographic" %>

--- a/src/main/webapp/billing/CA/ON/onAddEdit3rdAddr.jsp
+++ b/src/main/webapp/billing/CA/ON/onAddEdit3rdAddr.jsp
@@ -24,7 +24,7 @@
     String user_no = (String) session.getAttribute("user");
 
 %>
-<%@ page errorPage="../../../appointment/errorpage.jsp"
+<%@ page errorPage="/errorpage.jsp"
          import="java.util.*,java.sql.*,ca.openosp.*,java.text.*,java.net.*" %>
 <%@ page import="ca.openosp.openo.billing.ca.on.data.*" %>
 <%@ page import="org.apache.commons.lang.StringEscapeUtils" %>

--- a/src/main/webapp/billing/CA/ON/onSearch3rdBillAddr.jsp
+++ b/src/main/webapp/billing/CA/ON/onSearch3rdBillAddr.jsp
@@ -58,7 +58,7 @@
         }
     }
 %>
-<%@ page errorPage="../../../appointment/errorpage.jsp"
+<%@ page errorPage="/errorpage.jsp"
          import="java.util.*,java.sql.*,java.net.*" %>
 <%@ page import="org.apache.commons.lang.StringEscapeUtils" %>
 <%@ page import="org.apache.commons.lang.WordUtils" %>

--- a/src/main/webapp/casemgmt/encounterLayout.jsp
+++ b/src/main/webapp/casemgmt/encounterLayout.jsp
@@ -25,7 +25,7 @@
 
 
 <%@ include file="/casemgmt/taglibs.jsp" %>
-<%@ page errorPage="/casemgmt/error.jsp" %>
+<%@ page errorPage="/errorpage.jsp" %>
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
 
 <%

--- a/src/main/webapp/casemgmt/taglibs.jsp
+++ b/src/main/webapp/casemgmt/taglibs.jsp
@@ -24,7 +24,7 @@
 --%>
 
 
-<%@page errorPage="/casemgmt/error.jsp" %>
+<%@page errorPage="/errorpage.jsp" %>
 <%@ taglib uri="http://displaytag.sf.net" prefix="display" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>

--- a/src/main/webapp/decision/annualreview/annualreviewplannerprint.jsp
+++ b/src/main/webapp/decision/annualreview/annualreviewplannerprint.jsp
@@ -32,7 +32,7 @@
 %>
 <%@ page
         import="java.util.*, java.sql.*, ca.openosp.*, ca.openosp.openo.util.*, java.text.*, java.lang.*,java.net.*"
-        errorPage="../../appointment/errorpage.jsp" %>
+        errorPage="/errorpage.jsp" %>
 
 <jsp:useBean id="riskDataBean" class="java.util.Properties" scope="page"/>
 <jsp:useBean id="risks"

--- a/src/main/webapp/decision/antenatal/antenatalplannerprint.jsp
+++ b/src/main/webapp/decision/antenatal/antenatalplannerprint.jsp
@@ -32,7 +32,7 @@
 %>
 <%@ page
         import="java.util.*, java.sql.*, ca.openosp.*, java.text.*, java.lang.*,java.net.*,java.io.*"
-        errorPage="../../appointment/errorpage.jsp" %>
+        errorPage="/errorpage.jsp" %>
 
 <jsp:useBean id="riskDataBean" class="java.util.Properties" scope="page"/>
 <jsp:useBean id="risks"

--- a/src/main/webapp/demographic/demographiclabelprintsetting.jsp
+++ b/src/main/webapp/demographic/demographiclabelprintsetting.jsp
@@ -40,7 +40,7 @@
 %>
 
 
-<%@ page import="java.util.*, java.sql.*, java.net.*, ca.openosp.*" errorPage="../appointment/errorpage.jsp" %>
+<%@ page import="java.util.*, java.sql.*, java.net.*, ca.openosp.*" errorPage="/errorpage.jsp" %>
 
 <%@page import="ca.openosp.openo.utility.SpringUtils" %>
 

--- a/src/main/webapp/demographic/demographicprintdemographic.jsp
+++ b/src/main/webapp/demographic/demographicprintdemographic.jsp
@@ -26,7 +26,7 @@
 
 
 <%@ page import="java.util.*, java.sql.*, ca.openosp.*"
-         errorPage="../appointment/errorpage.jsp" %>
+         errorPage="/errorpage.jsp" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 
 

--- a/src/main/webapp/eform/attachEform.jsp
+++ b/src/main/webapp/eform/attachEform.jsp
@@ -84,7 +84,7 @@
     String requestId = request.getParameter("requestId");
     String providerNo = loggedInInfo.getLoggedInProviderNo();
 
-    if (demoNo == null) response.sendRedirect("../error.jsp");
+    if (demoNo == null) request.getRequestDispatcher("/errorpage.jsp").forward(request, response);
 
     EFormAttachDocs docsUtil = new EFormAttachDocs(requestId);
 

--- a/src/main/webapp/form/formbcarpg1namepopup.jsp
+++ b/src/main/webapp/form/formbcarpg1namepopup.jsp
@@ -20,7 +20,7 @@
     String fieldName = request.getParameter("fieldname") != null ? request.getParameter("fieldname") : "pg1_priCare";
 %>
 
-<%@ page import="java.sql.*" errorPage="../errorpage.jsp" %>
+<%@ page import="java.sql.*" errorPage="/errorpage.jsp" %>
 
 <jsp:useBean id="providerNameBean" class="java.util.Properties" scope="page"/>
 

--- a/src/main/webapp/lab/CA/ALL/labDisplayOLIS.jsp
+++ b/src/main/webapp/lab/CA/ALL/labDisplayOLIS.jsp
@@ -12,7 +12,7 @@
 <%@page import="ca.openosp.openo.commn.dao.DemographicDao" %>
 <%@page import="ca.openosp.openo.utility.LoggedInInfo" %>
 <%@page import="ca.openosp.openo.lab.ca.all.upload.MessageUploader" %>
-<%@ page language="java" errorPage="../../../provider/errorpage.jsp" %>
+<%@ page language="java" errorPage="/errorpage.jsp" %>
 <%@ page
         import="java.util.*,java.sql.*,ca.openosp.openo.olis.*,ca.openosp.openo.commn.dao.PatientLabRoutingDao, ca.openosp.openo.utility.SpringUtils, ca.openosp.openo.commn.model.PatientLabRouting,ca.openosp.openo.lab.ca.all.*,ca.openosp.openo.lab.ca.all.util.*,ca.openosp.openo.lab.ca.all.parsers.*,ca.openosp.openo.lab.LabRequestReportLink,ca.openosp.openo.mds.data.ReportStatus,ca.openosp.openo.log.*,org.apache.commons.codec.binary.Base64" %>
 <%@page import="ca.openosp.openo.utility.AppointmentUtil" %>

--- a/src/main/webapp/lab/CA/ON/CMLDisplay.jsp
+++ b/src/main/webapp/lab/CA/ON/CMLDisplay.jsp
@@ -42,7 +42,7 @@
 <%@page import="ca.openosp.openo.commn.model.PatientLabRouting" %>
 <%@page import="ca.openosp.openo.util.ConversionUtils" %>
 <%@page import="ca.openosp.openo.commn.dao.PatientLabRoutingDao" %>
-<%@page errorPage="../provider/errorpage.jsp" %>
+<%@page errorPage="/errorpage.jsp" %>
 <%@ page
         import="java.util.*, ca.openosp.openo.mds.data.*,ca.openosp.openo.lab.ca.on.CML.*,ca.openosp.openo.lab.LabRequestReportLink,ca.openosp.openo.db.*,java.sql.*,ca.openosp.openo.log.*,ca.openosp.openo.utility.SpringUtils,ca.openosp.openo.casemgmt.service.CaseManagementManager,ca.openosp.openo.casemgmt.model.*" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>

--- a/src/main/webapp/mcedt/addUpload.jsp
+++ b/src/main/webapp/mcedt/addUpload.jsp
@@ -24,7 +24,7 @@
 
 --%>
 
-<%@ page errorPage="error.jsp" %>
+<%@ page errorPage="/errorpage.jsp" %>
 
 <!DOCTYPE html>
 

--- a/src/main/webapp/mcedt/index.jsp
+++ b/src/main/webapp/mcedt/index.jsp
@@ -25,7 +25,7 @@
 --%>
 <!DOCTYPE html>
 
-<%@ page errorPage="error.jsp" %>
+<%@ page errorPage="/errorpage.jsp" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>

--- a/src/main/webapp/mcedt/info.jsp
+++ b/src/main/webapp/mcedt/info.jsp
@@ -23,7 +23,7 @@
     Ontario, Canada
 
 --%>
-<%@ page errorPage="error.jsp" %>
+<%@ page errorPage="/errorpage.jsp" %>
 
 <!DOCTYPE html>
 

--- a/src/main/webapp/mcedt/mailbox/addUpload.jsp
+++ b/src/main/webapp/mcedt/mailbox/addUpload.jsp
@@ -24,7 +24,7 @@
     
 --%>
 
-<%@ page errorPage="../error.jsp" %>
+<%@ page errorPage="/errorpage.jsp" %>
 
 <!DOCTYPE html>
 

--- a/src/main/webapp/mcedt/mailbox/autoDownload.jsp
+++ b/src/main/webapp/mcedt/mailbox/autoDownload.jsp
@@ -25,7 +25,7 @@
 --%>
 
 <!DOCTYPE html>
-<%@ page errorPage="../error.jsp" %>
+<%@ page errorPage="/errorpage.jsp" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>

--- a/src/main/webapp/mcedt/mailbox/autoUpload.jsp
+++ b/src/main/webapp/mcedt/mailbox/autoUpload.jsp
@@ -24,7 +24,7 @@
     
 --%>
 
-<%--@ page errorPage="../error.jsp"--%>
+<%--@ page errorPage="/errorpage.jsp"--%>
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>

--- a/src/main/webapp/mcedt/mailbox/autoUpload.jsp
+++ b/src/main/webapp/mcedt/mailbox/autoUpload.jsp
@@ -24,8 +24,6 @@
     
 --%>
 
-<%--@ page errorPage="/errorpage.jsp"--%>
-
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
@@ -35,7 +33,7 @@
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 
 <%@ page
-        import="java.io.*,java.util.*, java.sql.*, ca.openosp.*, java.net.*, ca.openosp.openo.integration.mcedt.mailbox.ActionUtils, java.math.BigInteger,ca.ontario.health.edt.ResponseResult" %>
+        import="java.io.*,java.util.*, java.sql.*, ca.openosp.*, java.net.*, ca.openosp.openo.integration.mcedt.mailbox.ActionUtils, java.math.BigInteger,ca.ontario.health.edt.ResponseResult" errorPage="/errorpage.jsp" %>
 <%
 
     List<File> toEdt = ActionUtils.getUploadList();

--- a/src/main/webapp/mcedt/mailbox/changepass.jsp
+++ b/src/main/webapp/mcedt/mailbox/changepass.jsp
@@ -24,7 +24,7 @@
     
 --%>
 
-<%@ page errorPage="../error.jsp" %>
+<%@ page errorPage="/errorpage.jsp" %>
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>

--- a/src/main/webapp/mcedt/mailbox/download.jsp
+++ b/src/main/webapp/mcedt/mailbox/download.jsp
@@ -24,7 +24,7 @@
     
 --%>
 
-<%@ page errorPage="../error.jsp" %>
+<%@ page errorPage="/errorpage.jsp" %>
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>

--- a/src/main/webapp/mcedt/mailbox/sent.jsp
+++ b/src/main/webapp/mcedt/mailbox/sent.jsp
@@ -27,7 +27,7 @@
     KAI Innovations Inc.
     KAIInnovations.com
 --%>
-<%@ page errorPage="../error.jsp" %>
+<%@ page errorPage="/errorpage.jsp" %>
 <!DOCTYPE html>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>

--- a/src/main/webapp/mcedt/mailbox/upload.jsp
+++ b/src/main/webapp/mcedt/mailbox/upload.jsp
@@ -24,7 +24,7 @@
     
 --%>
 
-<%@ page errorPage="../error.jsp" %>
+<%@ page errorPage="/errorpage.jsp" %>
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>

--- a/src/main/webapp/mcedt/update.jsp
+++ b/src/main/webapp/mcedt/update.jsp
@@ -24,7 +24,7 @@
 
 --%>
 
-<%@ page errorPage="error.jsp" %>
+<%@ page errorPage="/errorpage.jsp" %>
 
 <!DOCTYPE html>
 

--- a/src/main/webapp/mcedt/updateUpload.jsp
+++ b/src/main/webapp/mcedt/updateUpload.jsp
@@ -24,7 +24,7 @@
 
 --%>
 
-<%@ page errorPage="error.jsp" %>
+<%@ page errorPage="/errorpage.jsp" %>
 
 <!DOCTYPE html>
 

--- a/src/main/webapp/mcedt/uploads.jsp
+++ b/src/main/webapp/mcedt/uploads.jsp
@@ -24,7 +24,7 @@
 
 --%>
 
-<%@ page errorPage="error.jsp" %>
+<%@ page errorPage="/errorpage.jsp" %>
 
 <!DOCTYPE html>
 

--- a/src/main/webapp/messenger/generatePreviewPDF.jsp
+++ b/src/main/webapp/messenger/generatePreviewPDF.jsp
@@ -78,7 +78,7 @@
                 ca.openosp.openo.demographic.data.*" %>
 
 <%@ page import=" java.util.*, org.w3c.dom.*, java.sql.*, ca.openosp.*, java.text.*, java.lang.*,java.net.*"
-         errorPage="../appointment/errorpage.jsp" %>
+         errorPage="/errorpage.jsp" %>
 <%@ page import="ca.openosp.openo.utility.SpringUtils" %>
 <%@ page import="ca.openosp.openo.commn.dao.EChartDao" %>
 <%@ page import="ca.openosp.openo.commn.model.EChart" %>

--- a/src/main/webapp/messenger/processPDF.jsp
+++ b/src/main/webapp/messenger/processPDF.jsp
@@ -66,7 +66,7 @@
         import="ca.openosp.openo.messenger.docxfer.send.*,ca.openosp.openo.messenger.docxfer.util.*, ca.openosp.openo.encounter.data.*, ca.openosp.openo.encounter.pageUtil.EctSessionBean " %>
 <%@  page
         import=" java.util.*, org.w3c.dom.*, java.sql.*, ca.openosp.*, java.text.*, java.lang.*,java.net.*"
-        errorPage="../appointment/errorpage.jsp" %>
+        errorPage="/errorpage.jsp" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 
 

--- a/src/main/webapp/oscarEncounter/oscarConsultationRequest/DisplayDemographicConsultationRequests.jsp
+++ b/src/main/webapp/oscarEncounter/oscarConsultationRequest/DisplayDemographicConsultationRequests.jsp
@@ -66,7 +66,7 @@
         demoData = new DemographicData();
         demographic = demoData.getDemographic(LoggedInInfo.getLoggedInInfoFromSession(request), demo);
     } else
-        response.sendRedirect("../error.jsp");
+        request.getRequestDispatcher("/errorpage.jsp").forward(request, response);
 
     EctConsultationFormRequestUtil consultUtil;
     consultUtil = new EctConsultationFormRequestUtil();

--- a/src/main/webapp/oscarEncounter/oscarConsultationRequest/attachConsultation2.jsp
+++ b/src/main/webapp/oscarEncounter/oscarConsultationRequest/attachConsultation2.jsp
@@ -69,7 +69,7 @@
     String requestId = request.getParameter("requestId");
     String providerNo = request.getParameter("provNo");
 
-    if (demoNo == null && requestId == null) response.sendRedirect("../error.jsp");
+    if (demoNo == null && requestId == null) request.getRequestDispatcher("/errorpage.jsp").forward(request, response);
 
     if (demoNo == null || demoNo.equals("null")) {
 

--- a/src/main/webapp/oscarMDS/SegmentDisplay.jsp
+++ b/src/main/webapp/oscarMDS/SegmentDisplay.jsp
@@ -23,7 +23,7 @@
     Ontario, Canada
 
 --%>
-<%@page errorPage="../provider/errorpage.jsp" %>
+<%@page errorPage="/errorpage.jsp" %>
 <%@ page
         import="java.util.*, ca.openosp.openo.mds.data.*,ca.openosp.openo.lab.ca.on.*" %>
 <%@ page import="ca.openosp.openo.lab.ca.on.CommonLabResultData" %>

--- a/src/main/webapp/oscarReport/oscarReportCalendarPopup.jsp
+++ b/src/main/webapp/oscarReport/oscarReportCalendarPopup.jsp
@@ -29,7 +29,7 @@
 %>
 <%@ page
         import="java.util.*, java.sql.*, ca.openosp.*, java.text.*, java.lang.*,java.net.*"
-        errorPage="../appointment/errorpage.jsp" %>
+        errorPage="/errorpage.jsp" %>
 <%
     //to prepare calendar display  
     String type = request.getParameter("type");

--- a/src/main/webapp/patient/er.jsp
+++ b/src/main/webapp/patient/er.jsp
@@ -29,7 +29,7 @@
     String demographic_no = (String) session.getAttribute("demo_no");
 %>
 <%@ page import="java.util.*, java.sql.*, ca.openosp.*,java.net.*"
-         errorPage="../errorpage.jsp" %>
+         errorPage="/errorpage.jsp" %>
 
 <%@page import="ca.openosp.openo.utility.SpringUtils" %>
 <%@page import="ca.openosp.openo.commn.dao.DemographicAccessoryDao" %>

--- a/src/main/webapp/patient/patient_screen.jsp
+++ b/src/main/webapp/patient/patient_screen.jsp
@@ -28,7 +28,7 @@
     if (session.getValue("patient") == null) response.sendRedirect("../logout.jsp");
     String demographic_no = (String) session.getAttribute("demo_no");
 %>
-<%@ page import="java.util.*, java.sql.*, java.net.*, ca.openosp.*" errorPage="../appointment/errorpage.jsp" %>
+<%@ page import="java.util.*, java.sql.*, java.net.*, ca.openosp.*" errorPage="/errorpage.jsp" %>
 <%@page import="ca.openosp.openo.utility.SpringUtils" %>
 <%@page import="ca.openosp.openo.commn.dao.DemographicDao" %>
 <%@page import="ca.openosp.openo.commn.model.Demographic" %>

--- a/src/main/webapp/patient/sa.jsp
+++ b/src/main/webapp/patient/sa.jsp
@@ -30,7 +30,7 @@
     String user_no = (String) session.getAttribute("user");
     String demographic_no = (String) session.getAttribute("demo_no");
 %>
-<%@ page import="java.util.*, java.sql.*, ca.openosp.*,java.net.*" errorPage="../errorpage.jsp" %>
+<%@ page import="java.util.*, java.sql.*, ca.openosp.*,java.net.*" errorPage="/errorpage.jsp" %>
 
 <jsp:useBean id="risks" class="ca.openosp.OBRisks_99_12" scope="page"/>
 

--- a/src/main/webapp/provider/providerchangemygroup.jsp
+++ b/src/main/webapp/provider/providerchangemygroup.jsp
@@ -30,7 +30,7 @@
     String oldGroup_no = request.getParameter("mygroup_no") == null ? "." : request.getParameter("mygroup_no");
 %>
 <%@ page import="java.util.*,java.sql.*"
-         errorPage="../provider/errorpage.jsp" %>
+         errorPage="/errorpage.jsp" %>
 <%@ page import="ca.openosp.openo.utility.SpringUtils" %>
 <%@ page import="ca.openosp.openo.commn.model.MyGroup" %>
 <%@ page import="ca.openosp.openo.commn.dao.MyGroupDao" %>

--- a/src/main/webapp/provider/providerdisplaymygroup.jsp
+++ b/src/main/webapp/provider/providerdisplaymygroup.jsp
@@ -28,7 +28,7 @@
     if (session.getAttribute("user") == null) response.sendRedirect("../logout.htm");
 %>
 <%@ page import="java.util.*,java.sql.*"
-         errorPage="../provider/errorpage.jsp" %>
+         errorPage="/errorpage.jsp" %>
 <%@ page import="ca.openosp.openo.utility.SpringUtils" %>
 <%@ page import="ca.openosp.openo.commn.model.MyGroup" %>
 <%@ page import="ca.openosp.openo.commn.dao.MyGroupDao" %>

--- a/src/main/webapp/provider/providernewgroup.jsp
+++ b/src/main/webapp/provider/providernewgroup.jsp
@@ -24,7 +24,7 @@
 
 --%>
 
-<%@ page import="java.util.*,java.sql.*" errorPage="../provider/errorpage.jsp" %>
+<%@ page import="java.util.*,java.sql.*" errorPage="/errorpage.jsp" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 

--- a/src/main/webapp/provider/providersavemygroup.jsp
+++ b/src/main/webapp/provider/providersavemygroup.jsp
@@ -27,7 +27,7 @@
 <%
     if (session.getValue("user") == null) response.sendRedirect("../logout.htm");
 %>
-<%@ page import="java.sql.*, java.util.*, ca.openosp.MyDateFormat" errorPage="../errorpage.jsp" %>
+<%@ page import="java.sql.*, java.util.*, ca.openosp.MyDateFormat" errorPage="/errorpage.jsp" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 

--- a/src/main/webapp/provider/receptionistfindprovider.jsp
+++ b/src/main/webapp/provider/receptionistfindprovider.jsp
@@ -40,7 +40,7 @@
     String day = request.getParameter("pday") != null ? request.getParameter("pday") : "8";
 %>
 <%@ page import="java.util.*, java.sql.*, ca.openosp.*, java.text.*, java.lang.*,java.net.*"
-         errorPage="../appointment/errorpage.jsp" %>
+         errorPage="/errorpage.jsp" %>
 
 <%@page import="ca.openosp.openo.utility.SpringUtils" %>
 <%@page import="ca.openosp.openo.commn.dao.MyGroupDao" %>

--- a/src/main/webapp/report/dobformat.jsp
+++ b/src/main/webapp/report/dobformat.jsp
@@ -43,7 +43,7 @@
 
 %>
 <%@ page import="java.util.*, java.sql.*,java.io.*, ca.openosp.openo.util.*, java.text.*, java.net.*,sun.misc.*"
-         errorPage="../appointment/errorpage.jsp" %>
+         errorPage="/errorpage.jsp" %>
 <%@page import="ca.openosp.openo.utility.SpringUtils" %>
 <%@page import="ca.openosp.openo.commn.dao.DemographicDao" %>
 <%@page import="ca.openosp.openo.commn.model.Demographic" %>

--- a/src/main/webapp/report/reportBCARDemo2.jsp
+++ b/src/main/webapp/report/reportBCARDemo2.jsp
@@ -16,7 +16,7 @@
 
 <%@ page
         import="java.util.*, ca.openosp.openo.report.data.*, java.sql.*, ca.openosp.openo.login.*, java.net.*"
-        errorPage="../appointment/errorpage.jsp" %>
+        errorPage="/errorpage.jsp" %>
 <%@ page import="ca.openosp.openo.login.DBHelp" %>
 <%@ page import="ca.openosp.openo.report.data.RptReportCreator" %>
 <% java.util.Properties oscarVariables = ca.openosp.OscarProperties.getInstance(); %>

--- a/src/main/webapp/report/reportFilter.jsp
+++ b/src/main/webapp/report/reportFilter.jsp
@@ -13,7 +13,7 @@
     }
 %>
 
-<%@ page errorPage="../appointment/errorpage.jsp"
+<%@ page errorPage="/errorpage.jsp"
          import="java.util.*, ca.openosp.openo.report.data.*" %>
 <%@ page import="ca.openosp.openo.report.data.RptReportFilter" %>
 <%@ page import="ca.openosp.openo.report.data.RptReportItem" %>

--- a/src/main/webapp/report/reportFormCaption.jsp
+++ b/src/main/webapp/report/reportFormCaption.jsp
@@ -13,7 +13,7 @@
     }
 %>
 
-<%@ page errorPage="../appointment/errorpage.jsp"
+<%@ page errorPage="/errorpage.jsp"
          import="java.util.*, ca.openosp.openo.report.data.*" %>
 <%@ page import="ca.openosp.openo.login.*" %>
 <%@ page import="org.apache.commons.lang.*" %>

--- a/src/main/webapp/report/reportFormConfig.jsp
+++ b/src/main/webapp/report/reportFormConfig.jsp
@@ -13,7 +13,7 @@
     }
 %>
 
-<%@ page errorPage="../appointment/errorpage.jsp"
+<%@ page errorPage="/errorpage.jsp"
          import="java.util.*, ca.openosp.openo.report.data.*" %>
 <%@ page import="ca.openosp.openo.login.*" %>
 <%@ page import="org.apache.commons.lang.*" %>

--- a/src/main/webapp/report/reportFormDemoConfig.jsp
+++ b/src/main/webapp/report/reportFormDemoConfig.jsp
@@ -12,7 +12,7 @@
         return;
     }
 %>
-<%@ page errorPage="../appointment/errorpage.jsp"
+<%@ page errorPage="/errorpage.jsp"
          import="java.util.*, ca.openosp.openo.report.data.*" %>
 <%@ page import="ca.openosp.openo.login.*" %>
 <%@ page import="org.apache.commons.lang.*" %>

--- a/src/main/webapp/report/reportFormOrder.jsp
+++ b/src/main/webapp/report/reportFormOrder.jsp
@@ -12,7 +12,7 @@
         return;
     }
 %>
-<%@ page errorPage="../appointment/errorpage.jsp"
+<%@ page errorPage="/errorpage.jsp"
          import="java.util.*, ca.openosp.openo.report.data.*" %>
 <%@ page import="ca.openosp.openo.login.*" %>
 <%@ page import="org.apache.commons.lang.*" %>

--- a/src/main/webapp/report/reportFormRecord.jsp
+++ b/src/main/webapp/report/reportFormRecord.jsp
@@ -12,7 +12,7 @@
         return;
     }
 %>
-<%@ page errorPage="../appointment/errorpage.jsp"
+<%@ page errorPage="/errorpage.jsp"
          import="java.util.*, ca.openosp.openo.report.data.*" %>
 <%@ page import="ca.openosp.openo.login.*" %>
 <%@ page import="org.apache.commons.lang.StringEscapeUtils" %>

--- a/src/main/webapp/report/reportResult.jsp
+++ b/src/main/webapp/report/reportResult.jsp
@@ -22,7 +22,7 @@
         }
     }
 %>
-<%@ page errorPage="../appointment/errorpage.jsp"
+<%@ page errorPage="/errorpage.jsp"
          import="java.util.*, ca.openosp.openo.report.data.*" %>
 <%@ page import="ca.openosp.openo.report.pageUtil.*" %>
 <%@ page import="ca.openosp.openo.login.*" %>

--- a/src/main/webapp/report/reportapptsheet.jsp
+++ b/src/main/webapp/report/reportapptsheet.jsp
@@ -40,7 +40,7 @@
 %>
 
 <%@ page import="java.util.*, java.sql.*, ca.openosp.*,ca.openosp.openo.login.*, java.text.*, java.lang.*,java.net.*"
-         errorPage="../appointment/errorpage.jsp" %>
+         errorPage="/errorpage.jsp" %>
 
 <%@ page import="ca.openosp.openo.utility.SpringUtils" %>
 <%@ page import="ca.openosp.openo.commn.model.MyGroup" %>

--- a/src/main/webapp/report/reportbcedblist.jsp
+++ b/src/main/webapp/report/reportbcedblist.jsp
@@ -28,7 +28,7 @@
     if (request.getParameter("endDate") != null) endDate = request.getParameter("endDate");
 %>
 
-<%@ page import="java.util.*, java.sql.*" errorPage="../errorpage.jsp" %>
+<%@ page import="java.util.*, java.sql.*" errorPage="/errorpage.jsp" %>
 
 <jsp:useBean id="providerNameBean" class="java.util.Properties" scope="page"/>
 

--- a/src/main/webapp/report/reportbcedblist2007.jsp
+++ b/src/main/webapp/report/reportbcedblist2007.jsp
@@ -51,7 +51,7 @@
     if (request.getParameter("startDate") != null) startDate = request.getParameter("startDate");
     if (request.getParameter("endDate") != null) endDate = request.getParameter("endDate");
 %>
-<%@ page import="java.util.*, java.sql.*" errorPage="../errorpage.jsp" %>
+<%@ page import="java.util.*, java.sql.*" errorPage="/errorpage.jsp" %>
 
 <jsp:useBean id="providerNameBean" class="java.util.Properties" scope="page"/>
 <%@ page import="ca.openosp.openo.utility.SpringUtils" %>

--- a/src/main/webapp/report/reportbilledvisit.jsp
+++ b/src/main/webapp/report/reportbilledvisit.jsp
@@ -22,7 +22,7 @@
 %>
 <%@ page
         import="java.util.*, java.sql.*, ca.openosp.*, java.text.*, ca.openosp.openo.db.*,java.net.*"
-        errorPage="../appointment/errorpage.jsp" %>
+        errorPage="/errorpage.jsp" %>
 <%@ page import="ca.openosp.openo.db.DBPreparedHandler" %>
 <%@ page import="ca.openosp.openo.db.DBPreparedHandlerParam" %>
 <html>

--- a/src/main/webapp/report/reportbilledvisit1.jsp
+++ b/src/main/webapp/report/reportbilledvisit1.jsp
@@ -22,7 +22,7 @@
 %>
 <%@ page
         import="java.util.*, java.sql.*, ca.openosp.*, java.text.*, ca.openosp.openo.db.*,java.net.*"
-        errorPage="../appointment/errorpage.jsp" %>
+        errorPage="/errorpage.jsp" %>
 <%@ page import="ca.openosp.openo.db.DBPreparedHandler" %>
 <%@ page import="ca.openosp.openo.db.DBPreparedHandlerParam" %>
 <html>

--- a/src/main/webapp/report/reportbilledvisit2.jsp
+++ b/src/main/webapp/report/reportbilledvisit2.jsp
@@ -22,7 +22,7 @@
 %>
 <%@ page
         import="java.util.*, java.sql.*, ca.openosp.*, java.text.*, ca.openosp.openo.db.*,java.net.*"
-        errorPage="../appointment/errorpage.jsp" %>
+        errorPage="/errorpage.jsp" %>
 <%@ page import="ca.openosp.openo.db.DBPreparedHandler" %>
 <%@ page import="ca.openosp.openo.db.DBPreparedHandlerParam" %>
 <html>

--- a/src/main/webapp/report/reportbilledvisit3.jsp
+++ b/src/main/webapp/report/reportbilledvisit3.jsp
@@ -22,7 +22,7 @@
 %>
 <%@ page
         import="java.util.*, java.sql.*, ca.openosp.*, java.text.*, ca.openosp.openo.db.*,java.net.*"
-        errorPage="../appointment/errorpage.jsp" %>
+        errorPage="/errorpage.jsp" %>
 <%@ page import="ca.openosp.openo.db.DBPreparedHandler" %>
 <%@ page import="ca.openosp.openo.db.DBPreparedHandlerParam" %>
 <html>

--- a/src/main/webapp/report/reportdxvisit.jsp
+++ b/src/main/webapp/report/reportdxvisit.jsp
@@ -29,7 +29,7 @@
 %>
 <%@ page
         import="java.util.*, java.sql.*, ca.openosp.*, java.text.*, ca.openosp.openo.db.*,java.net.*"
-        errorPage="../appointment/errorpage.jsp" %>
+        errorPage="/errorpage.jsp" %>
 <html>
 <head>
     <script type="text/javascript" src="<%= request.getContextPath() %>/js/global.js"></script>

--- a/src/main/webapp/report/reportecharthistory.jsp
+++ b/src/main/webapp/report/reportecharthistory.jsp
@@ -51,7 +51,7 @@
     if (request.getParameter("limit2") != null) strLimit2 = request.getParameter("limit2");
 %>
 <%@ page import="java.util.*, java.sql.*, ca.openosp.*, java.text.*, java.lang.*,java.net.*,ca.openosp.openo.providers.data.*"
-         errorPage="../appointment/errorpage.jsp" %>
+         errorPage="/errorpage.jsp" %>
 <%@ page import="ca.openosp.openo.utility.SpringUtils" %>
 <%@ page import="ca.openosp.openo.commn.dao.EChartDao" %>
 <%@ page import="ca.openosp.openo.commn.model.EChart" %>

--- a/src/main/webapp/report/reportectapptsheet.jsp
+++ b/src/main/webapp/report/reportectapptsheet.jsp
@@ -52,7 +52,7 @@
 %>
 <%@ page
         import="java.util.*, java.sql.*, ca.openosp.*, java.text.*, java.lang.*,java.net.*"
-        errorPage="../appointment/errorpage.jsp" %>
+        errorPage="/errorpage.jsp" %>
 <jsp:useBean id="daySheetBean" class="ca.openosp.AppointmentMainBean"
              scope="page"/>
 <%

--- a/src/main/webapp/report/reportedblist.jsp
+++ b/src/main/webapp/report/reportedblist.jsp
@@ -52,7 +52,7 @@
     if (request.getParameter("endDate") != null) endDate = request.getParameter("endDate");
 %>
 <%@ page import="java.util.*, java.sql.*, ca.openosp.*"
-         errorPage="../errorpage.jsp" %>
+         errorPage="/errorpage.jsp" %>
 
 <jsp:useBean id="providerNameBean" class="ca.openosp.Dict" scope="page"/>
 <%@ page import="ca.openosp.openo.utility.SpringUtils" %>

--- a/src/main/webapp/report/reportencounterhistory.jsp
+++ b/src/main/webapp/report/reportencounterhistory.jsp
@@ -39,7 +39,7 @@
     }
 %>
 
-<%@ page import="java.util.*, java.sql.*, ca.openosp.*,java.net.*" errorPage="../errorpage.jsp" %>
+<%@ page import="java.util.*, java.sql.*, ca.openosp.*,java.net.*" errorPage="/errorpage.jsp" %>
 
 <%@ page import="ca.openosp.openo.utility.SpringUtils" %>
 <%@ page import="ca.openosp.openo.commn.dao.EncounterDao" %>

--- a/src/main/webapp/report/reportnewedblist.jsp
+++ b/src/main/webapp/report/reportnewedblist.jsp
@@ -52,7 +52,7 @@
     if (request.getParameter("startDate") != null) startDate = request.getParameter("startDate");
     if (request.getParameter("endDate") != null) endDate = request.getParameter("endDate");
 %>
-<%@ page import="java.util.*, java.sql.*" errorPage="../errorpage.jsp" %>
+<%@ page import="java.util.*, java.sql.*" errorPage="/errorpage.jsp" %>
 <%@ page import="ca.openosp.openo.utility.SpringUtils" %>
 <%@ page import="ca.openosp.openo.PMmodule.dao.ProviderDao" %>
 <%@ page import="ca.openosp.openo.commn.model.Provider" %>

--- a/src/main/webapp/report/reportnoshowapptlist.jsp
+++ b/src/main/webapp/report/reportnoshowapptlist.jsp
@@ -40,7 +40,7 @@
 %>
 
 <%@ page import="java.util.*, java.sql.*, ca.openosp.*, java.text.*, java.lang.*,java.net.*"
-         errorPage="../appointment/errorpage.jsp" %>
+         errorPage="/errorpage.jsp" %>
 
 <%@ page import="ca.openosp.openo.utility.SpringUtils" %>
 

--- a/src/main/webapp/report/reportonbilledphcp.jsp
+++ b/src/main/webapp/report/reportonbilledphcp.jsp
@@ -37,7 +37,7 @@
         }
     }
 %>
-<%@ page errorPage="../errorpage.jsp" %>
+<%@ page errorPage="/errorpage.jsp" %>
 <%@ page import="java.util.*" %>
 <%@ page import="java.sql.*" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>

--- a/src/main/webapp/report/reportonbilledphcp.jsp
+++ b/src/main/webapp/report/reportonbilledphcp.jsp
@@ -910,7 +910,7 @@
         // Log the error to the console
         System.err.println("JSP Processing Error:");
         e.printStackTrace(System.err);
-        request.getRequestDispatcher("/error.jsp").forward(request, response);
+        request.getRequestDispatcher("/errorpage.jsp").forward(request, response);
         return;
     }
     %>

--- a/src/main/webapp/report/reportonbilledphcpv2.jsp
+++ b/src/main/webapp/report/reportonbilledphcpv2.jsp
@@ -63,7 +63,7 @@
         }
     }
 %>
-<%@ page errorPage="../errorpage.jsp" %>
+<%@ page errorPage="/errorpage.jsp" %>
 <%@ page import="java.util.*" %>
 <%@ page import="java.sql.*" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>

--- a/src/main/webapp/report/reportonbilledvisit.jsp
+++ b/src/main/webapp/report/reportonbilledvisit.jsp
@@ -13,7 +13,7 @@
     }
 %>
 
-<%@ page errorPage="../errorpage.jsp" %>
+<%@ page errorPage="/errorpage.jsp" %>
 <html>
 <head>
     <script type="text/javascript" src="<%= request.getContextPath() %>/js/global.js"></script>

--- a/src/main/webapp/report/reportonbilledvisitprovider.jsp
+++ b/src/main/webapp/report/reportonbilledvisitprovider.jsp
@@ -18,7 +18,7 @@
     String curUser_no = (String) session.getAttribute("user");
     String[] ROLE = new String[]{"doctor", "resident", "nurse", "social worker", "other"};
 %>
-<%@ page errorPage="../errorpage.jsp" %>
+<%@ page errorPage="/errorpage.jsp" %>
 <%@ page import="java.util.*" %>
 <%@ page import="java.sql.*" %>
 <%@ page import="ca.openosp.openo.utility.SpringUtils" %>

--- a/src/main/webapp/report/reportonedblist.jsp
+++ b/src/main/webapp/report/reportonedblist.jsp
@@ -26,7 +26,7 @@
     if (request.getParameter("startDate") != null) startDate = request.getParameter("startDate");
     if (request.getParameter("endDate") != null) endDate = request.getParameter("endDate");
 %>
-<%@ page import="java.util.*, java.sql.*" errorPage="../errorpage.jsp" %>
+<%@ page import="java.util.*, java.sql.*" errorPage="/errorpage.jsp" %>
 <%@ page import="ca.openosp.openo.commn.dao.forms.FormsDao" %>
 
 <jsp:useBean id="providerNameBean" class="java.util.Properties" scope="page"/>

--- a/src/main/webapp/report/reportpatientchartlist.jsp
+++ b/src/main/webapp/report/reportpatientchartlist.jsp
@@ -40,7 +40,7 @@
 %>
 
 <%@ page import="java.util.*, java.sql.*, ca.openosp.*, java.text.*, java.lang.*,java.net.*"
-         errorPage="../appointment/errorpage.jsp" %>
+         errorPage="/errorpage.jsp" %>
 
 <%@ page import="ca.openosp.openo.utility.SpringUtils" %>
 

--- a/src/main/webapp/report/reportpatientchartlistspecial.jsp
+++ b/src/main/webapp/report/reportpatientchartlistspecial.jsp
@@ -41,7 +41,7 @@
 
 
 <%@ page import="java.util.*, java.sql.*, ca.openosp.*, java.text.*, java.lang.*,java.net.*"
-         errorPage="../appointment/errorpage.jsp" %>
+         errorPage="/errorpage.jsp" %>
 <%@ page import="ca.openosp.openo.utility.SpringUtils" %>
 
 <%@ page import="ca.openosp.openo.commn.model.MyGroup" %>

--- a/src/main/webapp/report/tabulardaysheetreport.jsp
+++ b/src/main/webapp/report/tabulardaysheetreport.jsp
@@ -21,7 +21,7 @@
 %>
 <%@ page
         import="java.util.*, java.sql.*, ca.openosp.*, java.text.*, java.lang.*,java.net.*,ca.openosp.openo.commn.model.*,org.apache.commons.lang.time.*"
-        errorPage="../appointment/errorpage.jsp" %>
+        errorPage="/errorpage.jsp" %>
 <%@ page import="ca.openosp.openo.web.admin.ProviderPreferencesUIBean" %>
 <jsp:useBean id="daySheetBean" class="ca.openosp.AppointmentMainBean" scope="page"/>
 <jsp:useBean id="providerBean" class="java.util.Properties" scope="session"/>

--- a/src/main/webapp/schedule/scheduleDisplayTemplate.jsp
+++ b/src/main/webapp/schedule/scheduleDisplayTemplate.jsp
@@ -27,7 +27,7 @@
 <%@page import="ca.openosp.openo.utility.SessionConstants" %>
 <%@page import="ca.openosp.openo.commn.model.ProviderPreference" %>
 <%@ page import="java.sql.*, java.util.*" %>
-<%@ page errorPage="/common/error.jsp" %>
+<%@ page errorPage="/errorpage.jsp" %>
 <%@page import="ca.openosp.openo.utility.SpringUtils" %>
 <%@page import="ca.openosp.openo.commn.dao.ScheduleTemplateDao" %>
 <%@page import="ca.openosp.openo.commn.model.ScheduleTemplate" %>

--- a/src/main/webapp/schedule/schedulecreatedate.jsp
+++ b/src/main/webapp/schedule/schedulecreatedate.jsp
@@ -52,7 +52,7 @@
 %>
 <%@ page
         import="java.util.*, java.sql.*, ca.openosp.*, java.text.*, java.lang.*,java.net.*"
-        errorPage="../appointment/errorpage.jsp" %>
+        errorPage="/errorpage.jsp" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 
 <jsp:useBean id="scheduleRscheduleBean" class="ca.openosp.RscheduleBean" scope="session"/>

--- a/src/main/webapp/schedule/scheduledatefinal.jsp
+++ b/src/main/webapp/schedule/scheduledatefinal.jsp
@@ -31,7 +31,7 @@
 %>
 <%@ page
         import="java.util.*, java.sql.*, ca.openosp.*, java.text.*, java.lang.*,java.net.*"
-        errorPage="../appointment/errorpage.jsp" %>
+        errorPage="/errorpage.jsp" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 
 

--- a/src/main/webapp/schedule/scheduledatepopup.jsp
+++ b/src/main/webapp/schedule/scheduledatepopup.jsp
@@ -27,7 +27,7 @@
 <%! boolean bMultisites = ca.openosp.openo.commn.IsPropertiesOn.isMultisitesEnable(); %>
 <%! String[] bgColors; %>
 
-<%@ page import="java.util.*, java.sql.*, ca.openosp.*, java.text.*, java.lang.*" errorPage="../appointment/errorpage.jsp" %>
+<%@ page import="java.util.*, java.sql.*, ca.openosp.*, java.text.*, java.lang.*" errorPage="/errorpage.jsp" %>
 <%@page import="ca.openosp.openo.utility.SpringUtils" %>
 <%@page import="ca.openosp.openo.commn.dao.ScheduleTemplateDao" %>
 <%@page import="ca.openosp.openo.commn.model.ScheduleTemplate" %>

--- a/src/main/webapp/schedule/scheduledatesave.jsp
+++ b/src/main/webapp/schedule/scheduledatesave.jsp
@@ -31,7 +31,7 @@
 %>
 <%@ page
         import="java.util.*, java.sql.*, ca.openosp.*, java.text.*, java.lang.*"
-        errorPage="../appointment/errorpage.jsp" %>
+        errorPage="/errorpage.jsp" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 
 

--- a/src/main/webapp/schedule/scheduledaytemplate.jsp
+++ b/src/main/webapp/schedule/scheduledaytemplate.jsp
@@ -29,7 +29,7 @@
 %>
 <%@ page
         import="java.util.*, java.sql.*, ca.openosp.*, java.text.*, java.lang.*"
-        errorPage="../appointment/errorpage.jsp" %>
+        errorPage="/errorpage.jsp" %>
 
 <jsp:useBean id="providerNameBean" class="ca.openosp.Dict" scope="session"/>
 <%@ page import="ca.openosp.openo.utility.SpringUtils" %>

--- a/src/main/webapp/schedule/scheduleedittemplate.jsp
+++ b/src/main/webapp/schedule/scheduleedittemplate.jsp
@@ -29,7 +29,7 @@
 %>
 <%@ page
         import="java.util.*, java.net.*, java.sql.*, ca.openosp.*, java.text.*, java.lang.*"
-        errorPage="../appointment/errorpage.jsp" %>
+        errorPage="/errorpage.jsp" %>
 <%@ page import="org.apache.commons.lang.StringEscapeUtils" %>
 <%@ page import="ca.openosp.OscarProperties" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>

--- a/src/main/webapp/schedule/scheduleflipview.jsp
+++ b/src/main/webapp/schedule/scheduleflipview.jsp
@@ -90,7 +90,7 @@
 %>
 <%@ page
         import="java.util.*, java.sql.*, ca.openosp.*, java.text.*, java.lang.*,java.net.*"
-        errorPage="../appointment/errorpage.jsp" %>
+        errorPage="/errorpage.jsp" %>
 
 <jsp:useBean id="DateTimeCodeBean" class="java.util.Hashtable"
              scope="page"/>

--- a/src/main/webapp/schedule/scheduleholidaysetting.jsp
+++ b/src/main/webapp/schedule/scheduleholidaysetting.jsp
@@ -52,7 +52,7 @@
 %>
 <%@ page
         import="java.util.*, java.sql.*, ca.openosp.*, java.text.*, java.lang.*"
-        errorPage="../appointment/errorpage.jsp" %>
+        errorPage="/errorpage.jsp" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 
 

--- a/src/main/webapp/schedule/scheduletemplatecodesetting.jsp
+++ b/src/main/webapp/schedule/scheduletemplatecodesetting.jsp
@@ -29,7 +29,7 @@
 %>
 <%@ page
         import="java.util.*, java.sql.*, ca.openosp.*, java.text.*, java.lang.*"
-        errorPage="../appointment/errorpage.jsp" %>
+        errorPage="/errorpage.jsp" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 
 

--- a/src/main/webapp/schedule/scheduletemplatesetting.jsp
+++ b/src/main/webapp/schedule/scheduletemplatesetting.jsp
@@ -27,7 +27,7 @@
 <%
 
 %>
-<%@ page import="java.util.*, java.sql.*, ca.openosp.*, java.text.*, java.lang.*" errorPage="../appointment/errorpage.jsp" %>
+<%@ page import="java.util.*, java.sql.*, ca.openosp.*, java.text.*, java.lang.*" errorPage="/errorpage.jsp" %>
 <%@page import="ca.openosp.openo.commn.model.Provider" %>
 <%@page import="ca.openosp.openo.PMmodule.dao.ProviderDao" %>
 <%@page import="ca.openosp.openo.utility.SpringUtils" %>

--- a/src/main/webapp/schedule/scheduletemplatesetting1.jsp
+++ b/src/main/webapp/schedule/scheduletemplatesetting1.jsp
@@ -28,7 +28,7 @@
 
     String weekdaytag[] = {"SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"};
 %>
-<%@ page import="java.util.*, java.sql.*, ca.openosp.*, java.text.*, java.lang.*" errorPage="../appointment/errorpage.jsp" %>
+<%@ page import="java.util.*, java.sql.*, ca.openosp.*, java.text.*, java.lang.*" errorPage="/errorpage.jsp" %>
 <%@page import="ca.openosp.openo.utility.SpringUtils" %>
 <%@page import="ca.openosp.openo.commn.model.RSchedule" %>
 <%@page import="ca.openosp.openo.commn.dao.RScheduleDao" %>

--- a/src/main/webapp/share/CalendarPopup.jsp
+++ b/src/main/webapp/share/CalendarPopup.jsp
@@ -39,7 +39,7 @@
 %>
 <%@ page
         import="java.util.*, java.sql.*, ca.openosp.*, java.text.*, java.lang.*,java.net.*"
-        errorPage="../appointment/errorpage.jsp" %>
+        errorPage="/errorpage.jsp" %>
 <%
     String urlfrom = request.getParameter("urlfrom") == null ? "" : request.getParameter("urlfrom");
     String param = request.getParameter("param") == null ? "" : request.getParameter("param");

--- a/src/main/webapp/taglibs.jsp
+++ b/src/main/webapp/taglibs.jsp
@@ -22,7 +22,7 @@
     Toronto, Ontario, Canada
 
 --%>
-<%@ page errorPage="/common/error.jsp" %>
+<%@ page errorPage="/errorpage.jsp" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>


### PR DESCRIPTION
This PR removes error page calls that are either:

- References to error pages that don't exist in the project
- References to error pages that do exist, but the path is incorrect
- References to error pages that are insecure (show too much information on the front end)
- References to error pages that can break context of the error itself if called

These have all been replaced with the generic error page that is located at the webapp root.

## Summary by Sourcery

Unify and secure error handling by replacing all references to missing, incorrect, or overly verbose error pages with the central /errorpage.jsp throughout Struts configuration and JSP views

Bug Fixes:
- Correct broken and misconfigured error page references in Struts actions and JSPs by pointing them to the generic root-level error page

Enhancements:
- Standardize on a single, secure generic error page across the application to replace non-existent, insecure, or context-breaking error handlers