### PR TITLE
Fixed 404 errors with back button in manage flowsheets admin page

### DIFF
--- a/src/main/webapp/oscarEncounter/oscarMeasurements/adminFlowsheet/EditFlowsheet.jsp
+++ b/src/main/webapp/oscarEncounter/oscarMeasurements/adminFlowsheet/EditFlowsheet.jsp
@@ -253,11 +253,12 @@
                     }
 
                     String flowsheetPath = "";
+                    String folderPath = "oscarEncounter/oscarMeasurements/";
 
                     if (request.getParameter("htracker") != null) {
-                        flowsheetPath = "oscarEncounter/oscarMeasurements/HealthTrackerPage.jspf";
+                        flowsheetPath = folderPath + "HealthTrackerPage.jspf";
                     } else {
-                        flowsheetPath = "oscarEncounter/oscarMeasurements/TemplateFlowSheet.jsp";
+                        flowsheetPath = folderPath + "TemplateFlowSheet.jsp";
                     }
             %>
 


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Add base folder prefix to HealthTrackerPage.jspf and TemplateFlowSheet.jsp to correct include paths and avoid 404 errors.