### PR TITLE
Fixed 500 error on security log report

### DIFF
--- a/src/main/webapp/admin/logReport.jsp
+++ b/src/main/webapp/admin/logReport.jsp
@@ -74,9 +74,9 @@
     Properties propName = new Properties();
     // select providers list
     if (isSiteAccessPrivacy) {
-        sql = "select p.* from providers p INNER JOIN providersite s ON p.provider_no = s.provider_no WHERE s.site_id IN (SELECT site_id from providersite where provider_no=" + curUser_no + ") order by p.first_name, p.last_name";
+        sql = "select p.* from provider p INNER JOIN providersite s ON p.provider_no = s.provider_no WHERE s.site_id IN (SELECT site_id from providersite where provider_no=" + curUser_no + ") order by p.first_name, p.last_name";
     } else {
-        sql = "select * from providers p order by p.first_name, p.last_name ";
+        sql = "select * from provider p order by p.first_name, p.last_name ";
     }
     ResultSet rs = dbObj.queryResults(sql);
 


### PR DESCRIPTION
Fixed 500 error on security log report due to incorrect db table name

## Summary by Sourcery

Bug Fixes:
- Resolve 500 error on security log report by correcting the database table name in SQL queries