### PR TITLE
491 revert code bypassing roles in Case Management action

### DIFF
--- a/src/main/java/ca/openosp/openo/casemgmt/web/CaseManagementEntry2Action.java
+++ b/src/main/java/ca/openosp/openo/casemgmt/web/CaseManagementEntry2Action.java
@@ -2100,8 +2100,7 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
             search = request.getParameter("term");
         }
 
-        // Use searchIssuesNoRolesConcerned to bypass program/role restrictions
-        List<Issue> searchResults = caseManagementMgr.searchIssuesNoRolesConcerned(providerNo, programId, search);
+        List<Issue> searchResults = caseManagementMgr.searchIssues(providerNo, programId, search);
 
         JSONUtil.jsonResponse(response, JsonUtil.pojoCollectionToJson(searchResults));
         return null;


### PR DESCRIPTION
Revert change to search issues change since its seems to not break the issue tickets that were fixed in the PR

## Summary by Sourcery

Bug Fixes:
- Replace searchIssuesNoRolesConcerned with searchIssues to restore program and role restrictions on issue retrieval