### PR TITLE
Fixed searching for allergies 404 error (and other issues with lookup)

### DIFF
--- a/src/main/java/ca/openosp/openo/prescript/pageUtil/RxSearchAllergy2Action.java
+++ b/src/main/java/ca/openosp/openo/prescript/pageUtil/RxSearchAllergy2Action.java
@@ -77,21 +77,17 @@ public final class RxSearchAllergy2Action extends ActionSupport {
         String jsondata = request.getParameter("jsonData");
         if (jsondata != null) {
             RxSearchAllergy2Form frm = (RxSearchAllergy2Form) JsonUtil.jsonToPojo(jsondata, RxSearchAllergy2Form.class);
+
             this.setType1(frm.getType1());
             this.setType2(frm.getType2());
             this.setType3(frm.getType3());
             this.setType4(frm.getType4());
             this.setType5(frm.getType5());
+            this.setSearchString(frm.getSearchString());
         }
-
-        RxAllergyData aData = new RxAllergyData();
-        //RxAllergyData.Allergy[] arr =
-        //    aData.AllergySearch(frm.getSearchString(), frm.getType5(),
-        //    frm.getType4(), frm.getType3(), frm.getType2(), frm.getType1());
 
 
         ///Search a drug like another one
-
         RxDrugRef drugRef = new RxDrugRef();
 
         java.util.Vector vec = new java.util.Vector();
@@ -135,6 +131,7 @@ public final class RxSearchAllergy2Action extends ActionSupport {
         boolean itemsFound = true;
 
         String wildcardRightOnly = OscarProperties.getInstance().getProperty("allergies.search_right_wildcard_only", "false");
+        
         vec = drugRef.list_search_element_select_categories(this.getSearchString(), catVec, Boolean.valueOf(wildcardRightOnly));
 
         //  'id':'0','category':'','name'
@@ -147,13 +144,13 @@ public final class RxSearchAllergy2Action extends ActionSupport {
         TreeMap<String, Allergy> flatList = new TreeMap<String, Allergy>();
 
         //we want to categorize the search results.
-        Map<Integer, List<Allergy>> allergyResults = new HashMap<Integer, List<Allergy>>();
-        allergyResults.put(8, new ArrayList<Allergy>());
-        allergyResults.put(10, new ArrayList<Allergy>());
-        allergyResults.put(11, new ArrayList<Allergy>());
-        allergyResults.put(12, new ArrayList<Allergy>());
-        allergyResults.put(13, new ArrayList<Allergy>());
-        allergyResults.put(14, new ArrayList<Allergy>());
+        Map<String, List<Allergy>> allergyResults = new HashMap<String, List<Allergy>>();
+        allergyResults.put("8", new ArrayList<Allergy>());
+        allergyResults.put("10", new ArrayList<Allergy>());
+        allergyResults.put("11", new ArrayList<Allergy>());
+        allergyResults.put("12", new ArrayList<Allergy>());
+        allergyResults.put("13", new ArrayList<Allergy>());
+        allergyResults.put("14", new ArrayList<Allergy>());
 
         Map<Integer, Allergy> classResults = new HashMap<Integer, Allergy>();
 
@@ -171,7 +168,7 @@ public final class RxSearchAllergy2Action extends ActionSupport {
                     classVec.add("" + arr[i].getDrugrefId());
                 }
 
-                allergyResults.get(hash.get("category")).add(arr[i]);
+                allergyResults.get(String.valueOf(hash.get("category"))).add(arr[i]);
                 if (flatList.get(arr[i].getDescription()) == null) {
                     flatList.put(arr[i].getDescription(), arr[i]);
                 }

--- a/src/main/java/ca/openosp/openo/prescript/pageUtil/RxSearchAllergy2Form.java
+++ b/src/main/java/ca/openosp/openo/prescript/pageUtil/RxSearchAllergy2Form.java
@@ -35,6 +35,10 @@ public final class RxSearchAllergy2Form {
     private boolean type2 = false;
     private boolean type1 = false;
 
+    private String iNKDA;
+    private String hasDrugAllergy;
+    private String submit;
+
     public String getSearchString() {
         return (this.searchString);
     }
@@ -81,5 +85,29 @@ public final class RxSearchAllergy2Form {
 
     public void setType1(boolean RHS) {
         this.type1 = RHS;
+    }
+
+    public String getiNKDA() {
+        return iNKDA;
+    }
+
+    public void setiNKDA(String iNKDA) {
+        this.iNKDA = iNKDA;
+    }
+
+    public String getHasDrugAllergy() {
+        return hasDrugAllergy;
+    }
+
+    public void setHasDrugAllergy(String hasDrugAllergy) {
+        this.hasDrugAllergy = hasDrugAllergy;
+    }
+
+    public String getSubmit() {
+        return submit;
+    }
+
+    public void setSubmit(String submit) {
+        this.submit = submit;
     }
 }

--- a/src/main/webapp/oscarRx/ChooseAllergy2.jsp
+++ b/src/main/webapp/oscarRx/ChooseAllergy2.jsp
@@ -40,7 +40,6 @@
 %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
-
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@page import="java.util.*" %>
 <%@ page import="ca.openosp.openo.prescript.pageUtil.RxSessionBean" %>
@@ -263,7 +262,7 @@
 
                                                     <!-- 分层显示不同类型过敏分类 -->
                                                     <c:if test="${!flatResults}">
-                                                        <c:forEach var="type" items="${[8, 10, 13, 11, 12, 14]}">
+                                                        <c:forEach var="type" items="${['8', '10', '13', '11', '12', '14']}">
                                                             <c:if test="${not empty allergyResults[type]}">
                                                                 <div class="DivContentSectionHead">
                                                                     <a href="javascript:void(0)" onclick="toggleSection('${type}');return false;">

--- a/src/main/webapp/oscarRx/ShowAllergies2.jsp
+++ b/src/main/webapp/oscarRx/ShowAllergies2.jsp
@@ -186,7 +186,7 @@
                     if (isEmpty()) {
                         $(".highLightButton").removeClass("highLightButton");
                         var form = $("#searchAllergy2");
-                        var url = "${ pageContext.servletContext.contextPath }" + form.attr('action');
+                        var url = form.attr('action');
                         var params = form.serializeArray();
                         var json = {};
                         $.each(params, function () {


### PR DESCRIPTION
Fully fixed allergy search (404, null values, empty front end updates)

## Summary by Sourcery

Restore and fix allergy search functionality by adding missing form fields, mapping search parameters correctly, aligning category key types between backend and frontend, and correcting the search request URL to prevent 404 errors.

Bug Fixes:
- Add iNKDA, hasDrugAllergy, and submit fields to RxSearchAllergy2Form to avoid null parameter errors
- Apply searchString from JSON payload in RxSearchAllergy2Action to ensure proper query execution
- Convert allergy category map keys to strings for consistency with JSP lookups
- Remove redundant contextPath prefix in ShowAllergies2.jsp form action to fix 404 on submission