### PR TITLE
Fix typo in JSON field name to resolve Patient MRP showing as undefined

### DIFF
--- a/src/main/java/ca/openosp/openo/commn/web/SearchDemographicAutoComplete2Action.java
+++ b/src/main/java/ca/openosp/openo/commn/web/SearchDemographicAutoComplete2Action.java
@@ -185,7 +185,7 @@ public class SearchDemographicAutoComplete2Action extends ActionSupport {
         for (int idx = 0; idx < size; ++idx) {
             record = info.get(idx);
             json.append("{\"label\":\"" + record.get("formattedName") + " " + record.get("fomattedDob") + " (" + record.get("status") + ")\",\"value\":\"" + record.get("demographicNo") + "\"");
-            json.append(",\"providerNo\":\"" + record.get("providerNo") + "\",\"providers\":\"" + record.get("providerName") + "\",\"nextAppt\":\"" + record.get("nextAppointment") + "\",");
+            json.append(",\"providerNo\":\"" + record.get("providerNo") + "\",\"provider\":\"" + record.get("providerName") + "\",\"nextAppt\":\"" + record.get("nextAppointment") + "\",");
             json.append("\"formattedName\":\"" + record.get("formattedName") + "\"}");
 
             if (idx < size - 1) {


### PR DESCRIPTION
### Issue
- When linking documents, the Patient’s MRP was showing as "undefined".  
- This was caused by a typo in the JSON field name: the code used `"providers"` instead of `"provider"`, which the JavaScript expected.

### Fix
- Corrected the typo by changing JSON key from `"providers"` → `"provider"`. 

Closes #650 