### PR TITLE
Fixed missing CSS in antenatal records

### DIFF
--- a/src/main/webapp/form/formarpg2.jsp
+++ b/src/main/webapp/form/formarpg2.jsp
@@ -89,8 +89,7 @@
         <script type="text/javascript" src="<%= request.getContextPath() %>/js/global.js"></script>
         <title>Antenatal Record 2</title>
         <base href="<%= request.getScheme() + "://" + request.getServerName() + ":" + request.getServerPort() + request.getContextPath() + "/" %>">
-        <link rel="stylesheet" type="text/css"
-              href="<%=bView?"arStyleView.css" : "arStyle.css"%>">
+        <link rel="stylesheet" type="text/css" href="<%=bView? request.getContextPath() + "/form/arStyleView.css" : request.getContextPath() + "/form/arStyle.css" %>">
     </head>
 
     <script type="text/javascript" language="Javascript">

--- a/src/main/webapp/form/formarpg3.jsp
+++ b/src/main/webapp/form/formarpg3.jsp
@@ -77,8 +77,7 @@
         <script type="text/javascript" src="<%= request.getContextPath() %>/js/global.js"></script>
         <title>Antenatal Record 2</title>
         <base href="<%= request.getScheme() + "://" + request.getServerName() + ":" + request.getServerPort() + request.getContextPath() + "/" %>">
-        <link rel="stylesheet" type="text/css"
-              href="<%=bView?"arStyleView.css" : "arStyle.css"%>">
+        <link rel="stylesheet" type="text/css" href="<%=bView? request.getContextPath() + "/form/arStyleView.css" : request.getContextPath() + "/form/arStyle.css" %>">
     </head>
 
 

--- a/src/main/webapp/form/formonarenhancedpg2.jsp
+++ b/src/main/webapp/form/formonarenhancedpg2.jsp
@@ -125,7 +125,7 @@
         <title>Antenatal Record 2</title>
         <base href="<%= request.getScheme() + "://" + request.getServerName() + ":" + request.getServerPort() + request.getContextPath() + "/" %>">
         <script type="text/javascript" src="<%= ctx %>/js/global.js"></script>
-        <link rel="stylesheet" type="text/css" href="<%=bView?"arStyleView.css" : "arStyle.css"%>">
+        <link rel="stylesheet" type="text/css" href="<%=bView? request.getContextPath() + "/form/arStyleView.css" : request.getContextPath() + "/form/arStyle.css" %>">
         <link rel="stylesheet" type="text/css" media="all" href="<%= request.getContextPath() %>/share/calendar/calendar.css" title="win2k-cold-1"/>
         <script type="text/javascript" src="<%= request.getContextPath() %>/share/calendar/calendar.js"></script>
         <script type="text/javascript"


### PR DESCRIPTION
Updated CSS paths in antenatal record jsp files with the correct path to fix missing CSS issues in the pages

Tested this by:

- Going to each page explained to have this issue in the ticket comments and description, and seeing if it matches the same styling as Magenta main

## Summary by Sourcery

Fix missing stylesheet loading in antenatal record JSP pages by prefixing CSS links with the application context path and "/form/" directory

Bug Fixes:
- Correct CSS link paths in formarpg2.jsp
- Correct CSS link paths in formarpg3.jsp
- Correct CSS link paths in formonarenhancedpg2.jsp

## Summary by Sourcery

Fix missing CSS loading in antenatal record JSP pages by updating stylesheet paths to use the application context path and "/form" directory

Bug Fixes:
- Update CSS link in formarpg2.jsp to include context path and form directory
- Update CSS link in formarpg3.jsp to include context path and form directory
- Update CSS link in formonarenhancedpg2.jsp to include context path and form directory