### PR TITLE
Fixed lab recall settings deletion functionality that gave a 500 error

### DIFF
--- a/src/main/java/ca/openosp/openo/provider/web/ProviderProperty2Action.java
+++ b/src/main/java/ca/openosp/openo/provider/web/ProviderProperty2Action.java
@@ -1724,7 +1724,7 @@ public class ProviderProperty2Action extends ActionSupport {
 
         String msgSuccess = "provider.setLabRecall.msgSuccess";
         if (delete) {
-            msgSuccess = "providers.setLabRecall.msgDeleted";
+            msgSuccess = "provider.setLabRecall.msgDeleted";
         }
         request.setAttribute("providermsgSuccess", msgSuccess);
         request.setAttribute("method", "saveLabRecallPrefs");


### PR DESCRIPTION
Fixed lab recall settings deletion functionality giving 500 error

## Summary by Sourcery

Bug Fixes:
- Correct the deletion message key from 'providers.setLabRecall.msgDeleted' to 'provider.setLabRecall.msgDeleted'