### PR TITLE
Fix inbox document uploads

### DIFF
--- a/src/main/java/ca/openosp/openo/documentManager/IncomingDocUtil.java
+++ b/src/main/java/ca/openosp/openo/documentManager/IncomingDocUtil.java
@@ -819,6 +819,10 @@ public final class IncomingDocUtil {
     }
 
     public static void doPagesAction(String pdfAction, String queueIdStr, String pdfDir, String pdfName, String pdfPageNumber, String pdfExtractPageNumber, Locale locale) throws Exception {
+        if (pdfAction == null || pdfAction.trim().isEmpty()) {
+            return;
+        }
+
         String filePathName = getIncomingDocumentFilePathName(queueIdStr, pdfDir, pdfName);
         ResourceBundle props = ResourceBundle.getBundle("oscarResources", locale);
         int degree = 0;

--- a/src/main/java/ca/openosp/openo/documentManager/actions/DocumentUpload2Action.java
+++ b/src/main/java/ca/openosp/openo/documentManager/actions/DocumentUpload2Action.java
@@ -75,7 +75,7 @@ public class DocumentUpload2Action extends ActionSupport {
         if (docFile == null) {
             map.put("error", 4);
         } else if (destination != null && destination.equals("incomingDocs")) {
-            String fileName = docFile.getName();
+            String fileName = this.filedataFileName;
             if (!fileName.toLowerCase().endsWith(".pdf")) {
                 map.put("error", props.getString("dms.documentUpload.onlyPdf"));
             } else if (docFile.length() == 0) {
@@ -110,7 +110,7 @@ public class DocumentUpload2Action extends ActionSupport {
             }
         } else {
             int numberOfPages = 0;
-            String fileName = MiscUtils.sanitizeFileName(docFile.getName());
+            String fileName = MiscUtils.sanitizeFileName(this.filedataFileName);
             String user = (String) request.getSession().getAttribute("user");
             SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd");
             EDoc newDoc = new EDoc("", "", fileName, "", user, user, this.getSource(), 'A',
@@ -278,12 +278,17 @@ public class DocumentUpload2Action extends ActionSupport {
                           .replaceAll("\"", "")         // Remove quotes
                           .replaceAll("\\*", "")        // Remove asterisks
                           .replaceAll("\\?", "");       // Remove question marks
-        
+
+        // Reject filenames starting with . (hidden files)
+        if (baseName.startsWith(".")) {
+            return null;
+        }
+
         // Ensure the filename ends with .pdf (case insensitive)
         if (!baseName.toLowerCase().endsWith(".pdf")) {
             return null;
         }
-        
+
         // Additional validation - ensure the filename is not empty after sanitization
         if (baseName.trim().isEmpty() || baseName.equals(".pdf")) {
             return null;
@@ -343,6 +348,8 @@ public class DocumentUpload2Action extends ActionSupport {
     private File docFile;
 
     private File filedata;
+    private String filedataFileName;
+    private String filedataContentType;
 
     private String docPublic = "";
     private String mode = "";
@@ -479,5 +486,21 @@ public class DocumentUpload2Action extends ActionSupport {
 
     public void setFiledata(File Filedata) {
         this.filedata = Filedata;
+    }
+
+    public String getFiledataFileName() {
+        return filedataFileName;
+    }
+
+    public void setFiledataFileName(String filedataFileName) {
+        this.filedataFileName = filedataFileName;
+    }
+
+    public String getFiledataContentType() {
+        return filedataContentType;
+    }
+
+    public void setFiledataContentType(String filedataContentType) {
+        this.filedataContentType = filedataContentType;
     }
 }

--- a/src/main/java/ca/openosp/openo/documentManager/actions/ManageDocument2Action.java
+++ b/src/main/java/ca/openosp/openo/documentManager/actions/ManageDocument2Action.java
@@ -118,6 +118,9 @@ public class ManageDocument2Action extends ActionSupport {
         ACTIONS.put("display", ctx -> { ctx.display(); return null; });
         ACTIONS.put("viewAnnotationAcknowledgementTickler", ctx -> { ctx.viewAnnotationAcknowledgementTickler(); return null; });
         ACTIONS.put("viewDocumentDescription", ctx -> { ctx.viewDocumentDescription(); return null; });
+        ACTIONS.put("viewIncomingDocPageAsPdf", ctx -> { ctx.viewIncomingDocPageAsPdf(); return null; });
+        ACTIONS.put("viewIncomingDocPageAsImage", ctx -> { ctx.viewIncomingDocPageAsImage(); return null; });
+        ACTIONS.put("displayIncomingDocs", ctx -> { ctx.displayIncomingDocs(); return null; });
         //  Enable calling the method to remove providers
         ACTIONS.put("removeLinkFromDocument", new ActionHandler() {
             public String handle(ManageDocument2Action action) {


### PR DESCRIPTION
## Changes made
- Use original file name in `DocumentUpload2Action` (not the "on disk" file name).
- Add null/empty file name check to `IncomingDocUtil`.
- Add `viewIncomingDocPageAsPdf`, `viewIncomingDocPageAsImage`, and `displayIncomingDocs` as actions in `ManageDocument2Action`.

## Summary by Sourcery

Fix inbox document uploads by preserving original file names, improving filename validation, preventing null page actions, and adding new view actions for incoming documents

New Features:
- Add actions to view incoming document pages as PDF and image and to display incoming documents in ManageDocument2Action

Bug Fixes:
- Use original uploaded file name instead of on-disk name in DocumentUpload2Action
- Guard against null or empty pdfAction in IncomingDocUtil.doPagesAction

Enhancements:
- Reject hidden filenames (starting with ‘.’) and enforce non-empty, .pdf-only base names during sanitization