### PR TITLE
Fixed new document uploads don't display in the inbox

### DIFF
--- a/src/main/java/ca/openosp/openo/documentManager/actions/DocumentUpload2Action.java
+++ b/src/main/java/ca/openosp/openo/documentManager/actions/DocumentUpload2Action.java
@@ -72,9 +72,6 @@ public class DocumentUpload2Action extends ActionSupport {
         HashMap<String, Object> map = new HashMap<String, Object>();
         File docFile = this.getFiledata();
         String destination = request.getParameter("destination");
-
-        System.out.println("Destination: " + destination);
-
         ResourceBundle props = ResourceBundle.getBundle("oscarResources");
         if (docFile == null) {
             map.put("error", 4);


### PR DESCRIPTION
Fixed pending document upload to the currently selected provider not displaying in the inbox.

## Summary by Sourcery

Bug Fixes:
- Change the request parameter key from 'providers' to 'provider' when retrieving the provider ID in DocumentUpload2Action