### PR TITLE
Fixed inbox hub documents not showing when clicking on matched patient name

### DIFF
--- a/src/main/java/ca/openosp/openo/commn/dao/InboxResultsDaoImpl.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/InboxResultsDaoImpl.java
@@ -293,16 +293,16 @@ public class InboxResultsDaoImpl implements InboxResultsDao {
                         + (dateSearchType.equals("receivedCreated") ? "doc.contentdatetime" : "doc.observationdate") + ", plr.lab_type as doctype, doc.doctype as description, date(doc.updatedatetime) "
                         + " FROM demographic d, providerLabRouting plr, document doc, "
                         + " (SELECT * FROM "
-                        + " (SELECT DISTINCT plr.id, plr.lab_type  FROM providerLabRouting plr, ctl_document cd "
+                        + " (SELECT DISTINCT plr.id, plr.lab_type FROM providerLabRouting plr, ctl_document cd "
                         + " WHERE 	" + " (cd.module_id = :demographicNo "
                         + "	AND cd.document_no = plr.lab_no"
                         + "	AND plr.lab_type = 'DOC'  	"
                         + "	AND plr.status " + ("".equals(status) ? " IS NOT NULL " : " = :status ")
-                        + (searchProvider ? " AND plr.provider_no = :providerNo " : " )")
+                        + (searchProvider ? " AND plr.provider_no = :providerNo )" : " )")
                         + " ORDER BY id DESC) AS Y"
                         + " UNION"
                         + " SELECT * FROM"
-                        + " (SELECT DISTINCT plr.id, plr.lab_type  FROM providerLabRouting plr, patientLabRouting plr2"
+                        + " (SELECT DISTINCT plr.id, plr.lab_type FROM providerLabRouting plr, patientLabRouting plr2"
                         + " WHERE"
                         + "	plr.lab_type = 'HL7' AND plr2.lab_type = 'HL7'"
                         + "	AND plr.status " + ("".equals(status) ? " IS NOT NULL " : " = :status ")
@@ -642,7 +642,7 @@ public class InboxResultsDaoImpl implements InboxResultsDao {
 
                 lbData.lastUpdateDate = getStringValue(r[updateDateLoc]);
 
-                lbData.finalResultsCount = 0;//rs.getInt("final_result_count");
+                lbData.finalResultsCount = 0;
                 labResults.add(lbData);
             }
 


### PR DESCRIPTION
In this PR, I have fixed:

- An SQL error in InboxResultsDaoImpl.java that results in missing matching documents when selecting a matched patient
- Removed double whitespace before two FROM clauses
- Removed dead commented out code

I have tested this by:

- Following Deval's screenshot with the inbox hub selected options (openodoc instead of oscardoc as the test doctor has been renamed) and tested to see if a matched patient (such as Jacky Jones, which has documents setup by default) matches correctly compared to Magenta main

## Summary by Sourcery

Fix the SQL query in populateDocumentResultsData to properly include the provider filter and return all matching documents, clean up SQL formatting, and remove dead commented code.

Bug Fixes:
- Correct the placement of parentheses in the SQL subquery to ensure the provider_no filter is applied and prevent missing documents for matched patients.

Enhancements:
- Remove double spaces before FROM clauses to normalize SQL string formatting.

Chores:
- Eliminate dead commented-out code in the finalResultsCount assignment.