### PR TITLE
Fixed missing image on print card page

### DIFF
--- a/src/main/java/ca/openosp/openo/ui/servlet/ImageRenderingServlet.java
+++ b/src/main/java/ca/openosp/openo/ui/servlet/ImageRenderingServlet.java
@@ -330,7 +330,7 @@ public final class ImageRenderingServlet extends HttpServlet {
         String defaultClinicLogo = (defaultResourceUrl != null) ? defaultResourceUrl.getPath() : null;
 
         try {
-            // Set the filename from properties or use default logo
+            // Set the filename from properties or use the default logo
             String filename = OscarProperties.getInstance().getProperty("CLINIC_LOGO_FILE", defaultClinicLogo);
             if (filename == null || filename.isEmpty()) {
                 filename = defaultClinicLogo;


### PR DESCRIPTION
Fixed missing image on print card page by setting default image to openosp logo

## Summary by Sourcery

Bug Fixes:
- Fallback to default OpenOSP logo when the configured clinic logo file is missing or undefined.