### PR TITLE
Fixed fetch faxes button causes infinite loading

### DIFF
--- a/src/main/java/ca/openosp/openo/commn/dao/FaxJobDaoImpl.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/FaxJobDaoImpl.java
@@ -52,10 +52,10 @@ public class FaxJobDaoImpl extends AbstractDaoImpl<FaxJob> implements FaxJobDao 
 
         if (demographic_no != null || status != null || team != null || beginDate != null || endDate != null
                 || provider_no != null) {
-            sql.append("where");
+            sql.append(" where ");
         }
 
-        boolean firstClause = false;
+        boolean firstClause = true;
 
         if (demographic_no != null) {
             if (!firstClause) sql.append(" and ");


### PR DESCRIPTION
In this PR, I have fixed:
- An issue where first clause variable was set to always append "and", which shouldn't be appended on first occurrence of variable, creating incorrect SQL syntax
- An issue where string concatenation with "where" caused it to concat to the first parameter in the query, creating incorrect SQL syntax

I have tested this by:
- Testing this functionality in Magenta main, and testing the same functionality in this branch, to ensure that they work the same way

## Summary by Sourcery

Fix SQL builder in FaxJobDaoImpl to prevent invalid query syntax causing infinite loading

Bug Fixes:
- Add space around WHERE clause to avoid malformed SQL
- Initialize firstClause flag correctly to prevent leading AND in SQL