### PR TITLE
643 Fixed echart eform UI outdated

### DIFF
--- a/src/main/webapp/eform/efmformslistadd.jsp
+++ b/src/main/webapp/eform/efmformslistadd.jsp
@@ -40,10 +40,16 @@ Ontario, Canada
 <%@ page import="java.util.*, ca.openosp.openo.eform.*" %>
 <%@ page import="ca.openosp.openo.utility.SpringUtils" %>
 
+<%@page import="ca.openosp.openo.commn.dao.UserPropertyDAO, ca.openosp.openo.commn.model.UserProperty" %>
+<%@page import="ca.openosp.openo.utility.LoggedInInfo" %>
+<%@ page import="ca.openosp.openo.managers.DemographicManager" %>
+<%@ page import="ca.openosp.openo.commn.model.Demographic" %>
+<%@ page import="org.owasp.encoder.Encode" %>
 <%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar" %>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
-<%@page import="ca.openosp.openo.common.dao.UserPropertyDAO, ca.openosp.openo.common.model.UserProperty" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
+
 <%
     String user = (String) session.getAttribute("user");
     if (session.getAttribute("userrole") == null) {
@@ -79,13 +85,12 @@ Ontario, Canada
     Demographic demographic = demographicManager.getDemographic(loggedInInfo, demographic_no);
 %>
 
-<%@page import="ca.openosp.openo.util.LoggedInInfo" %>
-<%@ page import="org.owasp.encoder.Encode" %>
-<%@ page import="ca.openosp.openo.managers.DemographicManager" %>
+<fmt:setBundle basename="oscarResources"/>
+
 <html>
     <head>
         <title>
-            <fmt:setBundle basename="oscarResources"/><fmt:message key="eform.myform.title"/>
+            <fmt:message key="eform.myform.title"/>
         </title>
 
         <link href="${pageContext.request.contextPath}/library/bootstrap/3.0.0/css/bootstrap.css" rel="stylesheet">
@@ -126,10 +131,10 @@ Ontario, Canada
 
 				var table = jQuery('#efmTable').DataTable({
 					"pageLength": 15,
-					"lengthMenu": [[15, 30, 60, 120, -1], [15, 30, 60, 120, '<fmt:setBundle basename="oscarResources"/><fmt:message key="demographic.search.All"/>']],
+					"lengthMenu": [[15, 30, 60, 120, -1], [15, 30, 60, 120, "<fmt:message key='demographic.search.All'/>"]],
 					"order": [[0,'asc']],
 					"language": {
-						"url": "<%=request.getContextPath() %>/library/DataTables/i18n/<fmt:setBundle basename="oscarResources"/><fmt:message key="global.i18nLanguagecode"/>.json"
+						"url": "<%=request.getContextPath() %>/library/DataTables/i18n/<fmt:message key='global.i18nLanguagecode'/>.json"
 					}
 				});
 
@@ -187,24 +192,24 @@ Ontario, Canada
             <div class="left-column">
 
                 <a href="${pageContext.request.contextPath}/demographic/demographiccontrol.jsp?demographic_no=<%=demographic_no%>&appointment=<%=appointment%>&displaymode=edit&dboperation=search_detail">
-                    <fmt:setBundle basename="oscarResources"/><fmt:message key="demographic.demographiceditdemographic.btnMasterFile"/></a>
+                    <fmt:message key="demographic.demographiceditdemographic.btnMasterFile"/></a>
                 <a href="efmformslistadd.jsp?demographic_no=<%=demographic_no%>&appointment=<%=appointment%>&parentAjaxId=<%=parentAjaxId%>"
-                   class="current"> <fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.btnAddEForm"/></a>
+                   class="current"> <fmt:message key="eform.showmyform.btnAddEForm"/></a>
                 <jsp:include page="efmviewgroups.jsp">
                     <jsp:param name="url" value="${pageContext.request.contextPath}/eform/efmformslistadd.jsp"/>
                     <jsp:param name="groupView" value="<%=groupView%>"/>
                 </jsp:include>
 
                 <a href="efmpatientformlist.jsp?demographic_no=<%=demographic_no%>&appointment=<%=appointment%>&parentAjaxId=<%=parentAjaxId%>">
-                    <fmt:setBundle basename="oscarResources"/><fmt:message key="eform.calldeletedformdata.btnGoToForm"/></a>
+                    <fmt:message key="eform.calldeletedformdata.btnGoToForm"/></a>
                 <a href="efmpatientformlistdeleted.jsp?demographic_no=<%=demographic_no%>&appointment=<%=appointment%>&parentAjaxId=<%=parentAjaxId%>">
-                    <fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.btnDeleted"/></a>
+                    <fmt:message key="eform.showmyform.btnDeleted"/></a>
 
                 <security:oscarSec roleName="<%=roleName$%>" objectName="_admin,_admin.eform" rights="w"
                                    reverse="<%=false%>">
                     <a href="#"
                        onclick="return popup(600, 1200, '${pageContext.request.contextPath}/administration/?show=Forms', 'manageeforms');"
-                       style="color: #835921;"><fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.msgManageEFrm"/></a>
+                       style="color: #835921;"><fmt:message key="eform.showmyform.msgManageEFrm"/></a>
                 </security:oscarSec>
 
             </div>
@@ -212,9 +217,9 @@ Ontario, Canada
                 <table id="efmTable" class="table table-striped table-compact dataTable no-footer">
                     <thead>
                     <tr>
-                        <th><fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.btnFormName"/></th>
-                        <th><fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.btnSubject"/></th>
-                        <th><fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.formDate"/></th>
+                        <th><fmt:message key="eform.showmyform.btnFormName"/></th>
+                        <th><fmt:message key="eform.showmyform.btnSubject"/></th>
+                        <th><fmt:message key="eform.showmyform.formDate"/></th>
                     </tr>
                     </thead>
                     <tbody>

--- a/src/main/webapp/eform/efmformslistadd.jsp
+++ b/src/main/webapp/eform/efmformslistadd.jsp
@@ -23,31 +23,32 @@ Hamilton
 Ontario, Canada
 
 --%>
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-"http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html>
 <%
-//Lists forms available to add to patient
-if (session.getValue("user") == null) response.sendRedirect("../logout.jsp");
-String demographic_no = request.getParameter("demographic_no");
-String deepColor = "#CCCCFF", weakColor = "#EEEEFF";
-String country = request.getLocale().getCountry();
-String parentAjaxId = request.getParameter("parentAjaxId");
-String appointment = request.getParameter("appointment");
+    //Lists forms available to add to patient
+    if (session.getValue("user") == null) {
+        response.sendRedirect("../logout.jsp");
+    }
+    String demographic_no = request.getParameter("demographic_no");
+    String country = request.getLocale().getCountry();
+    String parentAjaxId = request.getParameter("parentAjaxId");
+    String appointment = request.getParameter("appointment");
 
-LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
+    LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
 %>
 
-<%@ page import="java.util.*, java.sql.*, ca.openosp.openo.eform.*" %>
+<%@ page import="java.util.*, ca.openosp.openo.eform.*" %>
 <%@ page import="ca.openosp.openo.utility.SpringUtils" %>
-<%@ page import="ca.openosp.openo.managers.DemographicManager" %>
-<%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 
+<%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar" %>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
-<%@page import="ca.openosp.openo.commn.dao.UserPropertyDAO, ca.openosp.openo.commn.model.UserProperty" %>
+<%@page import="ca.openosp.openo.common.dao.UserPropertyDAO, ca.openosp.openo.common.model.UserProperty" %>
 <%
     String user = (String) session.getAttribute("user");
-    if (session.getAttribute("userrole") == null) response.sendRedirect("../logout.jsp");
+    if (session.getAttribute("userrole") == null) {
+        response.sendRedirect("../logout.jsp");
+    }
     String roleName$ = (String) session.getAttribute("userrole") + "," + user;
 
     String orderByRequest = request.getParameter("orderby");
@@ -62,7 +63,7 @@ LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
 
     String groupView = request.getParameter("group_view");
     if (groupView == null) {
-        UserPropertyDAO userPropDAO = (UserPropertyDAO) SpringUtils.getBean(UserPropertyDAO.class);
+        UserPropertyDAO userPropDAO = (UserPropertyDAO) SpringUtils.getBean("UserPropertyDAO");
         UserProperty usrProp = userPropDAO.getProp(user, UserProperty.EFORM_FAVOURITE_GROUP);
         if (usrProp != null) {
             groupView = usrProp.getValue();
@@ -75,41 +76,64 @@ LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
     DemographicManager demographicManager = SpringUtils.getBean(DemographicManager.class);
 %>
 <%
-    pageContext.setAttribute("demographic", demographicManager.getDemographic(loggedInInfo, demographic_no));
+    Demographic demographic = demographicManager.getDemographic(loggedInInfo, demographic_no);
 %>
 
-<%@page import="ca.openosp.openo.utility.LoggedInInfo" %>
-<%@ page import="ca.openosp.openo.eform.EFormUtil" %>
+<%@page import="ca.openosp.openo.util.LoggedInInfo" %>
+<%@ page import="org.owasp.encoder.Encode" %>
+<%@ page import="ca.openosp.openo.managers.DemographicManager" %>
 <html>
     <head>
         <title>
             <fmt:setBundle basename="oscarResources"/><fmt:message key="eform.myform.title"/>
         </title>
-        <link rel="stylesheet" type="text/css" href="<%= request.getContextPath() %>/share/css/OscarStandardLayout.css">
-        <link rel="stylesheet" type="text/css" href="<%= request.getContextPath() %>/share/css/eformStyle.css">
-        <script type="text/javascript" language="JavaScript" src="<%= request.getContextPath() %>/share/javascript/Oscar.js"></script>
-        <script type="text/javascript" language="JavaScript">
-            function popupPage(varpage, windowname) {
-                var page = "" + varpage;
-                windowprops = "height=800,width=960,location=no,"
-                    + "scrollbars=yes,menubars=no,status=yes,toolbars=no,resizable=yes,top=10,left=200";
-                var popup = window.open(page, windowname, windowprops);
-                if (popup != null) {
-                    if (popup.opener == null) {
-                        popup.opener = self;
-                    }
-                    popup.focus();
-                }
-            }
 
-            function updateAjax() {
-                var parentAjaxId = "<%=parentAjaxId%>";
-                if (parentAjaxId != "null") {
-                    window.opener.document.forms['encForm'].elements['reloadDiv'].value = parentAjaxId;
-                    window.opener.updateNeeded = true;
-                }
+        <link href="${pageContext.request.contextPath}/library/bootstrap/3.0.0/css/bootstrap.css" rel="stylesheet">
+        <link href="${pageContext.request.contextPath}/library/DataTables/datatables.css" rel="stylesheet">
+        <link href="${pageContext.request.contextPath}/library/jquery/jquery-ui-1.12.1.min.css" rel="stylesheet">
 
-            }
+        <script src="${pageContext.request.contextPath}/js/global.js"></script>
+        <script src="${pageContext.request.contextPath}/library/jquery/jquery-3.6.4.min.js"></script>
+        <script src="${pageContext.request.contextPath}/library/bootstrap/3.0.0/js/bootstrap.js"></script>
+        <script src="${pageContext.request.contextPath}/library/DataTables/datatables.min.js"></script>
+
+        <script src="${pageContext.request.contextPath}/share/javascript/Oscar.js"></script>
+
+        <script>
+			function popupPage(varpage, windowname) {
+				var page = "" + varpage;
+				windowprops = "height=700,width=800,location=no,"
+					+ "scrollbars=yes,menubars=no,status=yes,toolbars=no,resizable=yes,top=10,left=200";
+				var popup = window.open(page, windowname, windowprops);
+				if (popup != null) {
+					if (popup.opener == null) {
+						popup.opener = self;
+					}
+					popup.focus();
+				}
+			}
+
+			function updateAjax() {
+				var parentAjaxId = "<%=parentAjaxId%>";
+				if (parentAjaxId != "null") {
+					window.opener.document.forms['encForm'].elements['reloadDiv'].value = parentAjaxId;
+					window.opener.updateNeeded = true;
+				}
+
+			}
+
+			$(document).ready(function () {
+
+				var table = jQuery('#efmTable').DataTable({
+					"pageLength": 15,
+					"lengthMenu": [[15, 30, 60, 120, -1], [15, 30, 60, 120, '<fmt:setBundle basename="oscarResources"/><fmt:message key="demographic.search.All"/>']],
+					"order": [[0,'asc']],
+					"language": {
+						"url": "<%=request.getContextPath() %>/library/DataTables/i18n/<fmt:setBundle basename="oscarResources"/><fmt:message key="global.i18nLanguagecode"/>.json"
+					}
+				});
+
+			});
         </script>
         <style>
             :root *:not(h2, .h2) {
@@ -146,69 +170,54 @@ LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
         </style>
     </head>
 
-    <body onunload="updateAjax()" class="BodyStyle" vlink="#0000FF">
-    <!--  -->
-    <table class="MainTable" id="scrollNumber1" name="encounterTable">
-        <tr class="MainTableTopRow">
-            <td class="MainTableTopRowLeftColumn" width="175">
-                <fmt:setBundle basename="oscarResources"/><fmt:message key="eform.myform.msgEForm"/>
-            </td>
-            <td class="MainTableTopRowRightColumn">
-                <table class="TopStatusBar">
-                    <tr>
-                        <td>
-                            <fmt:setBundle basename="oscarResources"/><fmt:message key="eform.myform.msgFormLib"/>
-                        </td>
-                        <td>&nbsp;
+    <body onunload="updateAjax()">
 
-                        </td>
-                        <td style="text-align:right">
-                            <a
-                                href="javascript:popupStart(300,400,'About.jsp')"><fmt:setBundle basename="oscarResources"/><fmt:message key="global.about"/></a>
-                            | <a href="javascript:popupStart(300,400,'License.jsp')"><fmt:setBundle basename="oscarResources"/><fmt:message key="global.license"/></a>
-                        </td>
-                    </tr>
-                </table>
-            </td>
-        </tr>
-        <tr>
-            <td class="MainTableLeftColumn" valign="top">
+    <div class="container">
+        <div id="heading">
+        <h2>
+            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-file-earmark-plus" viewBox="0 0 16 16">
+                <path d="M8 6.5a.5.5 0 0 1 .5.5v1.5H10a.5.5 0 0 1 0 1H8.5V11a.5.5 0 0 1-1 0V9.5H6a.5.5 0 0 1 0-1h1.5V7a.5.5 0 0 1 .5-.5"></path>
+                <path d="M14 4.5V14a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V2a2 2 0 0 1 2-2h5.5zm-3 0A1.5 1.5 0 0 1 9.5 3V1H4a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V4.5z"></path>
+            </svg>
+            Add eForm
+        </h2> <span><%= Encode.forHtml(demographic.getDisplayName()) %></span>
+        </div>
+        <div class="menu-columns">
 
-                <a href="<%= request.getContextPath() %>/demographic/demographiccontrol.jsp?demographic_no=<%=demographic_no%>&appointment=<%=appointment%>&displaymode=edit&dboperation=search_detail"><fmt:setBundle basename="oscarResources"/><fmt:message key="demographic.demographiceditdemographic.btnMasterFile"/></a>
+            <div class="left-column">
 
-                <br>
+                <a href="${pageContext.request.contextPath}/demographic/demographiccontrol.jsp?demographic_no=<%=demographic_no%>&appointment=<%=appointment%>&displaymode=edit&dboperation=search_detail">
+                    <fmt:setBundle basename="oscarResources"/><fmt:message key="demographic.demographiceditdemographic.btnMasterFile"/></a>
                 <a href="efmformslistadd.jsp?demographic_no=<%=demographic_no%>&appointment=<%=appointment%>&parentAjaxId=<%=parentAjaxId%>"
-                   class="current"> <fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.btnAddEForm"/></a><br/>
-                <a href="efmpatientformlist.jsp?demographic_no=<%=demographic_no%>&appointment=<%=appointment%>&parentAjaxId=<%=parentAjaxId%>"><fmt:setBundle basename="oscarResources"/><fmt:message key="eform.calldeletedformdata.btnGoToForm"/></a><br/>
-                <a href="efmpatientformlistdeleted.jsp?demographic_no=<%=demographic_no%>&appointment=<%=appointment%>&parentAjaxId=<%=parentAjaxId%>"><fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.btnDeleted"/></a>
-
-                <security:oscarSec roleName="<%=roleName$%>" objectName="_admin,_admin.eform" rights="w"
-                                   reverse="<%=false%>">
-                    <br/>
-                    <a href="#"
-                       onclick="javascript: return popup(600, 1200, '../administration/?show=Forms', 'manageeforms');"
-                       style="color: #835921;"><fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.msgManageEFrm"/></a>
-                </security:oscarSec>
+                   class="current"> <fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.btnAddEForm"/></a>
                 <jsp:include page="efmviewgroups.jsp">
-                    <jsp:param name="url" value="../eform/efmformslistadd.jsp"/>
+                    <jsp:param name="url" value="${pageContext.request.contextPath}/eform/efmformslistadd.jsp"/>
                     <jsp:param name="groupView" value="<%=groupView%>"/>
                 </jsp:include>
 
-            </td>
-            <td class="MainTableRightColumn" style="vertical-align: top">
+                <a href="efmpatientformlist.jsp?demographic_no=<%=demographic_no%>&appointment=<%=appointment%>&parentAjaxId=<%=parentAjaxId%>">
+                    <fmt:setBundle basename="oscarResources"/><fmt:message key="eform.calldeletedformdata.btnGoToForm"/></a>
+                <a href="efmpatientformlistdeleted.jsp?demographic_no=<%=demographic_no%>&appointment=<%=appointment%>&parentAjaxId=<%=parentAjaxId%>">
+                    <fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.btnDeleted"/></a>
 
-                <table class="elements" style="margin-left: 0px; margin-right: 0px;" width="100%">
-                    <tr bgcolor=<%=deepColor%>>
-                        <th>
-                            <a href="efmformslistadd.jsp?demographic_no=<%=demographic_no%>&appointment=<%=appointment%>&group_view=<%=groupView%>&parentAjaxId=<%=parentAjaxId%>"><fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.btnFormName"/></a></th>
-                        <th>
-                            <a href="efmformslistadd.jsp?demographic_no=<%=demographic_no%>&appointment=<%=appointment%>&group_view=<%=groupView%>&orderby=form_subject&parentAjaxId=<%=parentAjaxId%>"><fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.btnSubject"/></a></th>
-                        <!--<th><a href="myform.jsp?demographic_no=<%=demographic_no%>&group_view=<%=groupView%>&orderby=file_name"><fmt:setBundle basename="oscarResources"/><fmt:message key="eform.myform.btnFile"/></a></th>-->
-                        <th>
-                            <a href="efmformslistadd.jsp?demographic_no=<%=demographic_no%>&appointment=<%=appointment%>&group_view=<%=groupView%>&orderby=form_date&parentAjaxId=<%=parentAjaxId%>"><fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.formDate"/></a></th>
-                        <!--<th><a href="myform.jsp?demographic_no=<%=demographic_no%>&group_view=<%=groupView%>"><fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.formTime"/></a></th> -->
+                <security:oscarSec roleName="<%=roleName$%>" objectName="_admin,_admin.eform" rights="w"
+                                   reverse="<%=false%>">
+                    <a href="#"
+                       onclick="return popup(600, 1200, '${pageContext.request.contextPath}/administration/?show=Forms', 'manageeforms');"
+                       style="color: #835921;"><fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.msgManageEFrm"/></a>
+                </security:oscarSec>
+
+            </div>
+            <div class="right-column">
+                <table id="efmTable" class="table table-striped table-compact dataTable no-footer">
+                    <thead>
+                    <tr>
+                        <th><fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.btnFormName"/></th>
+                        <th><fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.btnSubject"/></th>
+                        <th><fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.formDate"/></th>
                     </tr>
-
+                    </thead>
+                    <tbody>
                     <%
                         ArrayList<HashMap<String, ? extends Object>> eForms;
                         if (groupView.equals("") || groupView.equals("default")) {
@@ -220,27 +229,22 @@ LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
                             for (int i = 0; i < eForms.size(); i++) {
                                 HashMap<String, ? extends Object> curForm = eForms.get(i);
                     %>
-                    <tr bgcolor="<%= ((i%2) == 1)?"#F2F2F2":"white"%>">
-                        <td width="30%" style="padding-left: 7px">
+                    <tr>
+                        <td>
                             <a HREF="#"
-                               ONCLICK="javascript: popupPage('efmformadd_data.jsp?fid=<%=curForm.get("fid")%>&demographic_no=<%=demographic_no%>&appointment=<%=appointment%>','<%=curForm.get("fid") + "_" + demographic_no %>'); return true;"
+                               ONCLICK="popupPage('efmformadd_data.jsp?fid=<%=curForm.get("fid")%>&demographic_no=<%=demographic_no%>&appointment=<%=appointment%>','<%=curForm.get("fid") + "_" + demographic_no %>'); return true;"
                                TITLE='Add This eForm' OnMouseOver="window.status='Add This eForm' ; return true">
-                                <%=curForm.get("formName")%>
+                                <%= Encode.forHtmlContent((String) curForm.get("formName")) %>
                             </a></td>
-                        <td style="padding-left: 7px"><%=curForm.get("formSubject")%>
+                        <td><%=Encode.forHtmlContent((String) curForm.get("formSubject"))%>
                         </td>
-                        <td nowrap align='center'><%=curForm.get("formDate")%>
+                        <td><%=curForm.get("formDate")%>
                         </td>
                     </tr>
                     <%
-                        }
-                    } else {
-                    %>
-                    <tr>
-                        <td colspan="3" align="center"><fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.msgNoData"/></td>
-                    </tr>
-                    <%}%>
-
+                            }
+                        } %>
+                    </tbody>
                 </table>
             </div>
         </div>

--- a/src/main/webapp/eform/efmpatientformlist.jsp
+++ b/src/main/webapp/eform/efmpatientformlist.jsp
@@ -28,11 +28,14 @@
 <%@page import="java.util.*,ca.openosp.openo.eform.*" %>
 <%@ page import="org.owasp.encoder.Encode" %>
 <%@ page import="ca.openosp.openo.managers.DemographicManager" %>
+<%@ page import="ca.openosp.openo.commn.model.Demographic" %>
 <%@ page import="ca.openosp.openo.utility.SpringUtils" %>
 <%@ page import="ca.openosp.openo.utility.LoggedInInfo" %>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
 <%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
+
 <%
     LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
     String demographic_no = request.getParameter("demographic_no");
@@ -68,10 +71,12 @@
     Demographic demographic = demographicManager.getDemographic(loggedInInfo, demographic_no);
 %>
 
+<fmt:setBundle basename="oscarResources"/>
+
 <html>
     <head>
         <title>
-            <fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.title"/>
+            <fmt:message key="eform.showmyform.title"/>
         </title>
 
         <link href="${pageContext.request.contextPath}/library/bootstrap/3.0.0/css/bootstrap.css" rel="stylesheet">
@@ -83,19 +88,18 @@
         <script src="${pageContext.request.contextPath}/library/bootstrap/3.0.0/js/bootstrap.js"></script>
         <script src="${pageContext.request.contextPath}/library/DataTables/datatables.min.js"></script>
 
-        <script src="${ pageContext.request.contextPath }/js/jquery.fileDownload.js"></script>
-        <script src="${ pageContext.request.contextPath }/share/javascript/Oscar.js"></script>
+        <script src="${pageContext.request.contextPath}/js/jquery.fileDownload.js"></script>
+        <script src="${pageContext.request.contextPath}/share/javascript/Oscar.js"></script>
 
         <script>
 
 			$(document).ready(function () {
-
 				let table = jQuery('#efmTable').DataTable({
-					"lengthMenu": [[15, 30, 60, 120, -1], [15, 30, 60, 120, '<fmt:setBundle basename="oscarResources"/><fmt:message key="demographic.search.All"/>']],
+					"lengthMenu": [[15, 30, 60, 120, -1], [15, 30, 60, 120, "<fmt:message key='demographic.search.All'/>"]],
 					"order": [2],
 					columnDefs: [{ orderable: false, targets: 3 }],
 					"language": {
-						"url": "<%=request.getContextPath() %>/library/DataTables/i18n/<fmt:setBundle basename="oscarResources"/><fmt:message key="global.i18nLanguagecode"/>.json"
+						"url": "<%=request.getContextPath() %>/library/DataTables/i18n/<fmt:message key='global.i18nLanguagecode'/>.json"
 					}
 				});
 
@@ -165,7 +169,6 @@
                 text-wrap: nowrap;
             }
         </style>
-
     </head>
 
     <body onunload="updateAjax()">
@@ -175,7 +178,7 @@
                 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-file-earmark-ruled" viewBox="0 0 16 16">
                     <path d="M14 14V4.5L9.5 0H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2M9.5 3A1.5 1.5 0 0 0 11 4.5h2V9H3V2a1 1 0 0 1 1-1h5.5zM3 12v-2h2v2zm0 1h2v2H4a1 1 0 0 1-1-1zm3 2v-2h7v1a1 1 0 0 1-1 1zm7-3H6v-2h7z"></path>
                 </svg>
-                <fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.msgFormLybrary"/>
+                <fmt:message key="eform.showmyform.msgFormLybrary"/>
             </h2>
             <span><%= Encode.forHtml(demographic.getDisplayName()) %></span>
         </div>
@@ -184,11 +187,11 @@
             <div class="left-column">
 
                 <a href="${pageContext.request.contextPath}/demographic/demographiccontrol.jsp?demographic_no=<%=demographic_no%>&appointment=<%=appointment%>&displaymode=edit&dboperation=search_detail">
-                    <fmt:setBundle basename="oscarResources"/><fmt:message key="demographic.demographiceditdemographic.btnMasterFile"/></a>
+                    <fmt:message key="demographic.demographiceditdemographic.btnMasterFile"/></a>
                 <a href="efmformslistadd.jsp?demographic_no=<%=demographic_no%>&appointment=<%=appointment%>&parentAjaxId=<%=parentAjaxId%>"
-                   class="current"> <fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.btnAddEForm"/></a>
+                   class="current"> <fmt:message key="eform.showmyform.btnAddEForm"/></a>
                 <a href="efmpatientformlist.jsp?demographic_no=<%=demographic_no%>&appointment=<%=appointment%>&parentAjaxId=<%=parentAjaxId%>">
-                    <fmt:setBundle basename="oscarResources"/><fmt:message key="eform.calldeletedformdata.btnGoToForm"/></a>
+                    <fmt:message key="eform.calldeletedformdata.btnGoToForm"/></a>
                 <jsp:include page="efmviewgroups.jsp">
                     <jsp:param name="url" value="${pageContext.request.contextPath}/eform/efmpatientformlist.jsp"/>
                     <jsp:param name="groupView" value="<%=groupView%>"/>
@@ -197,12 +200,12 @@
                 </jsp:include>
 
                 <a href="efmpatientformlistdeleted.jsp?demographic_no=<%=demographic_no%>&appointment=<%=appointment%>&parentAjaxId=<%=parentAjaxId%>">
-                    <fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.btnDeleted"/></a>
+                    <fmt:message key="eform.showmyform.btnDeleted"/></a>
 
                 <security:oscarSec roleName="<%=roleName$%>" objectName="_admin,_admin.eform" rights="r"
                                    reverse="<%=false%>">
                     <a href="#" onclick="javascript: return popup(600, 1200, '${pageContext.request.contextPath}/administration/?show=Forms', 'manageeforms');" style="color: #835921;">
-                       <fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.msgManageEFrm"/></a>
+                       <fmt:message key="eform.showmyform.msgManageEFrm"/></a>
                 </security:oscarSec>
 
             </div>
@@ -214,16 +217,16 @@
                         <thead>
                         <tr>
                             <th>
-                                <fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.btnFormName"/>
+                                <fmt:message key="eform.showmyform.btnFormName"/>
                             </th>
                             <th>
-                                <fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.btnSubject"/>
+                                <fmt:message key="eform.showmyform.btnSubject"/>
                             </th>
                             <th>
-                                <fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.formDate"/>
+                                <fmt:message key="eform.showmyform.formDate"/>
                             </th>
                             <th>
-                                <fmt:setBundle basename="oscarResources"/><fmt:message key=="eform.showmyform.msgAction"/>
+                                <fmt:message key="eform.showmyform.msgAction"/>
                             </th>
                         </tr>
                         </thead>
@@ -243,9 +246,9 @@
 
                             <td><a href="#"
                                    ONCLICK="popupPage('efmshowform_data.jsp?fdid=<%=curform.get("fdid")%>&appointment=<%=appointment%>', '<%="FormP" + i%>'); return false;"
-                                   TITLE="<fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.msgViewFrm"/>"
+                                   TITLE="<fmt:message key="eform.showmyform.msgViewFrm"/>"
                                    onmouseover="window.status='
-                                        <fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.msgViewFrm"/>'; return true"><%=Encode.forHtmlContent((String)curform.get("formName"))%>
+                                        <fmt:message key="eform.showmyform.msgViewFrm"/>'; return true"><%=Encode.forHtmlContent((String)curform.get("formName"))%>
                             </a></td>
                             <td><%=Encode.forHtmlContent((String)curform.get("formSubject"))%>
                             </td>
@@ -253,7 +256,7 @@
                             </td>
                             <td><a style="color:red;" href="${pageContext.request.contextPath}/eform/removeEForm.do?fdid=<%=curform.get("fdid")%>&group_view=<%=groupView%>&demographic_no=<%=demographic_no%>&parentAjaxId=<%=parentAjaxId%>"
                                     onClick="return confirm('Are you sure you want to delete this eform?');">
-                                        <fmt:setBundle basename="oscarResources"/><fmt:message key="eform.uploadimages.btnDelete"/></a></td>
+                                        <fmt:message key="eform.uploadimages.btnDelete"/></a></td>
                         </tr>
                         <%
                             }

--- a/src/main/webapp/eform/efmpatientformlist.jsp
+++ b/src/main/webapp/eform/efmpatientformlist.jsp
@@ -23,27 +23,35 @@
     Ontario, Canada
 
 --%>
-
-<%@page import="ca.openosp.openo.utility.SpringUtils" %>
-<%@page import="ca.openosp.openo.utility.LoggedInInfo" %>
+<!DOCTYPE html>
 
 <%@page import="java.util.*,ca.openosp.openo.eform.*" %>
-<%@page import="ca.openosp.openo.web.eform.EfmPatientFormList" %>
-<%@ page import="ca.openosp.openo.eform.EFormUtil" %>
+<%@ page import="org.owasp.encoder.Encode" %>
+<%@ page import="ca.openosp.openo.managers.DemographicManager" %>
+<%@ page import="ca.openosp.openo.utility.SpringUtils" %>
+<%@ page import="ca.openosp.openo.utility.LoggedInInfo" %>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
 <%
+    LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
     String demographic_no = request.getParameter("demographic_no");
     String deepColor = "#CCCCFF", weakColor = "#EEEEFF";
 
-    if (session.getAttribute("userrole") == null) response.sendRedirect("../logout.jsp");
+	if (session.getAttribute("userrole") == null) {
+		response.sendRedirect("../logout.jsp");
+	}
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     String country = request.getLocale().getCountry();
     String orderByRequest = request.getParameter("orderby");
     String orderBy = "";
-    if (orderByRequest == null) orderBy = EFormUtil.DATE;
-    else if (orderByRequest.equals("form_subject")) orderBy = EFormUtil.SUBJECT;
-    else if (orderByRequest.equals("form_name")) orderBy = EFormUtil.NAME;
+	if (orderByRequest == null) {
+		orderBy = EFormUtil.DATE;
+	} else if (orderByRequest.equals("form_subject")) {
+		orderBy = EFormUtil.SUBJECT;
+	} else if (orderByRequest.equals("form_name")) {
+		orderBy = EFormUtil.NAME;
+	}
 
     String groupView = request.getParameter("group_view");
     if (groupView == null) {
@@ -52,255 +60,209 @@
 
     String appointment = request.getParameter("appointment");
     String parentAjaxId = request.getParameter("parentAjaxId");
-
-
-    int pageNo = 1;
-    int pageSize = 25;
-
-    String strPage = request.getParameter("page");
-    if (strPage != null) {
-        try {
-            pageNo = Integer.parseInt(strPage);
-        } catch (Exception e) {
-            pageNo = 1;
-        }
-    }
-    String strPageSize = request.getParameter("pageSize");
-    if (strPageSize != null) {
-        try {
-            pageSize = Integer.parseInt(strPageSize);
-        } catch (Exception e) {
-            pageSize = 25;
-        }
-    }
-
-    //probably just want to merge these 2 methods, and add the group restriction when necessary.
-    ArrayList<HashMap<String, ? extends Object>> eForms;
-    if (groupView.equals("")) {
-        eForms = EFormUtil.listPatientEForms(orderBy, EFormUtil.CURRENT, demographic_no, roleName$, pageSize * (pageNo - 1), pageSize);
-    } else {
-        eForms = EFormUtil.listPatientEForms(LoggedInInfo.getLoggedInInfoFromSession(request), orderBy, EFormUtil.CURRENT, demographic_no, groupView, pageSize * (pageNo - 1), pageSize);
-    }
-
-    boolean hasMore = eForms.size() == pageSize;
-
-    String reloadUrl = "efmpatientformlist.jsp?" + request.getQueryString();
-    if (reloadUrl.indexOf("page=") != -1) {
-        reloadUrl = reloadUrl.replaceFirst("(?<=[?&;])page=.*?($|[&;])", "");
-        reloadUrl = reloadUrl.replaceFirst("(?<=[?&;])pageSize=.*?($|[&;])", "");
-    }
-    if (reloadUrl.endsWith("&")) {
-        reloadUrl = reloadUrl.substring(0, reloadUrl.length() - 1);
-    }
 %>
-<%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
-
+<%!
+    DemographicManager demographicManager = SpringUtils.getBean(DemographicManager.class);
+%>
+<%
+    Demographic demographic = demographicManager.getDemographic(loggedInInfo, demographic_no);
+%>
 
 <html>
-
     <head>
-        <script type="text/javascript" src="<%=request.getContextPath()%>/js/global.js"></script>
-        <title><fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.title"/></title>
-        <link rel="stylesheet" type="text/css"
-              href="<%= request.getContextPath() %>/share/css/OscarStandardLayout.css">
-        <link rel="stylesheet" type="text/css"
-              href="<%= request.getContextPath() %>/share/css/eformStyle.css">
-        <script type="text/javascript" src="<%=request.getContextPath()%>/js/jquery-1.7.1.min.js"></script>
-        <script type="text/javascript" src="<%=request.getContextPath()%>/js/jquery.fileDownload.js"></script>
-        <script src="<%=request.getContextPath()%>/js/jquery-ui-1.8.18.custom.min.js"></script>
-        <script type="text/javascript" language="javascript">
-            $(document).ready(function () {
+        <title>
+            <fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.title"/>
+        </title>
 
-                //setup pagination
-                <%
-                    if(pageNo == 1) {
-                %>
-                $("#prev").attr("disabled", true);
-                <%}
-                if(!hasMore ) {
-                %>
-                $("#next").attr("disabled", true);
-                <%}%>
+        <link href="${pageContext.request.contextPath}/library/bootstrap/3.0.0/css/bootstrap.css" rel="stylesheet">
+        <link href="${pageContext.request.contextPath}/library/DataTables/datatables.css" rel="stylesheet">
+        <link href="${pageContext.request.contextPath}/library/jquery/jquery-ui-1.12.1.min.css" rel="stylesheet">
 
-                $("#pageSize").val('<%=pageSize%>');
+        <script src="${pageContext.request.contextPath}/js/global.js"></script>
+        <script src="${pageContext.request.contextPath}/library/jquery/jquery-3.6.4.min.js"></script>
+        <script src="${pageContext.request.contextPath}/library/bootstrap/3.0.0/js/bootstrap.js"></script>
+        <script src="${pageContext.request.contextPath}/library/DataTables/datatables.min.js"></script>
 
-                $("#prev").bind('click', function (event) {
-                    var page = $("#pageEl").val();
-                    var prevPage = parseInt(page) - 1;
-                    if (prevPage < 1) {
-                        return false;
-                    }
-                    location.href = '<%=reloadUrl%>' + '&page=' + prevPage + '&pageSize=' + $("#pageSize").val();
-                });
+        <script src="${ pageContext.request.contextPath }/js/jquery.fileDownload.js"></script>
+        <script src="${ pageContext.request.contextPath }/share/javascript/Oscar.js"></script>
 
-                $("#next").bind('click', function (event) {
-                    var page = $("#pageEl").val();
-                    var nextPage = parseInt(page) + 1;
-                    location.href = '<%=reloadUrl%>' + '&page=' + nextPage + '&pageSize=' + $("#pageSize").val();
-                });
+        <script>
 
-                $("#pageSize").bind('change', function (event) {
-                    location.href = '<%=reloadUrl%>' + '&page=1&pageSize=' + $("#pageSize").val();
-                });
+			$(document).ready(function () {
 
-            });
+				let table = jQuery('#efmTable').DataTable({
+					"lengthMenu": [[15, 30, 60, 120, -1], [15, 30, 60, 120, '<fmt:setBundle basename="oscarResources"/><fmt:message key="demographic.search.All"/>']],
+					"order": [2],
+					columnDefs: [{ orderable: false, targets: 3 }],
+					"language": {
+						"url": "<%=request.getContextPath() %>/library/DataTables/i18n/<fmt:setBundle basename="oscarResources"/><fmt:message key="global.i18nLanguagecode"/>.json"
+					}
+				});
 
+			});
+
+			function popupPage(varpage, windowname) {
+				let page = "" + varpage;
+				windowprops = "height=700,width=800,location=no,"
+					+ "scrollbars=yes,menubars=no,status=yes,toolbars=no,resizable=yes,top=10,left=200";
+				let popup = window.open(page, windowname, windowprops);
+				if (popup != null) {
+					if (popup.opener == null) {
+						popup.opener = self;
+					}
+					popup.focus();
+				}
+			}
+
+			function checkSelectBox() {
+				let selectVal = document.forms[0].group_view.value;
+				if (selectVal === "default") {
+					return false;
+				}
+			}
+
+			function updateAjax() {
+				let parentAjaxId = "<%=parentAjaxId%>";
+				if (parentAjaxId !== "null") {
+					window.opener.document.forms['encForm'].elements['reloadDiv'].value = parentAjaxId;
+					window.opener.updateNeeded = true;
+				}
+
+			}
         </script>
-
-        <script type="text/javascript" language="javascript">
-            function popupPage(varpage, windowname) {
-                var page = "" + varpage;
-                windowprops = "height=700,width=800,location=no,"
-                    + "scrollbars=yes,menubars=no,status=yes,toolbars=no,resizable=yes,top=10,left=200";
-                var popup = window.open(page, windowname, windowprops);
-                if (popup != null) {
-                    if (popup.opener == null) {
-                        popup.opener = self;
-                    }
-                    popup.focus();
-                }
+        <style>
+            :root *:not(h2, .h2) {
+                font-family: Arial, "Helvetica Neue", Helvetica, sans-serif !important;
+                font-size: 12px;
+                overscroll-behavior: none;
+                -webkit-font-smoothing: antialiased;
+                -moz-osx-font-smoothing: grayscale;
             }
 
-            function checkSelectBox() {
-                var selectVal = document.forms[0].group_view.value;
-                if (selectVal == "default") {
-                    return false;
-                }
+            #heading h2 {
+                display: inline-block;
             }
 
-            function updateAjax() {
-                var parentAjaxId = "<%=parentAjaxId%>";
-                if (parentAjaxId != "null") {
-                    window.opener.document.forms['encForm'].elements['reloadDiv'].value = parentAjaxId;
-                    window.opener.updateNeeded = true;
-                }
-
+            #heading span {
+                margin-left:50px;
             }
 
 
-        </script>
-        <script type="text/javascript" language="JavaScript"
-                src="<%= request.getContextPath() %>/share/javascript/Oscar.js"></script>
+            :root a {
+                color:blue;
+            }
+
+            div.menu-columns {
+                display: flex;
+                gap: 10px;
+            }
+
+            div.left-column {
+                display: flex;
+                flex-direction: column;
+                gap: 5px;
+                flex-basis: max-content;
+                text-wrap: nowrap;
+            }
+        </style>
+
     </head>
 
-    <body onunload="updateAjax()" class="BodyStyle" vlink="#0000FF">
+    <body onunload="updateAjax()">
+    <div class="container">
+        <div id="heading">
+            <h2>
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-file-earmark-ruled" viewBox="0 0 16 16">
+                    <path d="M14 14V4.5L9.5 0H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2M9.5 3A1.5 1.5 0 0 0 11 4.5h2V9H3V2a1 1 0 0 1 1-1h5.5zM3 12v-2h2v2zm0 1h2v2H4a1 1 0 0 1-1-1zm3 2v-2h7v1a1 1 0 0 1-1 1zm7-3H6v-2h7z"></path>
+                </svg>
+                <fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.msgFormLybrary"/>
+            </h2>
+            <span><%= Encode.forHtml(demographic.getDisplayName()) %></span>
+        </div>
+        <div class="menu-columns">
 
-    <!--  -->
-    <table class="MainTable" id="scrollNumber1" name="encounterTable">
-        <tr class="MainTableTopRow">
-            <td class="MainTableTopRowLeftColumn" width="175"><fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.msgMyForm"/></td>
-            <td class="MainTableTopRowRightColumn">
-                <table class="TopStatusBar">
-                    <tr>
-                        <td><fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.msgFormLybrary"/></td>
-                        <td>&nbsp;</td>
-                        <td style="text-align: right"><a
-                                href="javascript:popupStart(300,400,'About.jsp')"><fmt:setBundle basename="oscarResources"/><fmt:message key="global.about"/></a> | <a
-                                href="javascript:popupStart(300,400,'License.jsp')"><fmt:setBundle basename="oscarResources"/><fmt:message key="global.license"/></a></td>
-                    </tr>
-                </table>
-            </td>
-        </tr>
-        <tr>
-            <td class="MainTableLeftColumn" valign="top">
+            <div class="left-column">
 
-                <a href="<%= request.getContextPath() %>/demographic/demographiccontrol.jsp?demographic_no=<%=demographic_no%>&appointment=<%=appointment%>&displaymode=edit&dboperation=search_detail"><fmt:setBundle basename="oscarResources"/><fmt:message key="demographic.demographiceditdemographic.btnMasterFile"/></a>
-
-                <br>
+                <a href="${pageContext.request.contextPath}/demographic/demographiccontrol.jsp?demographic_no=<%=demographic_no%>&appointment=<%=appointment%>&displaymode=edit&dboperation=search_detail">
+                    <fmt:setBundle basename="oscarResources"/><fmt:message key="demographic.demographiceditdemographic.btnMasterFile"/></a>
                 <a href="efmformslistadd.jsp?demographic_no=<%=demographic_no%>&appointment=<%=appointment%>&parentAjaxId=<%=parentAjaxId%>"
-                   class="current"> <fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.btnAddEForm"/></a><br/>
-                <a href="efmpatientformlist.jsp?demographic_no=<%=demographic_no%>&appointment=<%=appointment%>&parentAjaxId=<%=parentAjaxId%>"><fmt:setBundle basename="oscarResources"/><fmt:message key="eform.calldeletedformdata.btnGoToForm"/></a><br/>
-                <a href="efmpatientformlistdeleted.jsp?demographic_no=<%=demographic_no%>&appointment=<%=appointment%>&parentAjaxId=<%=parentAjaxId%>"><fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.btnDeleted"/></a>
-
-                <security:oscarSec roleName="<%=roleName$%>" objectName="_admin,_admin.eform" rights="r"
-                                   reverse="<%=false%>">
-                    <br/>
-                    <a href="#"
-                       onclick="javascript: return popup(600, 1200, '../administration/?show=Forms', 'manageeforms');"
-                       style="color: #835921;"><fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.msgManageEFrm"/></a>
-                </security:oscarSec>
-
+                   class="current"> <fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.btnAddEForm"/></a>
+                <a href="efmpatientformlist.jsp?demographic_no=<%=demographic_no%>&appointment=<%=appointment%>&parentAjaxId=<%=parentAjaxId%>">
+                    <fmt:setBundle basename="oscarResources"/><fmt:message key="eform.calldeletedformdata.btnGoToForm"/></a>
                 <jsp:include page="efmviewgroups.jsp">
-                    <jsp:param name="url" value="../eform/efmpatientformlist.jsp"/>
+                    <jsp:param name="url" value="${pageContext.request.contextPath}/eform/efmpatientformlist.jsp"/>
                     <jsp:param name="groupView" value="<%=groupView%>"/>
                     <jsp:param name="patientGroups" value="1"/>
                     <jsp:param name="parentAjaxId" value="<%=parentAjaxId%>"/>
                 </jsp:include>
 
-            </td>
-            <td class="MainTableRightColumn" valign="top">
+                <a href="efmpatientformlistdeleted.jsp?demographic_no=<%=demographic_no%>&appointment=<%=appointment%>&parentAjaxId=<%=parentAjaxId%>">
+                    <fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.btnDeleted"/></a>
 
-                <div>
+                <security:oscarSec roleName="<%=roleName$%>" objectName="_admin,_admin.eform" rights="r"
+                                   reverse="<%=false%>">
+                    <a href="#" onclick="javascript: return popup(600, 1200, '${pageContext.request.contextPath}/administration/?show=Forms', 'manageeforms');" style="color: #835921;">
+                       <fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.msgManageEFrm"/></a>
+                </security:oscarSec>
+
+            </div>
+            <div class="right-column">
+
+                <form id="sendToPhrForm" action="efmpatientformlistSendPhrAction.jsp">
                     <input type="hidden" name="clientId" value="<%=demographic_no%>"/>
-                    <input type="hidden" name="page" id="pageEl" value="<%=pageNo%>"/>
-                    <table class="elements" width="100%">
-                        <tr bgcolor=<%=deepColor%>>
+                    <table id="efmTable" class="table table-striped table-compact dataTable no-footer">
+                        <thead>
+                        <tr>
                             <th>
-                                <a href="efmpatientformlist.jsp?demographic_no=<%=demographic_no%>&orderby=form_name&group_view=<%=groupView%>&parentAjaxId=<%=parentAjaxId%>">
-                                    <fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.btnFormName"/>
-                                </a>
+                                <fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.btnFormName"/>
                             </th>
-                            <th><a
-                                    href="efmpatientformlist.jsp?demographic_no=<%=demographic_no%>&orderby=form_subject&group_view=<%=groupView%>&parentAjaxId=<%=parentAjaxId%>"><fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.btnSubject"/></a></th>
-                            <th><a
-                                    href="efmpatientformlist.jsp?demographic_no=<%=demographic_no%>&group_view=<%=groupView%>&parentAjaxId=<%=parentAjaxId%>"><fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.formDate"/></a></th>
-                            <th><fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.msgAction"/></th>
+                            <th>
+                                <fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.btnSubject"/>
+                            </th>
+                            <th>
+                                <fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.formDate"/>
+                            </th>
+                            <th>
+                                <fmt:setBundle basename="oscarResources"/><fmt:message key=="eform.showmyform.msgAction"/>
+                            </th>
                         </tr>
+                        </thead>
+                        <tbody>
                         <%
-
+                            ArrayList<HashMap<String, ? extends Object>> eForms;
+                            if (groupView.equals("")) {
+                                eForms = EFormUtil.listPatientEForms(orderBy, EFormUtil.CURRENT, demographic_no, roleName$);
+                            } else {
+                                eForms = EFormUtil.listPatientEForms(orderBy, EFormUtil.CURRENT, demographic_no, groupView, roleName$);
+                            }
 
                             for (int i = 0; i < eForms.size(); i++) {
                                 HashMap<String, ? extends Object> curform = eForms.get(i);
                         %>
-                        <tr bgcolor="<%=((i % 2) == 1)?"#F2F2F2":"white"%>">
+                        <tr>
+
                             <td><a href="#"
                                    ONCLICK="popupPage('efmshowform_data.jsp?fdid=<%=curform.get("fdid")%>&appointment=<%=appointment%>', '<%="FormP" + i%>'); return false;"
                                    TITLE="<fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.msgViewFrm"/>"
-                                   onmouseover="window.status='<fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.msgViewFrm"/>'; return true"><%=curform.get("formName")%>
+                                   onmouseover="window.status='
+                                        <fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.msgViewFrm"/>'; return true"><%=Encode.forHtmlContent((String)curform.get("formName"))%>
                             </a></td>
-                            <td><%=curform.get("formSubject")%>
+                            <td><%=Encode.forHtmlContent((String)curform.get("formSubject"))%>
                             </td>
-                            <td align='center'><%=curform.get("formDate")%>
+                            <td><%=curform.get("formDate")%>
                             </td>
-                            <td align='center'><a
-                                    href="<%= request.getContextPath() %>/eform/removeEForm.do?fdid=<%=curform.get("fdid")%>&group_view=<%=groupView%>&demographic_no=<%=demographic_no%>&parentAjaxId=<%=parentAjaxId%>"
-                                    onClick="javascript: return confirm('Are you sure you want to delete this eform?');"><fmt:setBundle basename="oscarResources"/><fmt:message key="eform.uploadimages.btnDelete"/></a></td>
-                        </tr>
-                        <%
-                            }
-                            if (eForms.size() <= 0) {
-                        %>
-                        <tr>
-                            <td align='center' colspan='5'><fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.msgNoData"/></td>
+                            <td><a style="color:red;" href="${pageContext.request.contextPath}/eform/removeEForm.do?fdid=<%=curform.get("fdid")%>&group_view=<%=groupView%>&demographic_no=<%=demographic_no%>&parentAjaxId=<%=parentAjaxId%>"
+                                    onClick="return confirm('Are you sure you want to delete this eform?');">
+                                        <fmt:setBundle basename="oscarResources"/><fmt:message key="eform.uploadimages.btnDelete"/></a></td>
                         </tr>
                         <%
                             }
                         %>
+                        </tbody>
                     </table>
-
-
-                    <br/>
-
-                    <button id="prev" onclick="return false;">Previous Page</button>
-                    <button id="next" onclick="return false;">Next Page</button>
-                    &nbsp;
-                    <select name="pageSize" id="pageSize">
-                        <option value="25">25</option>
-                        <option value="50">50</option>
-                        <option value="100">100</option>
-                        <option value="150">150</option>
-                        <option value="200">200</option>
-                        <option value="250">250</option>
-                        <option value="500">500</option>
-                    </select>
-                </div>
-
-            </td>
-        </tr>
-        <tr>
-            <td class="MainTableBottomRowLeftColumn"></td>
-            <td class="MainTableBottomRowRightColumn"></td>
-        </tr>
-    </table>
+                </form>
+            </div>
+        </div>
+    </div>
     </body>
 </html>

--- a/src/main/webapp/eform/efmpatientformlistdeleted.jsp
+++ b/src/main/webapp/eform/efmpatientformlistdeleted.jsp
@@ -31,14 +31,16 @@
 	String demographic_no = request.getParameter("demographic_no");
 	String deepColor = "#CCCCFF" , weakColor = "#EEEEFF" ;
 %>
-<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
 <%@ page import="java.util.*, ca.openosp.openo.eform.*"%>
-<%@ page import="ca.openosp.openo.util.LoggedInInfo" %>
+<%@ page import="ca.openosp.openo.utility.LoggedInInfo" %>
 <%@ page import="ca.openosp.openo.managers.DemographicManager" %>
+<%@ page import="ca.openosp.openo.commn.model.Demographic" %>
 <%@ page import="ca.openosp.openo.utility.SpringUtils" %>
 <%@ page import="org.owasp.encoder.Encode" %>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
 <%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar"%>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 
 <%
 	LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
@@ -58,10 +60,13 @@
 <%
 	Demographic demographic = demographicManager.getDemographic(loggedInInfo, demographic_no);
 %>
+
+<fmt:setBundle basename="oscarResources"/>
+
 <html>
 	<head>
 		<title>
-            <fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.title" />
+            <fmt:message key="eform.showmyform.title" />
         </title>
 
 		<link href="${pageContext.request.contextPath}/library/bootstrap/3.0.0/css/bootstrap.css" rel="stylesheet">
@@ -104,10 +109,10 @@
 
 				let table = jQuery('#efmTable').DataTable({
 					"pageLength": 15,
-					"lengthMenu": [ [15, 30, 60, 120, -1], [15, 30, 60, 120, '<fmt:setBundle basename="oscarResources"/><fmt:message key="demographic.search.All"/>'] ],
+					"lengthMenu": [ [15, 30, 60, 120, -1], [15, 30, 60, 120, "<fmt:message key='demographic.search.All'/>"] ],
 					"order": [2],
 					"language": {
-						"url": "<%=request.getContextPath() %>/library/DataTables/i18n/<fmt:setBundle basename="oscarResources"/><fmt:message key="global.i18nLanguagecode"/>.json"
+						"url": "<%=request.getContextPath() %>/library/DataTables/i18n/<fmt:message key='global.i18nLanguagecode'/>.json"
 					}
 				});
 
@@ -157,25 +162,25 @@
 				<path d="M5.884 6.68a.5.5 0 1 0-.768.64L7.349 10l-2.233 2.68a.5.5 0 0 0 .768.64L8 10.781l2.116 2.54a.5.5 0 0 0 .768-.641L8.651 10l2.233-2.68a.5.5 0 0 0-.768-.64L8 9.219l-2.116-2.54z"></path>
 				<path d="M14 14V4.5L9.5 0H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2M9.5 3A1.5 1.5 0 0 0 11 4.5h2V14a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1h5.5z"></path>
 			</svg>
-			<fmt:setBundle basename="oscarResources"/><fmt:message key="eform.independent.btnDeleted" />
+			<fmt:message key="eform.independent.btnDeleted" />
 		</h2>
 		<span><%= Encode.forHtml(demographic.getDisplayName()) %></span>
 	</div>
 		<div class="menu-columns">
 			<div class="left-column">
 
-				<a href="${pageContext.request.contextPath}/demographic/demographiccontrol.jsp?demographic_no=<%=demographic_no%>&appointment=<%=appointment%>&displaymode=edit&dboperation=search_detail"><fmt:setBundle basename="oscarResources"/><fmt:message key="demographic.demographiceditdemographic.btnMasterFile" /></a>
+				<a href="${pageContext.request.contextPath}/demographic/demographiccontrol.jsp?demographic_no=<%=demographic_no%>&appointment=<%=appointment%>&displaymode=edit&dboperation=search_detail"><fmt:message key="demographic.demographiceditdemographic.btnMasterFile" /></a>
 
 				
 				<a href="efmformslistadd.jsp?demographic_no=<%=demographic_no%>&appointment=<%=appointment%>&parentAjaxId=<%=parentAjaxId%>" class="current"> 
-                    <fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.btnAddEForm"/></a>
+                    <fmt:message key="eform.showmyform.btnAddEForm"/></a>
 				<a href="efmpatientformlist.jsp?demographic_no=<%=demographic_no%>&appointment=<%=appointment%>&parentAjaxId=<%=parentAjaxId%>">
-                    <fmt:setBundle basename="oscarResources"/><fmt:message key="eform.calldeletedformdata.btnGoToForm"/></a>
+                    <fmt:message key="eform.calldeletedformdata.btnGoToForm"/></a>
 <%--			<a href="efmpatientformlistdeleted.jsp?demographic_no=<%=demographic_no%>&appointment=<%=appointment%>&parentAjaxId=<%=parentAjaxId%>">
-                    <fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.btnDeleted"/></a>--%>
+                    <fmt:message key="eform.showmyform.btnDeleted"/></a>--%>
 				<security:oscarSec roleName="<%=roleName$%>" objectName="_admin,_admin.eform" rights="r" reverse="<%=false%>" >
 					<a href="#" onclick="javascript: return popup(600, 1200, '${pageContext.request.contextPath}/administration/?show=Forms', 'manageeforms');" style="color: #835921;">
-                        <fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.msgManageEFrm"/></a>
+                        <fmt:message key="eform.showmyform.msgManageEFrm"/></a>
 				</security:oscarSec>
 			</div>
 			<div class="right-column">
@@ -185,16 +190,16 @@
 					<thead>
 					<tr>
 						<th>
-                            <fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.btnFormName" />
+                            <fmt:message key="eform.showmyform.btnFormName" />
 						</th>
 						<th>
-                            <fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.btnSubject" />
+                            <fmt:message key="eform.showmyform.btnSubject" />
                         </th>
 						<th>
-                            <fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.formDate" />
+                            <fmt:message key="eform.showmyform.formDate" />
                         </th>
 						<th>
-                            <fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.msgAction" />
+                            <fmt:message key="eform.showmyform.msgAction" />
                         </th>
 					</tr>
 					</thead>
@@ -213,7 +218,7 @@
 						<td ><%=curform.get("formDate")%></td>
 						<td ><a
 								href="${pageContext.request.contextPath}/eform/unRemoveEForm.do?fdid=<%=curform.get("fdid")%>&demographic_no=<%=demographic_no%>&parentAjaxId=<%=parentAjaxId%>" onClick="javascript: return confirm('Are you sure you want to restore this eform?');">
-                                    <fmt:setBundle basename="oscarResources"/><fmt:message key="global.btnRestore" /></a></td>
+                                    <fmt:message key="global.btnRestore" /></a></td>
 					</tr>
 					<%
 						}

--- a/src/main/webapp/eform/efmpatientformlistdeleted.jsp
+++ b/src/main/webapp/eform/efmpatientformlistdeleted.jsp
@@ -23,153 +23,206 @@
     Ontario, Canada
 
 --%>
-
+<!DOCTYPE html>
 <%
-    if (session.getAttribute("userrole") == null) response.sendRedirect("../logout.jsp");
-    String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
+	if(session.getAttribute("userrole") == null )  response.sendRedirect("../logout.jsp");
+	String roleName$ = (String)session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
 
-    //int demographic_no = Integer.parseInt(request.getParameter("demographic_no"));
-    String demographic_no = request.getParameter("demographic_no");
-    String deepColor = "#CCCCFF", weakColor = "#EEEEFF";
+	String demographic_no = request.getParameter("demographic_no");
+	String deepColor = "#CCCCFF" , weakColor = "#EEEEFF" ;
 %>
-
-<%@ page import="java.util.*, ca.openosp.openo.eform.*" %>
-<%@ page import="ca.openosp.openo.eform.EFormUtil" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
+<%@ page import="java.util.*, ca.openosp.openo.eform.*"%>
+<%@ page import="ca.openosp.openo.util.LoggedInInfo" %>
+<%@ page import="ca.openosp.openo.managers.DemographicManager" %>
+<%@ page import="ca.openosp.openo.utility.SpringUtils" %>
+<%@ page import="org.owasp.encoder.Encode" %>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar"%>
 
 <%
-    String country = request.getLocale().getCountry();
-    String orderByRequest = request.getParameter("orderby");
-    String orderBy = "";
-    if (orderByRequest == null) orderBy = EFormUtil.DATE;
-    else if (orderByRequest.equals("form_subject")) orderBy = EFormUtil.SUBJECT;
-    else if (orderByRequest.equals("form_name")) orderBy = EFormUtil.NAME;
+	LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
+	String country = request.getLocale().getCountry();
+	String orderByRequest = request.getParameter("orderby");
+	String orderBy = "";
+	if (orderByRequest == null) orderBy = EFormUtil.DATE;
+	else if (orderByRequest.equals("form_subject")) orderBy = EFormUtil.SUBJECT;
+	else if (orderByRequest.equals("form_name")) orderBy = EFormUtil.NAME;
 
-    String appointment = request.getParameter("appointment");
-    String parentAjaxId = request.getParameter("parentAjaxId");
+	String appointment = request.getParameter("appointment");
+	String parentAjaxId = request.getParameter("parentAjaxId");
 %>
-<%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
-
-
+<%!
+	DemographicManager demographicManager = SpringUtils.getBean(DemographicManager.class);
+%>
+<%
+	Demographic demographic = demographicManager.getDemographic(loggedInInfo, demographic_no);
+%>
 <html>
+	<head>
+		<title>
+            <fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.title" />
+        </title>
+
+		<link href="${pageContext.request.contextPath}/library/bootstrap/3.0.0/css/bootstrap.css" rel="stylesheet">
+		<link href="${pageContext.request.contextPath}/library/DataTables/datatables.css" rel="stylesheet">
+		<link href="${pageContext.request.contextPath}/library/jquery/jquery-ui-1.12.1.min.css" rel="stylesheet">
 
 
-    <head>
-        <script type="text/javascript" src="<%= request.getContextPath() %>/js/global.js"></script>
-        <title><fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.title"/></title>
-        <link rel="stylesheet" type="text/css"
-              href="<%= request.getContextPath() %>/share/css/OscarStandardLayout.css">
-        <link rel="stylesheet" type="text/css" href="<%= request.getContextPath() %>/share/css/eforms.css">
-        <script type="text/javascript" language="JavaScript"
-                src="<%= request.getContextPath() %>/share/javascript/Oscar.js"></script>
-        <script type="text/javascript" language="javascript">
-            function popupPage(varpage, windowname) {
-                var page = "" + varpage;
-                windowprops = "height=700,width=800,location=no,"
-                    + "scrollbars=yes,menubars=no,status=yes,toolbars=no,resizable=yes,top=10,left=200";
-                var popup = window.open(page, windowname, windowprops);
-                if (popup != null) {
-                    if (popup.opener == null) {
-                        popup.opener = self;
-                    }
-                    popup.focus();
-                }
-            }
+		<script src="${pageContext.request.contextPath}/js/global.js"></script>
+		<script src="${pageContext.request.contextPath}/library/jquery/jquery-3.6.4.min.js"></script>
+		<script src="${pageContext.request.contextPath}/library/bootstrap/3.0.0/js/bootstrap.js"></script>
+		<script src="${pageContext.request.contextPath}/library/DataTables/datatables.min.js"></script>
 
-            function updateAjax() {
-                var parentAjaxId = "<%=parentAjaxId%>";
-                if (parentAjaxId != "null") {
-                    window.opener.document.forms['encForm'].elements['reloadDiv'].value = parentAjaxId;
-                    window.opener.updateNeeded = true;
-                }
+		<script src="${pageContext.request.contextPath}/share/javascript/Oscar.js"></script>
 
-            }
-        </script>
+		<script>
 
-    </head>
+			function popupPage(varpage, windowname) {
+				let page = "" + varpage;
+				windowprops = "height=700,width=800,location=no,"
+						+ "scrollbars=yes,menubars=no,status=yes,toolbars=no,resizable=yes,top=10,left=200";
+				let popup = window.open(page, windowname, windowprops);
+				if (popup != null) {
+					if (popup.opener == null) {
+						popup.opener = self;
+					}
+					popup.focus();
+				}
+			}
 
-    <body onunload="updateAjax()" class="BodyStyle" vlink="#0000FF">
-    <!--  -->
-    <table class="MainTable" id="scrollNumber1" name="encounterTable">
-        <tr class="MainTableTopRow">
-            <td class="MainTableTopRowLeftColumn" width="175"><fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.msgMyForm"/></td>
-            <td class="MainTableTopRowRightColumn">
-                <table class="TopStatusBar">
-                    <tr>
-                        <td><fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.msgFormLybrary"/></td>
-                        <td>&nbsp;</td>
-                        <td style="text-align: right"><a
-                                href="javascript:popupStart(300,400,'About.jsp')"><fmt:setBundle basename="oscarResources"/><fmt:message key="global.about"/></a> | <a
-                                href="javascript:popupStart(300,400,'License.jsp')"><fmt:setBundle basename="oscarResources"/><fmt:message key="global.license"/></a></td>
-                    </tr>
-                </table>
-            </td>
-        </tr>
-        <tr>
-            <td class="MainTableLeftColumn" valign="top">
-                <a href="<%= request.getContextPath() %>/demographic/demographiccontrol.jsp?demographic_no=<%=demographic_no%>&appointment=<%=appointment%>&displaymode=edit&dboperation=search_detail"><fmt:setBundle basename="oscarResources"/><fmt:message key="demographic.demographiceditdemographic.btnMasterFile"/></a>
+			function updateAjax() {
+				let parentAjaxId = "<%=parentAjaxId%>";
+				if( parentAjaxId !== "null" ) {
+					window.opener.document.forms['encForm'].elements['reloadDiv'].value = parentAjaxId;
+					window.opener.updateNeeded = true;
+				}
 
-                <br>
-                <a href="efmformslistadd.jsp?demographic_no=<%=demographic_no%>&appointment=<%=appointment%>&parentAjaxId=<%=parentAjaxId%>"
-                   class="current"> <fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.btnAddEForm"/></a><br/>
-                <a href="efmpatientformlist.jsp?demographic_no=<%=demographic_no%>&appointment=<%=appointment%>&parentAjaxId=<%=parentAjaxId%>"><fmt:setBundle basename="oscarResources"/><fmt:message key="eform.calldeletedformdata.btnGoToForm"/></a><br/>
-                <a href="efmpatientformlistdeleted.jsp?demographic_no=<%=demographic_no%>&appointment=<%=appointment%>&parentAjaxId=<%=parentAjaxId%>"><fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.btnDeleted"/></a>
-                <security:oscarSec roleName="<%=roleName$%>" objectName="_admin,_admin.eform" rights="r"
-                                   reverse="<%=false%>">
-                    <br/>
-                    <a href="#"
-                       onclick="javascript: return popup(600, 1200, '../administration/?show=Forms', 'manageeforms');"
-                       style="color: #835921;"><fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.msgManageEFrm"/></a>
-                </security:oscarSec>
-            </td>
+			}
 
-            <td class="MainTableRightColumn" valign="top">
-                <table class="elements" width="100%">
-                    <tr bgcolor=<%=deepColor%>>
-                        <th><a
-                                href="efmpatientformlistdeleted.jsp?demographic_no=<%=demographic_no%>&orderby=form_name&parentAjaxId=<%=parentAjaxId%>"><fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.btnFormName"/></a></th>
-                        <th><a
-                                href="efmpatientformlistdeleted.jsp?demographic_no=<%=demographic_no%>&orderby=form_subject&parentAjaxId=<%=parentAjaxId%>"><fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.btnSubject"/></a></th>
-                        <th><a
-                                href="efmpatientformlistdeleted.jsp?demographic_no=<%=demographic_no%>&parentAjaxId=<%=parentAjaxId%>"><fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.formDate"/></a></th>
-                        <th><fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.msgAction"/></th>
-                    </tr>
-                    <%
-                        ArrayList<HashMap<String, ? extends Object>> forms = EFormUtil.listPatientEForms(orderBy, EFormUtil.DELETED, demographic_no, null);
-                        for (int i = 0; i < forms.size(); i++) {
-                            HashMap<String, ? extends Object> curform = forms.get(i);
-                    %>
-                    <tr bgcolor="<%= ((i%2) == 1)?"#F2F2F2":"white"%>">
-                        <td><a href="#"
-                               ONCLICK="popupPage('efmshowform_data.jsp?fdid=<%= curform.get("fdid")%>', '<%="FormPD" + i%>'); return false;"
-                               TITLE="View Form"
-                               onmouseover="window.status='View This Form'; return true"><%=curform.get("formName")%>
-                        </a></td>
-                        <td><%=curform.get("formSubject")%>
-                        </td>
-                        <td align='center'><%=curform.get("formDate")%>
-                        </td>
-                        <td align='center'><a
-                                href="<%= request.getContextPath() %>/eform/unRemoveEForm.do?fdid=<%=curform.get("fdid")%>&demographic_no=<%=demographic_no%>&parentAjaxId=<%=parentAjaxId%>"
-                                onClick="javascript: return confirm('Are you sure you want to restore this eform?');"><fmt:setBundle basename="oscarResources"/><fmt:message key="global.btnRestore"/></a></td>
-                    </tr>
-                    <%
-                        }
-                        if (forms.size() <= 0) {
-                    %>
-                    <tr>
-                        <td align='center' colspan='5'><fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.msgNoData"/></td>
-                    </tr>
-                    <%
-                        }
-                    %>
-                </table>
-            </td>
-        </tr>
-        <tr>
-            <td class="MainTableBottomRowLeftColumn"></td>
-            <td class="MainTableBottomRowRightColumn"></td>
-        </tr>
-    </table>
-    </body>
+			$(document).ready(function() {
+
+				let table = jQuery('#efmTable').DataTable({
+					"pageLength": 15,
+					"lengthMenu": [ [15, 30, 60, 120, -1], [15, 30, 60, 120, '<fmt:setBundle basename="oscarResources"/><fmt:message key="demographic.search.All"/>'] ],
+					"order": [2],
+					"language": {
+						"url": "<%=request.getContextPath() %>/library/DataTables/i18n/<fmt:setBundle basename="oscarResources"/><fmt:message key="global.i18nLanguagecode"/>.json"
+					}
+				});
+
+			});
+		</script>
+		<style>
+			:root *:not(h2, .h2) {
+				font-family: Arial, "Helvetica Neue", Helvetica, sans-serif !important;
+				font-size: 12px;
+				overscroll-behavior: none;
+				-webkit-font-smoothing: antialiased;
+				-moz-osx-font-smoothing: grayscale;
+			}
+
+			#heading h2 {
+				display: inline-block;
+			}
+
+			#heading span {
+				margin-left:50px;
+			}
+
+
+			:root a {
+				color:blue;
+			}
+
+			div.menu-columns {
+				display: flex;
+				gap: 10px;
+			}
+
+			div.left-column {
+				display: flex;
+				flex-direction: column;
+				gap: 5px;
+				flex-basis: max-content;
+				text-wrap: nowrap;
+			}
+		</style>
+	</head>
+	<body onunload="updateAjax()" >
+	<div class="container">
+	<div id="heading">
+		<h2>
+			<svg style="color:red;" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-file-earmark-excel" viewBox="0 0 16 16">
+				<path d="M5.884 6.68a.5.5 0 1 0-.768.64L7.349 10l-2.233 2.68a.5.5 0 0 0 .768.64L8 10.781l2.116 2.54a.5.5 0 0 0 .768-.641L8.651 10l2.233-2.68a.5.5 0 0 0-.768-.64L8 9.219l-2.116-2.54z"></path>
+				<path d="M14 14V4.5L9.5 0H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2M9.5 3A1.5 1.5 0 0 0 11 4.5h2V14a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1h5.5z"></path>
+			</svg>
+			<fmt:setBundle basename="oscarResources"/><fmt:message key="eform.independent.btnDeleted" />
+		</h2>
+		<span><%= Encode.forHtml(demographic.getDisplayName()) %></span>
+	</div>
+		<div class="menu-columns">
+			<div class="left-column">
+
+				<a href="${pageContext.request.contextPath}/demographic/demographiccontrol.jsp?demographic_no=<%=demographic_no%>&appointment=<%=appointment%>&displaymode=edit&dboperation=search_detail"><fmt:setBundle basename="oscarResources"/><fmt:message key="demographic.demographiceditdemographic.btnMasterFile" /></a>
+
+				
+				<a href="efmformslistadd.jsp?demographic_no=<%=demographic_no%>&appointment=<%=appointment%>&parentAjaxId=<%=parentAjaxId%>" class="current"> 
+                    <fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.btnAddEForm"/></a>
+				<a href="efmpatientformlist.jsp?demographic_no=<%=demographic_no%>&appointment=<%=appointment%>&parentAjaxId=<%=parentAjaxId%>">
+                    <fmt:setBundle basename="oscarResources"/><fmt:message key="eform.calldeletedformdata.btnGoToForm"/></a>
+<%--			<a href="efmpatientformlistdeleted.jsp?demographic_no=<%=demographic_no%>&appointment=<%=appointment%>&parentAjaxId=<%=parentAjaxId%>">
+                    <fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.btnDeleted"/></a>--%>
+				<security:oscarSec roleName="<%=roleName$%>" objectName="_admin,_admin.eform" rights="r" reverse="<%=false%>" >
+					<a href="#" onclick="javascript: return popup(600, 1200, '${pageContext.request.contextPath}/administration/?show=Forms', 'manageeforms');" style="color: #835921;">
+                        <fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.msgManageEFrm"/></a>
+				</security:oscarSec>
+			</div>
+			<div class="right-column">
+				
+
+				<table id="efmTable" class="table table-striped table-compact dataTable no-footer">
+					<thead>
+					<tr>
+						<th>
+                            <fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.btnFormName" />
+						</th>
+						<th>
+                            <fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.btnSubject" />
+                        </th>
+						<th>
+                            <fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.formDate" />
+                        </th>
+						<th>
+                            <fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.msgAction" />
+                        </th>
+					</tr>
+					</thead>
+					<tbody>
+					<%
+						ArrayList<HashMap<String, ? extends Object>> forms = EFormUtil.listPatientEForms(orderBy, EFormUtil.DELETED, demographic_no, null);
+						for (int i=0; i< forms.size(); i++) {
+							HashMap<String, ? extends Object> curform = forms.get(i);
+					%>
+					<tr>
+						<td><a href="#"
+						       ONCLICK="popupPage('efmshowform_data.jsp?fdid=<%= curform.get("fdid")%>', '<%="FormPD" + i%>'); return false;"
+						       TITLE="View Form"
+						       onmouseover="window.status='View This Form'; return true"><%=Encode.forHtmlContent((String)curform.get("formName"))%></a></td>
+						<td><%=Encode.forHtmlContent((String)curform.get("formSubject"))%></td>
+						<td ><%=curform.get("formDate")%></td>
+						<td ><a
+								href="${pageContext.request.contextPath}/eform/unRemoveEForm.do?fdid=<%=curform.get("fdid")%>&demographic_no=<%=demographic_no%>&parentAjaxId=<%=parentAjaxId%>" onClick="javascript: return confirm('Are you sure you want to restore this eform?');">
+                                    <fmt:setBundle basename="oscarResources"/><fmt:message key="global.btnRestore" /></a></td>
+					</tr>
+					<%
+						}
+					%>
+					</tbody>
+				</table>
+			</div>
+		
+		</div>
+	</div>
+	</body>
 </html>

--- a/src/main/webapp/eform/eformGenerator.jsp
+++ b/src/main/webapp/eform/eformGenerator.jsp
@@ -818,7 +818,6 @@ and other liscences (MIT, LGPL etc) as indicated
             textTop += " .DoNotPrint {\n\tdisplay:none;\n }\n .noborder {\n\tborder:0px;\n\tbackground: transparent;\n";
             textTop += "&lt;/style&gt;\n\n";
 
-
             if (<% if (OscarProperties.getInstance().isPropertyActive("eform_generator_indivica_print_enabled")) { %>(document.getElementById('includePdfPrintControl').checked) || <%}%> <% if (OscarProperties.getInstance().isPropertyActive("eform_generator_indivica_fax_enabled")) { %>(document.getElementById("includeFaxControl").checked) || <% } %> (document.getElementById('AddSignature').checked)) {
                 textTop += "&lt;!-- jQuery for greater functionality --&gt;\n"
                 // dependency on jquery up to version 2.2.1 for pdf and faxing for OSCAR Pro
@@ -1166,7 +1165,7 @@ and other liscences (MIT, LGPL etc) as indicated
                 textTop += "var ImgArray = [];\n"
                 textTop += "&lt;/script&gt;\n\n"
 
-                textTop += "&lt;script src="<%= request.getContextPath() %>/eform/displayImage.do?imagefile=stamps.js"&gt;&lt;/script&gt;\n"
+                textTop += "&lt;script src=\"<%= request.getContextPath() %>/eform/displayImage.do?imagefile=stamps.js\"&gt;&lt;/script&gt;\n"
                 textTop += "&lt;script type=&quot;text/javascript&quot;&gt;\n"
                 textTop += "//autoloading signature images\n"
                 textTop += "ImgArray.push(\n\t&quot;anonymous|BNK.png&quot;"


### PR DESCRIPTION
echart eform has an outdated UI, this includes the add, current, and deleted pages connected to it. I have moved the MagentaHealth version of these pages and converted them into struts 2 version, I have also fixed an issue in the eForm generator functionality that stopped it from working at all in it's current state.


Note: I dont seem to be having this issue with my test eForms, maybe it was fixed in this branch? will have to test with latest dogfish version to confirm (https://github.com/openo-beta/Open-O/issues/644)

## Summary by Sourcery

Modernize and migrate eForm UI pages to Struts2 with updated styling and functionality, and restore eForm generator functionality.

New Features:
- Integrate DataTables for client-side pagination, sorting, and search on eForm listing pages.
- Adopt Bootstrap layouts and responsive HTML5 elements across eForm JSPs.

Bug Fixes:
- Correct quoting around the stamps.js script import in the eForm generator to re-enable its functionality.

Enhancements:
- Replace custom JSP pagination and layout with flexbox, JSTL tags, and OWASP encoding to improve security and maintainability.
- Consolidate repeated script, style, and taglib imports into centralized, updated web resources.