### PR TITLE
733 Inbox bean message visible, also fixed other bean:message references to fmt:message in the project

### DIFF
--- a/src/main/webapp/admin/manageFlowsheets.jsp
+++ b/src/main/webapp/admin/manageFlowsheets.jsp
@@ -66,6 +66,9 @@
     }
 
 %>
+
+<fmt:setBundle basename="oscarResources"/>
+
 <html>
     <head>
         <script src="<%= request.getContextPath() %>/js/global.js"></script>
@@ -175,7 +178,7 @@
 		<div class="panel-body">
 			<form enctype="multipart/form-data" method="POST" action="<%=request.getContextPath()%>/admin/manageFlowsheetsUpload.jsp">
         <input type="file" name="flowsheet_file">
-				<span title="<bean:message key="global.uploadWarningBody"/>" style="vertical-align:middle;cursor:pointer"><img alt="alert" src="<%=request.getContextPath()%>/images/icon_alertsml.gif"/></span>
+				<span title="<fmt:message key="global.uploadWarningBody"/>" style="vertical-align:middle;cursor:pointer"><img alt="alert" src="<%=request.getContextPath()%>/images/icon_alertsml.gif"/></span>
         <input type="submit" value="Upload" class="btn btn-primary">
     </form>
 		</div>

--- a/src/main/webapp/admin/securityaddarecord.jsp
+++ b/src/main/webapp/admin/securityaddarecord.jsp
@@ -73,6 +73,8 @@
     OscarProperties op = OscarProperties.getInstance();
 %>
 
+<fmt:setBundle basename="oscarResources"/>
+
 <html>
     <script src="${pageContext.request.contextPath}/csrfguard"></script>
     <head>
@@ -350,7 +352,7 @@
 	<% if (MfaManager.isOscarMfaEnabled()) { %>
 	<tr>
 		<td style="text-align: right">
-			<bean:message key="admin.securityAddRecord.mfa.title"/>:
+			<fmt:message key="admin.securityAddRecord.mfa.title"/>:
 		</td>
 		<td style="">
 			<label>
@@ -360,14 +362,14 @@
 							   updatePinComponentsAccess(this.checked);
 							   <% } %>"
 				/>
-				<bean:message key="admin.securityAddRecord.mfa.description"/>
+				<fmt:message key="admin.securityAddRecord.mfa.description"/>
 			</label>
 		</td>
 	</tr>
 	<tr>
 		<td></td>
 		<td style="padding-left: 8px;">
-			<span id="mfaNote" style="font-size: x-small; color: darkslategray; vertical-align: top; display: none"><bean:message
+			<span id="mfaNote" style="font-size: x-small; color: darkslategray; vertical-align: top; display: none"><fmt:message
 					key="admin.securityAddRecord.mfa.note"/></span>
 		</td>
 	</tr>

--- a/src/main/webapp/admin/securityupdatesecurity.jsp
+++ b/src/main/webapp/admin/securityupdatesecurity.jsp
@@ -56,6 +56,8 @@
     OscarProperties op = OscarProperties.getInstance();
 %>
 
+<fmt:setBundle basename="oscarResources"/>
+
 <html>
     <script src="${pageContext.request.contextPath}/csrfguard"></script>
     <head>
