### PR TITLE
Fix printing eChart notes

### DIFF
--- a/src/main/java/ca/openosp/openo/casemgmt/service/CaseManagementManagerImpl.java
+++ b/src/main/java/ca/openosp/openo/casemgmt/service/CaseManagementManagerImpl.java
@@ -1473,33 +1473,14 @@ public class CaseManagementManagerImpl implements CaseManagementManager {
                 filteredNotes.add(cmNote);
                 continue;
             }
-            String noteRole = null;
-            String noteRoleName = "";
 
+            String noteRole;
+            String noteRoleName;
             if (cmNote.getType().equals("local_note")) {
                 noteRole = cmNote.getRole();
-                if (noteRole != null && !noteRole.trim().isEmpty()) {
-                    try {
-                        Long roleId = Long.valueOf(noteRole);
-                        logger.debug("Looking up role ID: " + roleId + " in RoleCache");
-                        Secrole noteSecrole = RoleCache.getRole(roleId);
-                        if (noteSecrole != null) {
-                            noteRoleName = noteSecrole.getName().toLowerCase();
-                            logger.debug("Found role: " + noteRoleName + " for ID: " + roleId);
-                        } else {
-                            noteRoleName = "";
-                        }
-                    } catch (NumberFormatException e) {
-                        logger.warn("Invalid role format: '" + noteRole + "' - not a valid Long");
-                        noteRoleName = "";
-                    }
-                } else {
-                    logger.debug("Note has null or empty role");
-                    noteRoleName = "";
-                }
-            }
-
-            if (cmNote.getType().equals("remote_note")) {
+                noteRoleName = safeGetRoleName(noteRole);
+            } else { // remote_note
+                noteRole = cmNote.getRole();
                 noteRoleName = cmNote.getRole();
             }
 
@@ -2725,6 +2706,32 @@ public class CaseManagementManagerImpl implements CaseManagementManager {
         }
 
         return noteStr.toString();
+    }
+
+    /**
+     * Helper method to safely extract role name from role ID string with proper error handling and logging.
+     *
+     * @param roleIdStr The role ID as a string
+     * @return The lowercase role name, or empty string if role ID is invalid or role not found
+     */
+    private String safeGetRoleName(String roleIdStr) {
+        if (roleIdStr == null || roleIdStr.trim().isEmpty()) {
+            logger.debug("Note has null or empty role");
+            return "";
+        }
+        try {
+            Long roleId = Long.valueOf(roleIdStr);
+            logger.debug("Looking up role ID: " + roleId);
+            Secrole secrole = RoleCache.getRole(roleId);
+            if (secrole != null) {
+                String name = secrole.getName().toLowerCase();
+                logger.debug("Found role: " + name + " for ID: " + roleId);
+                return name;
+            }
+        } catch (NumberFormatException e) {
+            logger.warn("Invalid role format: '" + roleIdStr + "' - not a valid Long");
+        }
+        return "";
     }
 
 }

