### PR TITLE
Pin JPA/Hibernate transitive dependencies

### DIFF
--- a/dependencies-lock.json
+++ b/dependencies-lock.json
@@ -2532,6 +2532,14 @@
     "optional" : false,
     "integrity" : "sha512:WfdHiP4J9vkf3NogVylOHrdy6zL0DO4HtIELxMsa39oVUrt6+gfFbb17xzdp77vPD4BtikWrpigV1GXC79RNeg=="
   }, {
+    "groupId" : "org.apiguardian",
+    "artifactId" : "apiguardian-api",
+    "version" : "1.1.2",
+    "scope" : "test",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:18zQ5wGfGpl9451m3ArU7+FQQo/df0x0PJOITxYCo+kBNa00uuqW1bbZJa1sDISHyOeDBPCgiaEjg9SmLiyaYQ=="
+  }, {
     "groupId" : "org.aspectj",
     "artifactId" : "aspectjweaver",
     "version" : "1.9.7",
@@ -3084,6 +3092,54 @@
     "optional" : false,
     "integrity" : "sha512:797THvWzQvCUIpNQduWZeJB2Qx6Tp0ZoXAYH595VknGbpqrN4L5nCz8GTR6FYw1Y1bzms0rtKiiP2zT3Re+3vA=="
   }, {
+    "groupId" : "org.junit.jupiter",
+    "artifactId" : "junit-jupiter-api",
+    "version" : "5.10.1",
+    "scope" : "test",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:sf70TUqngbsRmrcjw8Km8NJ+/ESTofomtgPHx6iITE1idLzOxlNvEg1V+Hb40FKq9swAMHTCfMcE3rLEvAi28A=="
+  }, {
+    "groupId" : "org.junit.jupiter",
+    "artifactId" : "junit-jupiter-engine",
+    "version" : "5.10.1",
+    "scope" : "test",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:H8yUBtHgMB4nU4dXyWSVRdeE6DdDqIAJMpcYgc/XihSiZK0TwLkvrZrhvlCWPFQEJ6GcstH+4GiI70gQWq1Miw=="
+  }, {
+    "groupId" : "org.junit.jupiter",
+    "artifactId" : "junit-jupiter-params",
+    "version" : "5.10.1",
+    "scope" : "test",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:29ijvKCgO27vVN4rSJaFyBJeDG8jy9tjMXSyHgfMe5eiS1XctbYOwaSWaDqRi/3x6gRZlQaJ43VaqWXqnhBu6Q=="
+  }, {
+    "groupId" : "org.junit.jupiter",
+    "artifactId" : "junit-jupiter",
+    "version" : "5.10.1",
+    "scope" : "test",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:yXovnu+m80RB/AyXdEhzBAu+SdM1lU7atDurJYdqM/Sz8RNHRZQgVp72YESXKKoJO7rl1CwPpzOgtiRwa1emXQ=="
+  }, {
+    "groupId" : "org.junit.platform",
+    "artifactId" : "junit-platform-commons",
+    "version" : "1.10.1",
+    "scope" : "test",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:SqgzUOem3yH+ubqHVrtKaJhvM/jG44RyDR2qRIREAWwN7xeBcpeI4+iEZkq9ZwOx48Dsa3mJOp1WRcOkgJwK0g=="
+  }, {
+    "groupId" : "org.junit.platform",
+    "artifactId" : "junit-platform-engine",
+    "version" : "1.10.1",
+    "scope" : "test",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:UuovEewu8EVzhDNdGwkmP07+z2PZ35nF+DlvdNlycixR+PdmNw6F4DD0R26AXaxyYDKWlCWTxbvlaZNFS52OMA=="
+  }, {
     "groupId" : "org.jvnet.mimepull",
     "artifactId" : "mimepull",
     "version" : "1.9.13",
@@ -3107,6 +3163,14 @@
     "type" : "jar",
     "optional" : false,
     "integrity" : "sha512:fYNi4VyUGo/MBw9AsUwAEf6UW+hVta8qNRKS3UadOg56kk4m6+lmBQ3RMEFdBGXeGx73cUFcGvSCLQnA9SKcGw=="
+  }, {
+    "groupId" : "org.mockito",
+    "artifactId" : "mockito-junit-jupiter",
+    "version" : "5.8.0",
+    "scope" : "test",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:B6gVYC1OcTt862fwXNN5R2unbOdQFnjP20asjNMBaZ01e6x5rhtNgbh3E5Tt34qOPOuhZfcfQ+rm4a8/hRQVZA=="
   }, {
     "groupId" : "org.mozilla",
     "artifactId" : "rhino",
@@ -3227,6 +3291,14 @@
     "type" : "jar",
     "optional" : false,
     "integrity" : "sha512:DW9IfOyQ7JMfzwFeQnWNkKy8BW2rILzLiJc3Ml/HRD7l7zvlHQKBQO9CQxNWLTfu0Kvnlfr7u1oWrjPpQ/EElg=="
+  }, {
+    "groupId" : "org.opentest4j",
+    "artifactId" : "opentest4j",
+    "version" : "1.3.0",
+    "scope" : "test",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:ePxpinhxu1AwXjZXiTwQUAWV8EM0jYdfV7w5ykpqUe2jlnt8jIp+w+j4XyFxvKSqmII+kS5BbofoHGultwo3ww=="
   }, {
     "groupId" : "org.ow2.asm",
     "artifactId" : "asm",

--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,32 @@
                 <artifactId>mina-core</artifactId>
                 <version>2.1.10</version>
             </dependency>
+
+            <!-- Transitive Hibernate/JPA dependencies -->
+            <!-- Hibernate core -->
+            <dependency>
+                <groupId>org.hibernate</groupId>
+                <artifactId>hibernate-core</artifactId>
+                <version>5.6.15.Final</version>
+            </dependency>
+            <!-- Hibernate commons annotations - transitive from hibernate-core -->
+            <dependency>
+                <groupId>org.hibernate.common</groupId>
+                <artifactId>hibernate-commons-annotations</artifactId>
+                <version>5.1.2.Final</version>
+            </dependency>
+            <!-- JPA API (javax namespace) - transitive from Hibernate 5.x -->
+            <dependency>
+                <groupId>javax.persistence</groupId>
+                <artifactId>javax.persistence-api</artifactId>
+                <version>2.2</version>
+            </dependency>
+            <!-- JPA API (jakarta namespace) - transitive from jaxws-ri -->
+            <dependency>
+                <groupId>jakarta.persistence</groupId>
+                <artifactId>jakarta.persistence-api</artifactId>
+                <version>2.2.3</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
## Changes made
- Pin Hibernate and JPA dependencies to ensure consistent builds.

## Summary by Sourcery

Pin JPA and Hibernate transitive dependencies to specific versions in pom.xml and refresh the dependency lock file to ensure consistent builds

Enhancements:
- Add explicit dependency entries for hibernate-core, hibernate-commons-annotations, javax.persistence-api, and jakarta.persistence-api

Build:
- Update pom.xml dependencyManagement with fixed versions for transitive dependencies
- Refresh dependencies-lock.json to reflect the pinned versions