### PR TITLE
Fixed remaining XXE attack alert on CodeQL

### DIFF
--- a/src/main/java/ca/openosp/openo/demographic/pageUtil/DemographicExportAction42Action.java
+++ b/src/main/java/ca/openosp/openo/demographic/pageUtil/DemographicExportAction42Action.java
@@ -3439,8 +3439,8 @@ public class DemographicExportAction42Action extends ActionSupport {
             // Disable XInclude
             factory.setXIncludeAware(false);
             
-            // enabled expansion of entity references
-            factory.setExpandEntityReferences(true);
+            // Disabled expansion of entity references
+            factory.setExpandEntityReferences(false);
         } catch (ParserConfigurationException e) {
             logger.error("Failed to configure XML parser security features", e);
             return false;

--- a/src/main/java/ca/openosp/openo/lab/ca/all/upload/handlers/ExcellerisOntarioHandler.java
+++ b/src/main/java/ca/openosp/openo/lab/ca/all/upload/handlers/ExcellerisOntarioHandler.java
@@ -112,6 +112,12 @@ public class ExcellerisOntarioHandler implements MessageHandler {
             docFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
             docFactory.setFeature("http://xml.org/sax/features/external-general-entities", false);
             docFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            docFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+            
+            // Disable XInclude
+            docFactory.setXIncludeAware(false);
+            
+            // Disabled expansion of entity references
             docFactory.setExpandEntityReferences(false);
             
             DocumentBuilder docBuilder = docFactory.newDocumentBuilder();

--- a/src/main/java/ca/openosp/openo/lab/ca/all/upload/handlers/PATHL7Handler.java
+++ b/src/main/java/ca/openosp/openo/lab/ca/all/upload/handlers/PATHL7Handler.java
@@ -86,7 +86,11 @@ public class PATHL7Handler implements MessageHandler {
             docFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
             docFactory.setFeature("http://xml.org/sax/features/external-general-entities", false);
             docFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            docFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+
+            // Disable XInclude
             docFactory.setXIncludeAware(false);
+            // Disabled expansion of entity references
             docFactory.setExpandEntityReferences(false);
             DocumentBuilder docBuilder = docFactory.newDocumentBuilder();
             doc = docBuilder.parse(targetPath.toFile());

--- a/src/main/java/ca/openosp/openo/olis1/Driver.java
+++ b/src/main/java/ca/openosp/openo/olis1/Driver.java
@@ -210,13 +210,17 @@ public class Driver {
             DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
 
             try {
-                // Disable external entities
+                // Disable external entities to prevent XXE attacks
                 dbf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
                 dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
                 dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
                 dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
                 dbf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+                
+                // Disable XInclude
                 dbf.setXIncludeAware(false);
+                
+                // Disabled expansion of entity references
                 dbf.setExpandEntityReferences(false);
 
             } catch (ParserConfigurationException e) {

--- a/src/main/java/ca/openosp/openo/util/UtilXML.java
+++ b/src/main/java/ca/openosp/openo/util/UtilXML.java
@@ -124,7 +124,21 @@ public class UtilXML {
         Document document;
         try {
             InputSource is = new InputSource(new StringReader(xmlInput));
-            Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(is);
+            DocumentBuilderFactory docBuilder = DocumentBuilderFactory.newInstance();
+
+            // Disable external entities to prevent XXE attacks
+            docBuilder.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            docBuilder.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            docBuilder.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            docBuilder.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+            
+            // Disable XInclude
+            docBuilder.setXIncludeAware(false);
+            
+            // Disabled expansion of entity references
+            docBuilder.setExpandEntityReferences(false);
+            
+            Document doc = docBuilder.newDocumentBuilder().parse(is);
             Document document1 = doc;
             return document1;
         } catch (Exception e) {


### PR DESCRIPTION
Fixed XXE attack vector in UtilXML.java, updated some other DocumentBuilderFactory protections for extra comments for clarity, and some more protections on each

## Summary by Sourcery

Bug Fixes:
- Prevent XXE attacks by disabling DOCTYPE declarations, external general and parameter entities, nonvalidating DTD loading, XInclude, and expansion of entity references in XML parsers used in UtilXML, upload handlers, Driver, and DemographicExportAction42Action.

## Summary by Sourcery

Bug Fixes:
- Prevent XXE attacks by disabling DOCTYPE declarations, external general and parameter entities, nonvalidating DTD loading, XInclude, and entity reference expansion in XML parsers used in UtilXML, upload handlers, Driver, and DemographicExportAction42Action