--- a/src/main/java/ca/openosp/openo/casemgmt/service/CaseManagementManagerImpl.java
+++ b/src/main/java/ca/openosp/openo/casemgmt/service/CaseManagementManagerImpl.java
@@ -1478,11 +1478,31 @@ public class CaseManagementManagerImpl implements CaseManagementManager {
 
             if (cmNote.getType().equals("local_note")) {
                 noteRole = cmNote.getRole();
-                noteRoleName = RoleCache.getRole(Long.valueOf(noteRole)).getName().toLowerCase();
+                if (noteRole != null && !noteRole.trim().isEmpty()) {
+                    try {
+                        Long roleId = Long.valueOf(noteRole);
+                        logger.debug("Looking up role ID: " + roleId + " in RoleCache");
+                        Secrole noteSecrole = RoleCache.getRole(roleId);
+                        if (noteSecrole != null) {
+                            noteRoleName = noteSecrole.getName().toLowerCase();
+                            logger.debug("Found role: " + noteRoleName + " for ID: " + roleId);
+                        } else {
+                            noteRoleName = "";
+                        }
+                    } catch (NumberFormatException e) {
+                        logger.warn("Invalid role format: '" + noteRole + "' - not a valid Long");
+                        noteRoleName = "";
+                    }
+                } else {
+                    logger.debug("Note has null or empty role");
+                    noteRoleName = "";
+                }
             }
+
             if (cmNote.getType().equals("remote_note")) {
                 noteRoleName = cmNote.getRole();
             }
+
             ProgramAccess pa = null;
             boolean add = false;
 

--- a/src/main/java/ca/openosp/openo/casemgmt/service/CaseManagementPrint.java
+++ b/src/main/java/ca/openosp/openo/casemgmt/service/CaseManagementPrint.java
@@ -43,6 +43,7 @@ import java.io.OutputStream;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.*;
+import java.util.stream.Collectors;
 
 public class CaseManagementPrint {
 
@@ -68,20 +69,19 @@ public class CaseManagementPrint {
 
         String providerNo = loggedInInfo.getLoggedInProviderNo();
 
-
         if (printAllNotes) {
-            noteIds = getAllNoteIds(loggedInInfo, request, "" + demographicNo);
-            if (noteIds == null) {
-                noteIds = new String[0];
-            }
+            List<CaseManagementNote> allNotes = caseManagementMgr.getNotes(String.valueOf(demographicNo));
+            noteIds = allNotes.stream()
+                .map(note -> note.getId().toString())
+                .toArray(String[]::new);
         }
 
         if (useDateRange) {
-            noteIds = getAllNoteIdsWithinDateRange(loggedInInfo, request, "" + demographicNo, startDate.getTime(), endDate.getTime());
+            noteIds = getAllNoteIdsWithinDateRange(loggedInInfo, request, String.valueOf(demographicNo), startDate.getTime(), endDate.getTime());
         }
         logger.debug("NOTES2PRINT: " + noteIds);
 
-        String demono = "" + demographicNo;
+        String demono = String.valueOf(demographicNo);
         request.setAttribute("demoName", getDemoName(demono));
         request.setAttribute("demoSex", getDemoSex(demono));
         request.setAttribute("demoAge", getDemoAge(demono));
@@ -92,15 +92,15 @@ public class CaseManagementPrint {
         request.setAttribute("demoDOB", dob);
 
 
-        List<CaseManagementNote> notes = new ArrayList<CaseManagementNote>();
-        List<String> remoteNoteUUIDs = new ArrayList<String>();
+        List<CaseManagementNote> notes = new ArrayList<>();
+        List<String> remoteNoteUUIDs = new ArrayList<>();
         String uuid;
-        for (int idx = 0; idx < noteIds.length; ++idx) {
-            if (noteIds[idx].startsWith("UUID")) {
-                uuid = noteIds[idx].substring(4);
+        for (String noteIdStr : noteIds) {
+            if (noteIdStr.startsWith("UUID")) {
+                uuid = noteIdStr.substring(4);
                 remoteNoteUUIDs.add(uuid);
             } else {
-                Long noteId = ConversionUtils.fromLongString(noteIds[idx]);
+                Long noteId = ConversionUtils.fromLongString(noteIdStr);
                 if (noteId > 0) {
                     CaseManagementNote note = this.caseManagementMgr.getNote(noteId.toString());
                     if (note != null && note.getProviderNo() != null
@@ -111,7 +111,7 @@ public class CaseManagementPrint {
             }
         }
 
-        if (loggedInInfo.getCurrentFacility().isIntegratorEnabled() && remoteNoteUUIDs.size() > 0) {
+        if (loggedInInfo.getCurrentFacility().isIntegratorEnabled() && !remoteNoteUUIDs.isEmpty()) {
             DemographicWs demographicWs = CaisiIntegratorManager.getDemographicWs(loggedInInfo, loggedInInfo.getCurrentFacility());
             List<CachedDemographicNote> remoteNotes = demographicWs.getLinkedCachedDemographicNotes(Integer.parseInt(demono));
             for (CachedDemographicNote remoteNote : remoteNotes) {
@@ -137,33 +137,35 @@ public class CaseManagementPrint {
 
         //How should i filter out observation dates?
         if (!printAllNotes && (startDate != null && endDate != null)) {
-            List<CaseManagementNote> dateFilteredList = new ArrayList<CaseManagementNote>();
             logger.debug("start date " + startDate);
             logger.debug("end date " + endDate);
 
-            for (CaseManagementNote cmn : notes) {
-                logger.debug("cmn " + cmn.getId() + "  -- " + cmn.getObservation_date() + " ? start date " + startDate.getTime().before(cmn.getObservation_date()) + " end date " + endDate.getTime().after(cmn.getObservation_date()));
-                if (startDate.getTime().before(cmn.getObservation_date()) && endDate.getTime().after(cmn.getObservation_date())) {
-                    dateFilteredList.add(cmn);
-                }
-            }
-            notes = dateFilteredList;
+            notes = notes.stream()
+                .filter(cmn -> {
+                    logger.debug("cmn " + cmn.getId() + "  -- " + cmn.getObservation_date() +
+                        " ? start date " + startDate.getTime().before(cmn.getObservation_date()) +
+                        " end date " + endDate.getTime().after(cmn.getObservation_date()));
+
+                    return startDate.getTime().before(cmn.getObservation_date()) &&
+                           endDate.getTime().after(cmn.getObservation_date());
+                })
+                .collect(Collectors.toList());
         }
 
         List<CaseManagementNote> issueNotes;
         List<CaseManagementNote> tmpNotes;
         HashMap<String, List<CaseManagementNote>> cpp = null;
         if (printCPP) {
-            cpp = new HashMap<String, List<CaseManagementNote>>();
+            cpp = new HashMap<>();
             String[] issueCodes = {"OMeds", "SocHistory", "MedHistory", "Concerns", "Reminders", "FamHistory", "RiskFactors"};
-            for (int j = 0; j < issueCodes.length; ++j) {
-                List<Issue> issues = caseManagementMgr.getIssueInfoByCode(providerNo, issueCodes[j]);
-                String[] issueIds = getIssueIds(issues);// = new String[issues.size()];
+            for (String issueCode : issueCodes) {
+                List<Issue> issues = caseManagementMgr.getIssueInfoByCode(providerNo, issueCode);
+                String[] issueIds = getIssueIds(issues);
                 tmpNotes = caseManagementMgr.getNotes(demono, issueIds);
-                issueNotes = new ArrayList<CaseManagementNote>();
-                for (int k = 0; k < tmpNotes.size(); ++k) {
-                    if (!tmpNotes.get(k).isLocked() && !tmpNotes.get(k).isArchived()) {
-                        List<CaseManagementNoteExt> exts = caseManagementMgr.getExtByNote(tmpNotes.get(k).getId());
+                issueNotes = new ArrayList<>();
+                for (CaseManagementNote tmpNote : tmpNotes) {
+                    if (!tmpNote.isLocked() && !tmpNote.isArchived()) {
+                        List<CaseManagementNoteExt> exts = caseManagementMgr.getExtByNote(tmpNote.getId());
                         boolean exclude = false;
                         for (CaseManagementNoteExt ext : exts) {
                             if (ext.getKeyVal().equals("Hide Cpp")) {
@@ -173,11 +175,11 @@ public class CaseManagementPrint {
                             }
                         }
                         if (!exclude) {
-                            issueNotes.add(tmpNotes.get(k));
+                            issueNotes.add(tmpNote);
                         }
                     }
                 }
-                cpp.put(issueCodes[j], issueNotes);
+                cpp.put(issueCode, issueNotes);
             }
         }
         String demoNo = null;
@@ -429,7 +431,8 @@ public class CaseManagementPrint {
             criteria.setProgramId(programId);
         }
 
-
+        // Apply session filters if they exist (set by CaseManagementView2Action)
+        // If no filters are present, criteria will have empty lists which means "no filtering" - get all notes
         if (se.getAttribute("CaseManagementViewAction_filter_roles") != null) {
             criteria.getRoles().addAll((List<String>) se.getAttribute("CaseManagementViewAction_filter_roles"));
         }

--- a/src/main/java/ca/openosp/openo/casemgmt/service/CaseManagementPrint.java
+++ b/src/main/java/ca/openosp/openo/casemgmt/service/CaseManagementPrint.java
@@ -71,6 +71,9 @@ public class CaseManagementPrint {
 
         if (printAllNotes) {
             noteIds = getAllNoteIds(loggedInInfo, request, "" + demographicNo);
+            if (noteIds == null) {
+                noteIds = new String[0];
+            }
         }
 
         if (useDateRange) {
@@ -370,7 +373,6 @@ public class CaseManagementPrint {
             criteria.setProgramId(programId);
         }
 
-
         if (se.getAttribute("CaseManagementViewAction_filter_roles") != null) {
             criteria.getRoles().addAll((List<String>) se.getAttribute("CaseManagementViewAction_filter_roles"));
         }
@@ -379,10 +381,9 @@ public class CaseManagementPrint {
             criteria.getProviders().addAll((List<String>) se.getAttribute("CaseManagementViewAction_filter_providers"));
         }
 
-        if (se.getAttribute("CaseManagementViewAction_filter_providers") != null) {
+        if (se.getAttribute("CaseManagementViewAction_filter_issues") != null) {
             criteria.getIssues().addAll((List<String>) se.getAttribute("CaseManagementViewAction_filter_issues"));
         }
-
 
         if (logger.isDebugEnabled()) {
             logger.debug("SEARCHING FOR NOTES WITH CRITERIA: " + criteria);
@@ -390,15 +391,14 @@ public class CaseManagementPrint {
 
         NoteSelectionResult result = noteService.findNotes(loggedInInfo, criteria);
 
-
         List<String> buf = new ArrayList<String>();
-        for (NoteDisplay nd : result.getNotes()) {
-            if (!(nd instanceof NoteDisplayLocal)) {
-                continue;
+        if (result != null && result.getNotes() != null) {
+            for (NoteDisplay nd : result.getNotes()) {
+                if (nd instanceof NoteDisplayLocal) {
+                    buf.add(nd.getNoteId().toString());
+                }
             }
-            buf.add(nd.getNoteId().toString());
         }
-
 
         return buf.toArray(new String[0]);
     }
@@ -448,15 +448,14 @@ public class CaseManagementPrint {
 
         NoteSelectionResult result = noteService.findNotes(loggedInInfo, criteria);
 
-
         List<String> buf = new ArrayList<String>();
-        for (NoteDisplay nd : result.getNotes()) {
-            if (!(nd instanceof NoteDisplayLocal)) {
-                continue;
+        if (result != null && result.getNotes() != null) {
+            for (NoteDisplay nd : result.getNotes()) {
+                if (nd instanceof NoteDisplayLocal) {
+                    buf.add(nd.getNoteId().toString());
+                }
             }
-            buf.add(nd.getNoteId().toString());
         }
-
 
         return buf.toArray(new String[0]);
     }

--- a/src/main/webapp/js/newCaseManagementView.js.jsp
+++ b/src/main/webapp/js/newCaseManagementView.js.jsp
@@ -3467,6 +3467,18 @@ function autoSave(async) {
         if ($F("printRx") == "true")
             printInfo("imgPrintRx", "printRx");
 
+        // Clear date fields
+        if ($("printStartDate"))
+            $("printStartDate").value = "";
+        if ($("printEndDate"))
+            $("printEndDate").value = "";
+
+        // Uncheck radio buttons
+        if ($("printopDates"))
+            $("printopDates").checked = false;
+        if ($("printopAllNotes"))
+            $("printopAllNotes").checked = false;
+
         return false;
 
     }


### PR DESCRIPTION
## Changes made
- Refactored `CaseManagementPrint.doPrint()`.
  - Gets filtered notes from `CaseManagementPrint.caseManagementMgr` directly, instead of using session attributes. These attributes are not consistently set between the `CaseManagementView` and `CaseManagementEntry` struts actions.
  - Used streams to improve readability.
- Add several null checks in `CaseManagementManagerImpl` when getting role and roleName.

#### Additional changes as of 29/09/2025:
- Fix date range filtering in `CaseManagementPrint.doPrint()`.
- Properly reset print dialog when clicking "Clear".

## Summary by Sourcery

Improve the eChart notes printing workflow by refactoring note retrieval and filtering logic using streams, and harden role resolution in CaseManagementManagerImpl with null and format checks

Bug Fixes:
- Add null and format checks when retrieving role and roleName in CaseManagementManagerImpl to prevent errors

Enhancements:
- Refactor CaseManagementPrint.doPrint to fetch notes directly from the manager instead of session attributes
- Replace manual loops with Java streams for note ID collection and date filtering
- Simplify collection initializations and condition checks for cleaner code