### PR TITLE
Fixed billing reconciliation 404 error, and all other incorrect servlet paths with old oscar namespace

### DIFF
--- a/src/main/webapp/admin/admin.jsp
+++ b/src/main/webapp/admin/admin.jsp
@@ -353,7 +353,7 @@
                     <li><a href="#" onclick='popupPage(600,900, "${pageContext.request.contextPath}/billing/CA/ON/viewMOHFiles.jsp");return false;'><fmt:setBundle basename="oscarResources"/><fmt:message key="admin.admin.viewMOHFiles"/></a></li>
                     <% } %>
                     <li><a href="#"
-                           onclick='popupPage(600,900, "${pageContext.request.contextPath}/servlet/oscar.DocumentUploadServlet");return false;'><fmt:setBundle basename="oscarResources"/><fmt:message key="admin.admin.btnBillingReconciliation"/></a></li>
+                           onclick='popupPage(600,900, "${pageContext.request.contextPath}/servlet/ca.openosp.DocumentUploadServlet");return false;'><fmt:setBundle basename="oscarResources"/><fmt:message key="admin.admin.btnBillingReconciliation"/></a></li>
                     <!-- li><a href="#" onclick ='popupPage(600,900,"${pageContext.request.contextPath}/billing/CA/ON/billingRA.jsp");return false;'><fmt:setBundle basename="oscarResources"/><fmt:message key="admin.admin.btnBillingReconciliation"/></a></li-->
                     <!-- li><a href="#" onclick ='popupPage(600,1000,"${pageContext.request.contextPath}/billing/CA/ON/billingOBECEA.jsp");return false;'><fmt:setBundle basename="oscarResources"/><fmt:message key="admin.admin.btnEDTBillingReportGenerator"/></a></li-->
                     <li>

--- a/src/main/webapp/administration/leftNav.jspf
+++ b/src/main/webapp/administration/leftNav.jspf
@@ -205,7 +205,7 @@ String curProvider_no = (String)session.getAttribute("user");
 					</li>
 					</oscar:oscarPropertiesCheck>
 					<li><a href='javascript:void(0);'
-						class="xlink" rel="${ctx}/servlet/oscar.DocumentUploadServlet"><fmt:setBundle basename="oscarResources"/><fmt:message key="admin.admin.btnBillingReconciliation"/></a></li>                       
+						class="xlink" rel="${ctx}/servlet/ca.openosp.DocumentUploadServlet"><fmt:setBundle basename="oscarResources"/><fmt:message key="admin.admin.btnBillingReconciliation"/></a></li>                       
 		                        <!--  li><a href='javascript:void(0);' onclick ='popupPage(600,900,"${ctx}/billing/CA/ON/billingRA.jsp");return false;'><fmt:setBundle basename="oscarResources"/><fmt:message key="admin.admin.btnBillingReconciliation"/></a></li-->
 					<!--  li><a href='javascript:void(0);' onclick ='popupPage(600,1000,"${ctx}/billing/CA/ON/billingOBECEA.jsp");return false;'><fmt:setBundle basename="oscarResources"/><fmt:message key="admin.admin.btnEDTBillingReportGenerator"/></a></li-->
 					<li><a href='javascript:void(0);'

--- a/src/main/webapp/billing/CA/ON/billingONUpload.jsp
+++ b/src/main/webapp/billing/CA/ON/billingONUpload.jsp
@@ -43,10 +43,10 @@
             }
             if (val1.substring(0, 1) == "P" || val1.substring(0, 1) == "S") {
                 if (document.all) {
-                    document.all.form1.action = "../../../servlet/oscar.DocumentUploadServlet";
+                    document.all.form1.action = "${pageContext.request.contextPath}/servlet/ca.openosp.DocumentUploadServlet";
                     document.all.form1.submit();
                 } else {
-                    document.getElementById('form1').action = "../../../servlet/oscar.DocumentUploadServlet";
+                    document.getElementById('form1').action = "${pageContext.request.contextPath}/servlet/ca.openosp.DocumentUploadServlet";
                     document.getElementById('form1').submit();
                 }
             } else {

--- a/src/main/webapp/billing/CA/ON/billingRA.jsp
+++ b/src/main/webapp/billing/CA/ON/billingRA.jsp
@@ -52,7 +52,7 @@
 <p>
 <table width="400" border="0">
     <form name="form1" method="post"
-          action="../../../servlet/oscar.DocumentUploadServlet"
+          action="${pageContext.request.contextPath}/servlet/ca.openosp.DocumentUploadServlet"
           ENCTYPE="multipart/form-data" onsubmit="return onSubmit();">
         <tr>
             <td width="181"><b><font face="Arial, Helvetica, sans-serif"

--- a/src/main/webapp/billing/CA/ON/viewMOHFiles.jsp
+++ b/src/main/webapp/billing/CA/ON/viewMOHFiles.jsp
@@ -44,7 +44,7 @@
                 location.href = "<%= request.getContextPath() %>/billing/CA/ON/viewMOHFiles.jsp";
                 return;
             } else if (fileType == "P" || fileType == "S") {
-                form.action = "/<%= OscarProperties.getInstance().getProperty("project_home") %>/servlet/oscar.DocumentUploadServlet";
+                form.action = "/<%= OscarProperties.getInstance().getProperty("project_home") %>/servlet/ca.openosp.DocumentUploadServlet";
             } else if (fileType == "L") {
                 form.action = "<%= request.getContextPath() %>/billing/CA/ON/billingLreport.jsp";
             } else {


### PR DESCRIPTION
Fixed all references to old document upload servlet package name of oscar to new openosp naming convention, this fixed the 404 on the admin panel

## Summary by Sourcery

Bug Fixes:
- Replace all occurrences of oscar.DocumentUploadServlet with ca.openosp.DocumentUploadServlet in JSPs to fix billing reconciliation and related servlet path errors