### PR TITLE
Update make lock functionality to default to updating both versions of dependency lock, create a legacy param to update just the legacy lock file

### DIFF
--- a/.devcontainer/development/scripts/make
+++ b/.devcontainer/development/scripts/make
@@ -343,7 +343,7 @@ for arg in "$@"; do
       docusaurus_serve
       ;;
     lock)
-       # Update the maven dependency lock files
+      # Update the maven dependency lock files
       if [ "$2" = "--modern" ]; then
         echo "Updating modern dependencies lock file (dependencies-lock-modern.json)..."
         mvn se.vandmo:dependency-lock-maven-plugin:lock -Pmodern-tests -Ddependency.lock.filename=dependencies-lock-modern.json


### PR DESCRIPTION
Updated make file to make it so that the make lock command defaults to both dependency lock files, and replace the param --all with --legacy for legacy dependency lock updating only, updating help description for new updates in the file


NOTE: since this make lock file is copied from the file that was modified in this branch to the docker container, to get these changes with the make file, you will need to either:

- cp /workspace/.devcontainer/development/scripts/make /scripts/make
OR
- Rebuild your docker container

## Summary by Sourcery

Revise the make lock command to update both dependency lock files by default, introduce a --legacy flag to target only the legacy lock file, and refresh the help description accordingly.

Enhancements:
- Default make lock to update both new and legacy dependency lock files
- Replace the --all flag with --legacy for updating only the legacy lock file
- Update the lock target help text to reflect the new default behavior and flag change