### PR TITLE
Fixed MRP and next appointment date not being set on eChart header correctly

### DIFF
--- a/src/main/java/ca/openosp/openo/managers/DemographicManagerImpl.java
+++ b/src/main/java/ca/openosp/openo/managers/DemographicManagerImpl.java
@@ -116,7 +116,7 @@ public class DemographicManagerImpl implements DemographicManager {
 
     /**
 	 *  Get the patient demographic profile.
-	 *  This method also sets the Demographic.MRP and Demographic.nextAppointment
+	 *  This particular method also sets the Demographic.MRP and Demographic.nextAppointment
 	 *  properties.
 	 * @param loggedInInfo
 	 * @param demographicId


### PR DESCRIPTION
Fixed MRP and next appointment date not being set since magenta main changes were missing to getDemographic methods in manager impl

## Summary by Sourcery

Ensure that the DemographicManagerImpl.getDemographic method populates the MRP and next appointment date on the eChart header by invoking the appropriate helper methods.

Bug Fixes:
- Populate missing Demographic.MRP and nextAppointment fields when retrieving a patient demographic.

Enhancements:
- Add JavaDoc to the overloaded getDemographic methods to document MRP and nextAppointment behavior.