### PR TITLE
732 save and bill not updating status of appointment when processed

### DIFF
--- a/src/main/java/ca/openosp/openo/billings/ca/bc/pageUtil/Billing2Action.java
+++ b/src/main/java/ca/openosp/openo/billings/ca/bc/pageUtil/Billing2Action.java
@@ -93,7 +93,7 @@ public final class Billing2Action extends ActionSupport {
                 }
 
                 request.getSession().setAttribute("billingSessionBean", bean);
-
+                
                 try {
                     _log.debug("Start of billing rules");
                     List<DSConsequence> list = BillingGuidelines.getInstance().evaluateAndGetConsequences(loggedInInfo, request.getParameter("demographic_no"), (String) request.getSession().getAttribute("user"));

--- a/src/main/java/ca/openosp/openo/casemgmt/web/CaseManagementEntry2Action.java
+++ b/src/main/java/ca/openosp/openo/casemgmt/web/CaseManagementEntry2Action.java
@@ -1951,9 +1951,13 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
         }
 
         String toBill = request.getParameter("toBill");
+
         if (toBill != null && toBill.equalsIgnoreCase("true")) {
             String region = this.getBillRegion();
-            String appointmentNo = this.getAppointmentNo();
+            // Try to get appointment number from the note first, before the action field
+            Integer noteApptNo = this.getCaseNote() != null ? this.getCaseNote().getAppointmentNo() : null;
+            String appointmentNo = (noteApptNo != null && noteApptNo > 0) ?
+                String.valueOf(noteApptNo) : this.getAppointmentNo();
             String name = this.getDemoName(demoNo);
             String date = this.getAppointmentDate();
             String start_time = this.getStart_time();


### PR DESCRIPTION
Fixed save and bill not updating appointment status

## Summary by Sourcery

Fix the save-and-bill process to use the appointment number from the case note before falling back to the action field, and remove redundant whitespace in the billing action.

Bug Fixes:
- Ensure the save-and-bill flow correctly updates the appointment status by retrieving the appointment number from the case note when available

Enhancements:
- Clean up trailing whitespace in Billing2Action