### PR TITLE
Add missing documentUpdate action mappings to ManageDocument2Action

### DIFF
--- a/src/main/java/ca/openosp/openo/documentManager/actions/ManageDocument2Action.java
+++ b/src/main/java/ca/openosp/openo/documentManager/actions/ManageDocument2Action.java
@@ -118,6 +118,8 @@ public class ManageDocument2Action extends ActionSupport {
         ACTIONS.put("display", ctx -> { ctx.display(); return null; });
         ACTIONS.put("viewAnnotationAcknowledgementTickler", ctx -> { ctx.viewAnnotationAcknowledgementTickler(); return null; });
         ACTIONS.put("viewDocumentDescription", ctx -> { ctx.viewDocumentDescription(); return null; });
+        ACTIONS.put("documentUpdate", ctx -> { ctx.documentUpdate(); return null; });
+        ACTIONS.put("documentUpdateAjax", ctx -> { ctx.documentUpdateAjax(); return null; });
         //  Enable calling the method to remove providers
         ACTIONS.put("removeLinkFromDocument", new ActionHandler() {
             public String handle(ManageDocument2Action action) {


### PR DESCRIPTION
## Summary
  - Adds missing `documentUpdate` and `documentUpdateAjax` action handler mappings to `ManageDocument2Action`
  - Fixes issue where document data was not saving due to unregistered action methods

  ## Problem
  The `ManageDocument2Action` class had `documentUpdate()` and `documentUpdateAjax()` methods implemented, but they were not registered in the `ACTIONS` map. This caused the action dispatcher to fail to route requests to these methods, resulting in document updates not being saved.

Closes #646

## Summary by Sourcery

Bug Fixes:
- Register missing documentUpdate and documentUpdateAjax action mappings in ManageDocument2Action to enable document updates