### PR TITLE
Add Playwright MCP server to Devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -27,7 +27,7 @@
                         "command": "npx",
                         "args": ["@executeautomation/playwright-mcp-server"],
                         "env": {
-                            "PLAYWRIGHT_BROWSER": "chromium",
+                            "PLAYWRIGHT_BROWSER": "firefox",
                             "PLAYWRIGHT_HEADLESS": "true"
                         }
                     }

--- a/.devcontainer/development/Dockerfile
+++ b/.devcontainer/development/Dockerfile
@@ -63,7 +63,7 @@ RUN npm install -g @google/gemini-cli
 
 # Install Playwright and Playwright MCP server
 RUN npm install -g @executeautomation/playwright-mcp-server playwright && \
-    npx playwright install chromium --with-deps
+    npx playwright install chromium firefox --with-deps
 
 # Install pipx and Aider AI coding assistant
 RUN apt-get update && apt-get install -y pipx && \


### PR DESCRIPTION
## Changes made
- Install Playwright and Playwright MCP in Devcontainer.
- Add configuration for Claude Code to use Playwright MCP.

## Summary by Sourcery

Set up Playwright with its MCP server in the devcontainer and configure the Claude Code extension to target the new server.

New Features:
- Install Playwright, its MCP server, and Chromium dependencies in the development container
- Add devcontainer configuration for Claude Code to use the Playwright MCP server