### PR TITLE
Fixed 404 error on demographiccontrol.jsp Search # hyperlink

### DIFF
--- a/src/main/webapp/demographic/demographiceditdemographic.js.jsp
+++ b/src/main/webapp/demographic/demographiceditdemographic.js.jsp
@@ -196,7 +196,7 @@ function referralScriptAttach2(elementName, name2) {
 var d = elementName;
 t0 = escape("document.forms[1].elements[\'"+d+"\'].value");
 t1 = escape("document.forms[1].elements[\'"+name2+"\'].value");
-rs('att',('../billing/CA/ON/searchRefDoc.jsp?param='+t0+'&param2='+t1),600,600,1);
+rs('att',('<%=request.getContextPath()%>/billing/CA/ON/searchRefDoc.jsp?param='+t0+'&param2='+t1),600,600,1);
 }
 function removeAccents(s){
 var r=s.toLowerCase();


### PR DESCRIPTION
Fixed 404 error on demographiccontrol.jsp Search # hyperlink

## Summary by Sourcery

Bug Fixes:
- Prepend the application context path to the searchRefDoc.jsp URL in demographiceditdemographic.js.jsp to prevent a 404 error