### PR TITLE
Update PMD to 7.10.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1753,12 +1753,12 @@
                     <dependency>
                         <groupId>net.sourceforge.pmd</groupId>
                         <artifactId>pmd-core</artifactId>
-                        <version>7.7.0</version>
+                        <version>7.10.0</version>
                     </dependency>
                     <dependency>
                         <groupId>net.sourceforge.pmd</groupId>
                         <artifactId>pmd-java</artifactId>
-                        <version>7.7.0</version>
+                        <version>7.10.0</version>
                     </dependency>
                 </dependencies>
             </plugin>


### PR DESCRIPTION
## Changes made
- Update `pmd-core` and `pmd-java` to 7.10.0 to address dependabot alert [242](https://github.com/openo-beta/Open-O/security/dependabot/242).