### PR TITLE
Fixed eForm convert to edoc broken (672, 675, 676)

### DIFF
--- a/src/main/java/ca/openosp/openo/documentManager/ConvertToEdoc.java
+++ b/src/main/java/ca/openosp/openo/documentManager/ConvertToEdoc.java
@@ -323,7 +323,10 @@ public final class ConvertToEdoc {
                 fallbackRender(document, os);
             } catch (Exception fallbackError) {
                 logger.error("Fallback PDF conversion also failed", fallbackError);
-                DocumentException docEx = new DocumentException("PDF conversion failed with all methods");
+                String combinedMessage = "PDF conversion failed with all methods. "
+                        + "Primary error: " + e.getMessage()
+                        + "; Fallback error: " + fallbackError.getMessage();
+                DocumentException docEx = new DocumentException(combinedMessage);
                 docEx.initCause(fallbackError);
                 throw docEx;
             }

--- a/src/main/java/ca/openosp/openo/documentManager/EDocUtil.java
+++ b/src/main/java/ca/openosp/openo/documentManager/EDocUtil.java
@@ -1229,7 +1229,7 @@ public final class EDocUtil {
             if (!canonicalPath.startsWith(canonicalDocDir + File.separator) && 
                 !canonicalPath.startsWith(canonicalTempDir + File.separator)) {
                 logger.warn("Path is outside of the allowed directories: " + fileName);
-                throw new SecurityException("Access denied: File is outside the allowed directoires");
+                throw new SecurityException("Access denied: File is outside the allowed directories");
             }
             
             return canonicalPath;

--- a/src/main/java/ca/openosp/openo/documentManager/EDocUtil.java
+++ b/src/main/java/ca/openosp/openo/documentManager/EDocUtil.java
@@ -52,6 +52,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 import org.apache.pdfbox.pdmodel.PDDocument;
+
 import ca.openosp.openo.PMmodule.caisi_integrator.CaisiIntegratorManager;
 import ca.openosp.openo.PMmodule.caisi_integrator.IntegratorFallBackManager;
 import ca.openosp.openo.PMmodule.dao.ProviderDao;
@@ -1214,25 +1215,21 @@ public final class EDocUtil {
         
         try {
             String docDir = OscarProperties.getInstance().getProperty("DOCUMENT_DIR");
-            if (docDir == null || docDir.trim().isEmpty()) {
-                throw new IllegalStateException("DOCUMENT_DIR is not configured");
-            }
-            
+
             File documentDir = new File(docDir);
             String canonicalDocDir = documentDir.getCanonicalPath();
-            
-            String baseFileName = inputPath.getFileName().toString();
-            
-            // Always resolve the file within the document directory
-            File file = new File(documentDir, baseFileName);
-            
+
+            String canonicalTempDir = new File(System.getProperty("java.io.tmpdir")).getCanonicalPath(); 
+
             // Get the canonical path to resolve any symbolic links or relative paths
-            String canonicalPath = file.getCanonicalPath();
+            File inputFile = inputPath.toFile();
+            String canonicalPath = inputFile.getCanonicalPath();
             
             // Validate that the resolved path is within the allowed document directory
-            if (!canonicalPath.startsWith(canonicalDocDir + File.separator)) {
-                logger.warn("Path is outside of the document directory: " + fileName);
-                throw new SecurityException("Access denied: File is outside the document directory");
+            if (!canonicalPath.startsWith(canonicalDocDir + File.separator) && 
+                !canonicalPath.startsWith(canonicalTempDir + File.separator)) {
+                logger.warn("Path is outside of the allowed directories: " + fileName);
+                throw new SecurityException("Access denied: File is outside the allowed directoires");
             }
             
             return canonicalPath;

--- a/src/main/java/ca/openosp/openo/documentManager/ReplacedElementFactoryImpl.java
+++ b/src/main/java/ca/openosp/openo/documentManager/ReplacedElementFactoryImpl.java
@@ -87,33 +87,11 @@ public class ReplacedElementFactoryImpl implements ReplacedElementFactory {
     }
 
     protected final FSImage imageForPDF(String attribute, UserAgentCallback uac) throws IOException, BadElementException {
-        FSImage fsImage = null;
-
-        // Handle data URIs (base64 encoded images)
-        if (attribute != null && attribute.startsWith("data:")) {
-            try {
-                String base64Data = attribute.substring(attribute.indexOf(",") + 1);
-                byte[] decodedBytes = java.util.Base64.getDecoder().decode(base64Data);
-                Image image = Image.getInstance(decodedBytes);
-                fsImage = new ITextFSImage(image);
-                return fsImage;
-            } catch (Exception e) {
-                logger.warn("Failed to decode data URI image: " + e.getMessage());
-                return null;
-            }
-        }
-
-        // Handle file paths
-        if (attribute != null && !attribute.isEmpty()) {
-            try (InputStream input = new FileInputStream(attribute)) {
-                byte[] bytes = IOUtils.toByteArray(input);
-                Image image = Image.getInstance(bytes);
-                fsImage = new ITextFSImage(image);
-            } catch (Exception e) {
-                logger.warn("Failed to load image from file: " + attribute + " - " + e.getMessage());
-                // Try with a placeholder image or just return null
-                return null;
-            }
+        FSImage fsImage;
+        try (InputStream input = new FileInputStream(attribute)) {
+            byte[] bytes = IOUtils.toByteArray(input);
+            Image image = Image.getInstance(bytes);
+            fsImage = new ITextFSImage(image);
         }
 
         return fsImage;

--- a/src/main/java/ca/openosp/openo/eform/actions/AddEForm2Action.java
+++ b/src/main/java/ca/openosp/openo/eform/actions/AddEForm2Action.java
@@ -304,7 +304,6 @@ public class AddEForm2Action extends ActionSupport {
                 /*
                  * For now, this download code is added here and will be moved to the appropriate place after refactoring is done.
                  */
-                String path = request.getContextPath() + "/eform/efmshowform_data.jsp?fdid=" + fdid + "&parentAjaxId=eforms";
                 String fileName = generateFileName(loggedInInfo, Integer.parseInt(demographic_no));
                 String pdfBase64 = "";
                 try {
@@ -321,14 +320,12 @@ public class AddEForm2Action extends ActionSupport {
                 request.setAttribute("eFormPDFName", fileName);
                 request.setAttribute("isDownload", "true");
 
-                try {
-                    response.sendRedirect(path);
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
-                }
-                return NONE;
+                request.setAttribute("fdid", fdid);
+                request.setAttribute("parentAjaxId", "eforms");
+
+                return "download";
             } else if (isEmailEForm) {
-                String path = "/email/emailComposeAction.do?method=prepareComposeEFormMailer";
+                String path = request.getContextPath() + "/email/emailComposeAction.do?method=prepareComposeEFormMailer";
                 addEmailAttachments(request, attachedEForms, attachedDocuments, attachedLabs, attachedHRMDocuments, attachedForms);
                 try {
                     response.sendRedirect(path);
@@ -384,7 +381,6 @@ public class AddEForm2Action extends ActionSupport {
                 /*
                  * For now, this download code is added here and will be moved to the appropriate place after refactoring is done.
                  */
-                String path = request.getContextPath() + "/eform/efmshowform_data.jsp?fdid=" + prev_fdid + "&parentAjaxId=eforms";
                 String fileName = generateFileName(loggedInInfo, Integer.parseInt(demographic_no));
                 String pdfBase64 = "";
                 try {
@@ -401,14 +397,12 @@ public class AddEForm2Action extends ActionSupport {
                 request.setAttribute("eFormPDFName", fileName);
                 request.setAttribute("isDownload", "true");
 
-                try {
-                    response.sendRedirect(path);
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
-                }
-                return NONE;
+                request.setAttribute("fdid", prev_fdid);
+                request.setAttribute("parentAjaxId", "eforms");
+
+                return "download";
             } else if (isEmailEForm) {
-                String path = "/email/emailComposeAction.do?method=prepareComposeEFormMailer";
+                String path = request.getContextPath() + "/email/emailComposeAction.do?method=prepareComposeEFormMailer";
                 addEmailAttachments(request, attachedEForms, attachedDocuments, attachedLabs, attachedHRMDocuments, attachedForms);
                 try {
                     response.sendRedirect(path);
@@ -442,7 +436,6 @@ public class AddEForm2Action extends ActionSupport {
 		}
 
         String fdid = (String) request.getAttribute("fdid");
-        String path = request.getContextPath() + "/eform/efmshowform_data.jsp?fdid=" + fdid + "&parentAjaxId=eforms";
 
 		String pdfBase64;
 		try {
@@ -459,12 +452,10 @@ public class AddEForm2Action extends ActionSupport {
 		request.setAttribute("eFormPDFName", generateFileName(loggedInInfo, Integer.parseInt(demographic_no)));
 		request.setAttribute("isSuccess_Autoclose", "true");
 
-        try {
-            response.sendRedirect(path);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-        return NONE;
+        request.setAttribute("fdid", fdid);
+        request.setAttribute("parentAjaxId", "eforms");
+
+        return "close";
 	}
 	
 	private String generateFileName(LoggedInInfo loggedInInfo, int demographicNo) {

--- a/src/main/java/ca/openosp/openo/eform/actions/DisplayImage2Action.java
+++ b/src/main/java/ca/openosp/openo/eform/actions/DisplayImage2Action.java
@@ -68,7 +68,7 @@ public class DisplayImage2Action extends ActionSupport {
             response.setContentType(contentType);
             OutputStream outputStream = response.getOutputStream();
             IOUtils.copy(stream, outputStream);
-            return SUCCESS;
+            return NONE;
         } catch (Exception e) {
             return NONE;
         } finally {

--- a/src/main/webapp/WEB-INF/classes/struts.xml
+++ b/src/main/webapp/WEB-INF/classes/struts.xml
@@ -1554,7 +1554,7 @@
             <result name="success">/eform/efmformrtl_config.jsp</result>
         </action>
         <action name="eform/addEForm" class="ca.openosp.openo.eform.actions.AddEForm2Action">
-            <result name="close">/eform/efmclosewindow.jsp</result>
+            <result name="close">/eform/efmshowform_data.jsp</result>
             <result name="fax">/fax/faxAction.do</result>
             <result name="download">/eform/efmshowform_data.jsp</result>
             <result name="error">/eform/efmshowform_data.jsp?error=true</result>

--- a/src/main/webapp/eform/efmshowform_data.jsp
+++ b/src/main/webapp/eform/efmshowform_data.jsp
@@ -137,6 +137,7 @@
     eForm.addHiddenInputElement("eFormPDF", (String) request.getAttribute("eFormPDF"));
     eForm.addHiddenInputElement("isDownloadEForm", (String) request.getAttribute("isDownload"));
     eForm.addHiddenInputElement("newForm", "false");
+    eForm.addHiddenInputElement("isSuccess_Autoclose", (String) request.getAttribute("isSuccess_Autoclose"));
     // Add EForm attachments
     LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
     addHiddenEFormAttachments(loggedInInfo, eForm, fdid);


### PR DESCRIPTION
Fixed eForm convert to edoc broken (issues 672, 675, 676)

## Summary by Sourcery

Overhaul eForm-to-EDoc conversion: introduce default and configurable wkhtmltopdf settings, add robust fallback using Flying Saucer with XHTML preprocessing, refactor ExternalEDocConverter error handling, improve HTML parsing, and fix broken eForm download/close flows by updating Struts actions and JSP mappings.

New Features:
- Added fallback PDF conversion path using Flying Saucer with strict XHTML preprocessing
- Introduced default wkhtmltopdf command and args configurable via properties

Bug Fixes:
- Restore eForm download and close flows by replacing redirects with Struts action results and setting necessary request attributes
- Corrected DisplayImage2Action to return NONE instead of SUCCESS
- Extend file path resolution to include system temp directory

Enhancements:
- Refactored ExternalEDocConverter to instantiate commands per execution, separate stderr, and improve error reporting
- Hardened HTML parsing settings for XHTML compliance in getDocument and conversion prep

Chores:
- Refined logging levels and removed obsolete contextPath usage