### PR TITLE
Update hapi log4j dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -355,6 +355,11 @@
                     <groupId>commons-lang</groupId>
                     <artifactId>commons-lang</artifactId>
                 </exclusion>
+                <!-- Exclude vulnerable log4j v1.2.x - default to using log4j 2.x instead (see version of log4j-1.2-api) -->
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Changes made
- Force `hapi-base` to use `log4j` version `2.x` instead of `1.2.x` (which is affected by several CVEs).