### PR TITLE
Demographic name "FAKE-" prefix

### DIFF
--- a/.devcontainer/db/scripts/populate_db.sh
+++ b/.devcontainer/db/scripts/populate_db.sh
@@ -10,4 +10,6 @@ mysql -u root -ppassword -e "CREATE DATABASE IF NOT EXISTS drugref2;"
 mysql -u root -ppassword drugref2 < /database/mysql/development-drugref.sql
 echo 'Loading demo data for development...'
 mysql -u root -ppassword oscar < /scripts/development.sql
+echo 'Preparing demographic names for development environment...'
+mysql -u root -ppassword oscar < /database/mysql/updates/update-2025-11-06-demo-name-sanitization.sql
 cd ../../

--- a/database/mysql/updates/update-2025-11-06-demo-name-sanitization.sql
+++ b/database/mysql/updates/update-2025-11-06-demo-name-sanitization.sql
@@ -1,0 +1,16 @@
+-- Update script for name sanitization
+-- Prefixes all demographic first and last names with "FAKE-" for the devcontainer environment
+
+-- Update first names
+UPDATE demographic
+SET first_name = CONCAT('FAKE-', first_name)
+WHERE first_name NOT LIKE 'FAKE-%'
+  AND first_name IS NOT NULL
+  AND first_name != '';
+
+-- Update last names
+UPDATE demographic
+SET last_name = CONCAT('FAKE-', last_name)
+WHERE last_name NOT LIKE 'FAKE-%'
+  AND last_name IS NOT NULL
+  AND last_name != '';


### PR DESCRIPTION
## Changes made
- Write script to prefix demographic first and last names with `FAKE-`.
- Run script when building `db` devcontainer.

## Summary by Sourcery

Prefix all demographic first and last names with "FAKE-" in the development database by introducing a sanitization SQL script and running it during the devcontainer build.

Enhancements:
- Add SQL script to prefix demographic first and last names with "FAKE-" if not already prefixed
- Invoke demographic name sanitization script in the db devcontainer populate_db.sh