@@ -182,7 +184,7 @@
 	 * @param {number} securityId - The ID of the sec record.
 	 */
 	function handleResetMfa(securityId) {
-		if (confirm("<bean:message key="admin.securityAddRecord.mfa.reset.confirm"/>")) {
+		if (confirm("<fmt:message key="admin.securityAddRecord.mfa.reset.confirm"/>")) {
 			let url = "${pageContext.request.contextPath}/securityRecord/mfa.do";
 			let data = {
 				method: '<%= MfaActions2Action.METHOD_RESET_MFA %>',
@@ -319,7 +321,7 @@
 		<% if (MfaManager.isOscarMfaEnabled()) { %>
 		<tr>
 			<td style="text-align: right">
-				<bean:message key="admin.securityAddRecord.mfa.title"/>:
+				<fmt:message key="admin.securityAddRecord.mfa.title"/>:
 			</td>
 			<td style="">
 				<label>
@@ -329,12 +331,12 @@
 								   updatePinComponentsAccess(this.checked);
 								   <% } %>"
 							<%= security.isUsingMfa() ? "checked" : "" %>/>
-					<bean:message key="admin.securityAddRecord.mfa.description"/>
+					<fmt:message key="admin.securityAddRecord.mfa.description"/>
 				</label>
 				<% if (security.isUsingMfa() && !security.isMfaRegistrationNeeded()) { %>
 				<a id="resetMfaLink" onclick="handleResetMfa(<%=securityId%>)"
 				   style="margin-left: 4px; font-size: small; color: blue; text-decoration:
-				   underline; cursor: pointer;"><bean:message key="admin.securityAddRecord.mfa.reset.link"/></a>
+				   underline; cursor: pointer;"><fmt:message key="admin.securityAddRecord.mfa.reset.link"/></a>
 				<% } %>
 			</td>
 		</tr>
@@ -344,7 +346,7 @@
 			<span id="mfaNote"
 				  style="font-size: x-small; color: darkslategray; vertical-align: top;
 				  display: <%= (security.isUsingMfa() && security.isMfaRegistrationNeeded()) ? "inline" : "none" %>">
-				<bean:message key="admin.securityAddRecord.mfa.note"/></span>
+				<fmt:message key="admin.securityAddRecord.mfa.note"/></span>
 			</td>
 		</tr>
 		<% } %>

--- a/src/main/webapp/appointment/addappointment.jsp
+++ b/src/main/webapp/appointment/addappointment.jsp
@@ -103,6 +103,7 @@ Ontario, Canada
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar" %>
 
+<fmt:setBundle basename="oscarResources"/>
 <jsp:useBean id="providerBean" class="java.util.Properties" scope="session"/>
 
 <%
@@ -1419,7 +1420,7 @@ Ontario, Canada
 		    <% if (pros.isPropertyActive("mc_number")) { %>
 		    <tr>
 			    <td>
-				    <bean:message key="Appointment.formMC" />:
+				    <fmt:message key="Appointment.formMC" />:
 			    </td>
 			    <td>
 				    <input type="text" name="appt_mc_number" class="form-control"/>

--- a/src/main/webapp/provider/appointmentprovideradminday.jsp
+++ b/src/main/webapp/provider/appointmentprovideradminday.jsp
@@ -435,6 +435,8 @@
     <c:set var="masterLinkRights" value="true" scope="page"/>
 </security:oscarSec>
 
+<fmt:setBundle basename="oscarResources"/>
+
 <html>
     <head>
         <title><%=WordUtils.capitalize(userlastname + ", " + org.apache.commons.lang.StringUtils.substring(userfirstname, 0, 1)) + "-"%><fmt:setBundle basename="oscarResources"/><fmt:message key="provider.appointmentProviderAdminDay.title"/></title>
@@ -892,11 +894,11 @@
                                     <c:if test="${doctorLinkRights}">
                                         <li>
                                        <a HREF="#" id="inboxLink">
-                                                <span id="oscar_new_lab"><bean:message key="global.lab"/></span>
+                                                <span id="oscar_new_lab"><fmt:message key="global.lab"/></span>
                                             </a>
                                             <oscar:newUnclaimedLab>
                                                 <a id="unclaimedLabLink" class="tabalert" HREF="javascript:void(0)"
-                                                   title='<bean:message key="provider.appointmentProviderAdminDay.viewLabReports"/>'>U</a>
+                                                   title='<fmt:message key="provider.appointmentProviderAdminDay.viewLabReports"/>'>U</a>
                                             </oscar:newUnclaimedLab>
                                         </li>
                                     </c:if>


### PR DESCRIPTION
Fixed bean message issue on Lab "U" hover, and fixed any other found bean:message issues, since this is not used in the project and should be updated to fmt:message.

## Summary by Sourcery

Replace deprecated bean:message tags with JSTL fmt:message across JSP pages and add fmt:setBundle declarations to ensure message resources load correctly, fixing the Lab “U” hover tooltip.

Bug Fixes:
- Restore Lab “U” hover tooltip by updating its message tag to fmt:message

Enhancements:
- Convert all bean:message references to fmt:message in JSPs
- Add fmt:setBundle basename declaration in JSP pages to load oscarResources bundle