### PR TITLE
Fixed cancelled appointment status not showing on echarts that have saved notes

### DIFF
--- a/src/main/webapp/appointment/addappointment.jsp
+++ b/src/main/webapp/appointment/addappointment.jsp
@@ -1667,7 +1667,7 @@ Ontario, Canada
                                 </td>
                                 <td style="background-color: #e8e8e8; padding-right: 25px"><%=p.getFormattedName()%>
                                 </td>
-                                <td style="background-color: #e8e8e8;"><%=a.getStatus() == null ? "" : (a.getStatus().equals("N") ? "No Show" : (a.getStatus().equals("C") ? "Cancelled" : ""))%>
+                                <td style="background-color: #e8e8e8;"><%=a.getStatus() == null ? "" : (a.getStatus().startsWith("N") ? "No Show" : (a.getStatus().startsWith("C") ? "Cancelled" : ""))%>
                                 </td>
                             </tr>
                             <%
@@ -1690,7 +1690,7 @@ Ontario, Canada
                                 </td>
                                 <td style="background-color: #e8e8e8; padding-right: 25px"><%=p.getFormattedName()%>
                                 </td>
-                                <td style="background-color: #e8e8e8;"><%=a.getStatus() == null ? "" : (a.getStatus().equals("N") ? "No Show" : (a.getStatus().equals("C") ? "Cancelled" : ""))%>
+                                <td style="background-color: #e8e8e8;"><%=a.getStatus() == null ? "" : (a.getStatus().startsWith("N") ? "No Show" : (a.getStatus().startsWith("C") ? "Cancelled" : ""))%>
                                 </td>
                             </tr>
                             <%

--- a/src/main/webapp/demographic/demographicappthistory.jsp
+++ b/src/main/webapp/demographic/demographicappthistory.jsp
@@ -381,9 +381,9 @@
                             boolean newline = false;
 
                             if (appointment.getStatus() != null) {
-                                if (appointment.getStatus().contains("N")) {
+                                if (appointment.getStatus().startsWith("N")) {
                                     comments = "No Show";
-                                } else if (appointment.getStatus().equals("C")) {
+                                } else if (appointment.getStatus().startsWith("C")) {
                                     comments = "Cancelled";
                                 }
                             }
@@ -439,7 +439,7 @@
                             <%=(p != null ? p.getLastName() + "," + p.getFirstName() : "") %> (remote)
                         </td>
                         <td>
-                            &nbsp;<%=a.getStatus() == null ? "" : (a.getStatus().contains("N") ? "No Show" : (a.getStatus().equals("C") ? "Cancelled" : "")) %>
+                            &nbsp;<%=a.getStatus() == null ? "" : (a.getStatus().startsWith("N") ? "No Show" : (a.getStatus().startsWith("C") ? "Cancelled" : "")) %>
                         </td>
                     </tr>
                     <%

--- a/src/main/webapp/documentManager/showDocument.jsp
+++ b/src/main/webapp/documentManager/showDocument.jsp
@@ -690,7 +690,7 @@
                             <td><%=prov == null ? "N/A" : prov.getFormattedName()%>
                             </td>
                             <td><% if (a.getStatus() == null) {%>
-                                "" <% } else if (a.getStatus().equals("N")) {%><fmt:message key="oscar.appt.ApptStatusData.msgNoShow"/><% } else if (a.getStatus().equals("C")) {%><fmt:message key="oscar.appt.ApptStatusData.msgCanceled"/> <%}%>
+                                "" <% } else if (a.getStatus().startsWith("N")) {%><fmt:message key="oscar.appt.ApptStatusData.msgNoShow"/><% } else if (a.getStatus().startsWith("C")) {%><fmt:message key="oscar.appt.ApptStatusData.msgCanceled"/> <%}%>
                             </td>
                         </tr>
                         <%}%>


### PR DESCRIPTION
Fixed issues with appointment status that have values appended onto them ("S" appended for signed, "V" appended for verified, ect). Not equaling some status values for conditions, using startsWith for this, status appends could be looked at to be removed possibly at some point if not needed

This was tested by:

- Creating an appointment, cancelling it, and checking a document on the patient echart (old error that was fixed in a previous PR, to ensure no regressions)
- Creating an appointment, going into the echart, adding a note by clicking "Sign & Save" button, then cancelling the appointment, and checking a document on the patient echart (error that was present till this PR, was fixed with these changes)

## Summary by Sourcery

Bug Fixes:
- Use startsWith to match statuses starting with 'N' and 'C' so that 'No Show' and 'Cancelled' appointments display correctly when codes have appended characters