### PR TITLE
Update spring-security-crypto to version 6.3.9

### DIFF
--- a/dependencies-lock-modern.json
+++ b/dependencies-lock-modern.json
@@ -3526,11 +3526,11 @@
   }, {
     "groupId" : "org.springframework.security",
     "artifactId" : "spring-security-crypto",
-    "version" : "6.3.8",
+    "version" : "6.3.9",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:GwBF9om2yx9QPfVCVCeuKVIPGIAeC+jHpdSbl5MXTanNMTL5ac20sj5d8+M1k0Yjh1c0b9GSwjsQUEieeJgeYw=="
+    "integrity" : "sha512:miq5ftqPiXgbLMVicLUvnSO53a62SqSXA5TPH9Xl7CrSptRriFpGDMPMCbp1Jx48tphBzJ3Z+AHoNgvC2b57Dw=="
   }, {
     "groupId" : "org.springframework",
     "artifactId" : "spring-aop",

--- a/dependencies-lock.json
+++ b/dependencies-lock.json
@@ -3454,11 +3454,11 @@
   }, {
     "groupId" : "org.springframework.security",
     "artifactId" : "spring-security-crypto",
-    "version" : "6.3.8",
+    "version" : "6.3.9",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:GwBF9om2yx9QPfVCVCeuKVIPGIAeC+jHpdSbl5MXTanNMTL5ac20sj5d8+M1k0Yjh1c0b9GSwjsQUEieeJgeYw=="
+    "integrity" : "sha512:miq5ftqPiXgbLMVicLUvnSO53a62SqSXA5TPH9Xl7CrSptRriFpGDMPMCbp1Jx48tphBzJ3Z+AHoNgvC2b57Dw=="
   }, {
     "groupId" : "org.springframework",
     "artifactId" : "spring-aop",

--- a/pom.xml
+++ b/pom.xml
@@ -460,7 +460,7 @@
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-crypto</artifactId>
-            <version>6.3.8</version>
+            <version>6.3.9</version>
         </dependency>
 
         <!-- Spring Cache Support with EhCache 2.x -->


### PR DESCRIPTION
Updated spring-security-crypto to version 6.3.8, which seems to be the lowest version with the security vulnerability patched out

Note: this was updated to version 6.3.9, since synk said that there was another security vulnerability affecting 6.3.8

<img width="1898" height="922" alt="image" src="https://github.com/user-attachments/assets/28e52a1a-bcf1-4891-ad1c-4ebde6e61d62" />

Note: see below image for explanation why 5.8.18 wasn't picked for the dependency update previously:

<img width="1187" height="830" alt="image" src="https://github.com/user-attachments/assets/d6994d66-a67f-4c00-a01f-1cd5ecfd6b40" />

## Summary by Sourcery

Upgrade spring-security-crypto to version 6.3.8 to address a known security vulnerability and update dependency lock files accordingly

Bug Fixes:
- Bump spring-security-crypto from 5.8.16 to 6.3.8 to include the security vulnerability patch

Build:
- Regenerate dependencies-lock-modern.json and dependencies-lock.json to reflect the updated version

## Summary by Sourcery

Upgrade spring-security-crypto to version 6.3.9 to address known security vulnerabilities and update lock files accordingly

Bug Fixes:
- Upgrade spring-security-crypto from 5.8.16 to 6.3.9 to include security vulnerability patches

Build:
- Regenerate dependencies-lock.json and dependencies-lock-modern.json to reflect the updated dependency version