### PR TITLE
Fix "providers" references in JSPs

### DIFF
--- a/dependencies-lock.json
+++ b/dependencies-lock.json
@@ -1405,11 +1405,11 @@
   }, {
     "groupId" : "net.java.dev.jna",
     "artifactId" : "jna",
-    "version" : "5.18.0",
+    "version" : "5.18.1",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:FQsMRq9urazfh8ZNyrEJ+sWotSJG6nARKnQlCkgDeAdVdyFCnIFBPE4DgTQcT2Wmvi83/HBlEzJ9ok1ukmPNTg=="
+    "integrity" : "sha512:6Fmqe/AyJdrN0EPGf5OeklDj4iPvAxoMtncXl0Ni6d8r0dnXBOe1LnQIIw8B2Ba6t+wadF2c8v6ybr2DmAJsfg=="
   }, {
     "groupId" : "net.sf.ezmorph",
     "artifactId" : "ezmorph",

--- a/src/main/webapp/billing/CA/BC/TeleplanSimulation.jsp
+++ b/src/main/webapp/billing/CA/BC/TeleplanSimulation.jsp
@@ -148,7 +148,7 @@
     <form action="${pageContext.request.contextPath}/billing/CA/BC/SimulateTeleplanFile.do"
                onsubmit="return checkSubmit();" class="form-inline">
         <label for="provider">Select provider</label>
-        <select id="provider" name="provider">
+        <select id="provider" name="providers">
             <option value="all">All Providers</option>
             <%
                 ProviderData pd = new ProviderData();

--- a/src/main/webapp/billing/CA/BC/TeleplanSubmission.jsp
+++ b/src/main/webapp/billing/CA/BC/TeleplanSubmission.jsp
@@ -171,7 +171,7 @@
                class="form-inline">
 
         Select provider
-        <select name="provider">
+        <select name="providers">
             <option value="all">All Providers</option>
             <%
                 ProviderData pd = new ProviderData();

--- a/src/main/webapp/billing/CA/BC/billingSim.jsp
+++ b/src/main/webapp/billing/CA/BC/billingSim.jsp
@@ -144,7 +144,7 @@
         <tr>
             <td width="220"><b><font face="Arial, Helvetica, sans-serif"
                                      size="2" color="#003366"> Select Provider </font></b></td>
-            <td width="254"><select name="provider">
+            <td width="254"><select name="providers">
                 <option value="%"><b>All Providers</b></option>
                 <%
                     String proFirst = "";

--- a/src/main/webapp/billing/CA/BC/billingTeleplanGroupReport.jsp
+++ b/src/main/webapp/billing/CA/BC/billingTeleplanGroupReport.jsp
@@ -196,7 +196,7 @@
             <td width="220"><b><font face="Arial, Helvetica, sans-serif"
                                      size="2" color="#003366">Select provider </font></b></td>
             <td width="254"><b><font face="Arial, Helvetica, sans-serif"
-                                     size="2" color="#003366"> <select name="provider">
+                                     size="2" color="#003366"> <select name="providers">
                 <option value="all">All Providers</option>
                 <%
                     String proFirst = "";

--- a/src/main/webapp/billing/CA/ON/addBatchBilling.jsp
+++ b/src/main/webapp/billing/CA/ON/addBatchBilling.jsp
@@ -204,7 +204,7 @@
                                     face="Verdana, Arial, Helvetica, sans-serif" size="1"
                                     color="#000000"><fmt:setBundle basename="oscarResources"/><fmt:message key="billing.batchbilling.billingProvider"/></font>
                             </td>
-                            <td width="50%"><select name="provider">
+                            <td width="50%"><select name="providers">
                                 <option value=""
                                         <%=request.getParameter("creator").equals("") ? "selected" : ""%>>Select
                                     Provider

--- a/src/main/webapp/billing/CA/ON/billingOHIPGroupReport.jsp
+++ b/src/main/webapp/billing/CA/ON/billingOHIPGroupReport.jsp
@@ -133,7 +133,7 @@
             <td width="220"><b><font face="Arial, Helvetica, sans-serif"
                                      size="2" color="#003366">Select provider </font></b></td>
             <td width="254"><b><font face="Arial, Helvetica, sans-serif"
-                                     size="2" color="#003366"> <select name="provider">
+                                     size="2" color="#003366"> <select name="providers">
                 <option value="all">All Providers</option>
                 <% String proFirst = "";
                     String proLast = "";

--- a/src/main/webapp/billing/CA/ON/billingOHIPsimulation.jsp
+++ b/src/main/webapp/billing/CA/ON/billingOHIPsimulation.jsp
@@ -331,7 +331,7 @@
 
                 <div class="span3">
                     Select Provider<br>
-                    <select name="provider">
+                    <select name="providers">
                         <% if (bMultisites) { %>
                         <option value="all">Select Providers</option>
                         <% } else { %>

--- a/src/main/webapp/billing/CA/ON/billingONMRI.jsp
+++ b/src/main/webapp/billing/CA/ON/billingONMRI.jsp
@@ -252,7 +252,7 @@
 
             <div class="span4">
                 Select Provider<br>
-                <select name="provider" onchange="setBillingCenter(this.value);">
+                <select name="providers" onchange="setBillingCenter(this.value);">
                     <%
                         List providerStr;
 

--- a/src/main/webapp/billing/CA/ON/inr/addINRbilling.jsp
+++ b/src/main/webapp/billing/CA/ON/inr/addINRbilling.jsp
@@ -161,7 +161,7 @@
                             <td width="29%"><font
                                     face="Verdana, Arial, Helvetica, sans-serif" size="1"
                                     color="#000000">Billing Provider</font></td>
-                            <td width="50%"><select name="provider">
+                            <td width="50%"><select name="providers">
                                 <option value=""
                                         <%=request.getParameter("creator").equals("") ? "selected" : ""%>>Select
                                     Provider

--- a/src/main/webapp/billing/CA/ON/specialtyBilling/fluBilling/addFluBilling.jsp
+++ b/src/main/webapp/billing/CA/ON/specialtyBilling/fluBilling/addFluBilling.jsp
@@ -463,7 +463,7 @@
                     <tr bgcolor="#DFDFEA">
                         <td width="19%"><font
                                 face="Verdana, Arial, Helvetica, sans-serif" size="1"
-                                color="#000000">Billing Provider <select name="provider">
+                                color="#000000">Billing Provider <select name="providers">
                             <option value=""
                                     <%=request.getParameter("mrp").equals("") ? "selected" : ""%>>Select
                                 Provider

--- a/src/main/webapp/documentManager/documentUploader.jsp
+++ b/src/main/webapp/documentManager/documentUploader.jsp
@@ -136,7 +136,7 @@
             <button id="cancel" type="reset" class="cancel">Cancel upload</button>
             <br>
             <span>
-				<input type="hidden" id="provider" name="provider" value="<%=provider%>"/>
+				<input type="hidden" id="provider" name="providers" value="<%=provider%>"/>
 				<input type="hidden" id="queue" name="queue" value="<%=queueId%>"/>
                                 <input type="hidden" id="destination" name="destination" value="<%=destination%>"/>
                                 <input type="hidden" id="destFolder" name="destFolder" value="<%=destFolder%>"/>

--- a/src/main/webapp/documentManager/documentUploaderFirefox36.jsp
+++ b/src/main/webapp/documentManager/documentUploaderFirefox36.jsp
@@ -78,7 +78,7 @@
         <div class="file_upload_buttons fileupload-buttonbar ui-widget-header ui-corner-top">
             <form action="<%=context%>/documentManager/documentUpload.do?method=executeUpload" method="POST"
                   enctype="multipart/form-data">
-                <input type="hidden" id="provider" name="provider" value="<%=provider%>"/>
+                <input type="hidden" id="provider" name="providers" value="<%=provider%>"/>
                 <input type="hidden" name="queue" value="<%=queueId%>"/>
                 <input type="file" name="filedata" multiple>
                 <button type="submit">Upload</button>

--- a/src/main/webapp/js/eform_highlight.js
+++ b/src/main/webapp/js/eform_highlight.js
@@ -33,7 +33,7 @@ function _refreshfields() {
 
     $.ajax({
         url: 'FetchUpdatedData.do?method=ajaxFetchData&demographic=' + demographic +
-            '&provider=' + provider + '&fields=' + fields,
+            '&providers=' + provider + '&fields=' + fields,
         dataType: 'json',
         success: function (data) {
             for (var s in data) {


### PR DESCRIPTION
## Changes made
- Fixed JSP references to `provider` or `providers` that did not align with the property name used by the corresponding Struts action class.
- Updated lock file.

## Summary by Sourcery

Align web form parameter naming with backend actions by changing 'provider' to 'providers' across JSPs and related script, and update the dependency lock file

Bug Fixes:
- Rename form parameter 'provider' to 'providers' in multiple JSP files to match Struts action property
- Update AJAX request in eform_highlight.js to use 'providers' parameter

Build:
- Regenerate dependencies-lock.json