### PR TITLE
Fixed lab upload 404 error due to maximum default file size in struts 2

### DIFF
--- a/src/main/webapp/WEB-INF/classes/struts.xml
+++ b/src/main/webapp/WEB-INF/classes/struts.xml
@@ -11,6 +11,7 @@
     <constant name="struts.action.excludePattern" value=".*\.(css|js|png|jpg|gif)$|^/ws/.*" />
     <constant name="struts.custom.i18n.resources" value="oscarResources"/>
     <constant name="struts.custom.i18n.resources" value="oscarResources,MessageResources_mcedt"/>
+    <constant name="struts.multipart.maxSize" value="524288000" />
     <!-- Default package extending struts-default -->
 	<package name="default" namespace="/" extends="struts-default">
         <action name="logout" class="ca.openosp.openo.login.Logout2Action">
@@ -1627,6 +1628,7 @@
             <interceptor-ref name="fileUpload" />
             <interceptor-ref name="defaultStack"/>
             <result name="success">/lab/CA/ALL/testUploader.jsp</result>
+            <result name="input">/lab/CA/ALL/testUploader.jsp</result>
         </action>
         <action name="lab/CA/ALL/oruR01Upload" class="ca.openosp.openo.lab.ca.all.pageUtil.OruR01Upload2Action">
             <result name="result">/common/genericResultPage.jsp</result>


### PR DESCRIPTION
In this PR, I have fixed:

- multipart file uploads that exceed maximum file size of 2MB are blocked (in struts 1, the maximum file size is 500MB, see below section for more information)
- Missing input result in the lab upload action (returned when lab upload is empty or null)

I have tested this by:
- Comparing lab file upload result from this branch and Magenta main, seeing if the file uploads without a 404 and if the labs uploaded match on information (some information is missing and is listed in their own tickets, 840, 841)

# More information about the file upload max size change
- The maximum size of file uploads is defaulted to 2MB in struts 2
     - When looking at the struts 1 implementation, one line related to maxFileSize is found:
```
	<controller processorClass="org.apache.struts.tiles.TilesRequestProcessor" maxFileSize="500M" />
```
- To fix this, I have created a constant, that sets the max size of uploads to 500MB in bytes:

```
<constant name="struts.multipart.maxSize" value="524288000" />
```

In terms of file size, this could be too large, but I wanted it to match struts 1 configuration as much as possible. We can look into changing this if wanted.

## Summary by Sourcery

Increase Struts 2 multipart upload limit to 500 MB and add input result mapping to fix 404 errors on large lab uploads and handle missing file submissions

Bug Fixes:
- Prevent 404 errors by raising default Struts 2 file size limit
- Return 'input' result when lab upload file is empty or null

Enhancements:
- Align Struts 2 multipart maxSize configuration with Struts 1 by setting it to 500 MB