### PR TITLE
Fix eForm Email 500 error

### DIFF
--- a/src/main/java/ca/openosp/openo/eform/actions/AddEForm2Action.java
+++ b/src/main/java/ca/openosp/openo/eform/actions/AddEForm2Action.java
@@ -330,7 +330,7 @@ public class AddEForm2Action extends ActionSupport {
                 return "download";
             } else if (isEmailEForm) {
                 String path = request.getContextPath() + "/email/emailComposeAction.do?method=prepareComposeEFormMailer";
-                addEmailAttachments(request, attachedEForms, attachedDocuments, attachedLabs, attachedHRMDocuments, attachedForms);
+                addEmailAttachmentsToSession(request, fdid, demographic_no, attachedEForms, attachedDocuments, attachedLabs, attachedHRMDocuments, attachedForms);
                 try {
                     response.sendRedirect(path);
                 } catch (IOException e) {
@@ -407,7 +407,7 @@ public class AddEForm2Action extends ActionSupport {
                 return "download";
             } else if (isEmailEForm) {
                 String path = request.getContextPath() + "/email/emailComposeAction.do?method=prepareComposeEFormMailer";
-                addEmailAttachments(request, attachedEForms, attachedDocuments, attachedLabs, attachedHRMDocuments, attachedForms);
+                addEmailAttachmentsToSession(request, prev_fdid, demographic_no, attachedEForms, attachedDocuments, attachedLabs, attachedHRMDocuments, attachedForms);
                 try {
                     response.sendRedirect(path);
                 } catch (IOException e) {
@@ -471,6 +471,45 @@ public class AddEForm2Action extends ActionSupport {
         String formattedDate = dateFormat.format(currentDate);
 
         return formattedDate + "_" + demographicLastName + ".pdf";
+    }
+
+    /**
+     * Stores email attachment data in session for use after redirect.
+     * Session attributes survive redirects, unlike request attributes.
+     *
+     * @param request HTTP request
+     * @param fdid eForm data ID
+     * @param demographicNo demographic number
+     * @param attachedEForms array of attached eForm IDs
+     * @param attachedDocuments array of attached document IDs
+     * @param attachedLabs array of attached lab IDs
+     * @param attachedHRMDocuments array of attached HRM document IDs
+     * @param attachedForms array of attached form IDs
+     */
+    private void addEmailAttachmentsToSession(HttpServletRequest request, String fdid, String demographicNo,
+        String[] attachedEForms, String[] attachedDocuments, String[] attachedLabs,
+        String[] attachedHRMDocuments, String[] attachedForms) {
+        Boolean attachEFormItSelf = request.getParameter("attachEFormToEmail") == null || "true".equals(request.getParameter("attachEFormToEmail"));
+        Boolean openEFormAfterEmail = "true".equals(request.getParameter("openEFormAfterSendingEmail"));
+        Boolean isEmailEncrypted = request.getParameter("enableEmailEncryption") == null || "true".equals(request.getParameter("enableEmailEncryption"));
+        Boolean isEmailAttachmentEncrypted = request.getParameter("encryptEmailAttachments") == null || "true".equals(request.getParameter("encryptEmailAttachments"));
+        Boolean isEmailAutoSend = "true".equals(request.getParameter("autoSendEmail"));
+        Boolean deleteEFormAfterEmail = "true".equals(request.getParameter("deleteEFormAfterSendingEmail"));
+
+        HttpSession session = request.getSession();
+        session.setAttribute("deleteEFormAfterEmail", deleteEFormAfterEmail);
+        session.setAttribute("isEmailEncrypted", isEmailEncrypted);
+        session.setAttribute("isEmailAttachmentEncrypted", isEmailAttachmentEncrypted);
+        session.setAttribute("isEmailAutoSend", isEmailAutoSend);
+        session.setAttribute("openEFormAfterEmail", openEFormAfterEmail);
+        session.setAttribute("attachEFormItSelf", attachEFormItSelf);
+        session.setAttribute("fdid", fdid);
+        session.setAttribute("demographicId", demographicNo);
+        session.setAttribute("attachedEForms", attachedEForms);
+        session.setAttribute("attachedDocuments", attachedDocuments);
+        session.setAttribute("attachedLabs", attachedLabs);
+        session.setAttribute("attachedHRMDocuments", attachedHRMDocuments);
+        session.setAttribute("attachedForms", attachedForms);
     }
 
     private void addEmailAttachments(HttpServletRequest request, String[] attachedEForms, String[] attachedDocuments, String[] attachedLabs, String[] attachedHRMDocuments, String[] attachedForms) {

--- a/src/main/java/ca/openosp/openo/email/action/EmailCompose2Action.java
+++ b/src/main/java/ca/openosp/openo/email/action/EmailCompose2Action.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
 
 import org.apache.logging.log4j.Logger;
 import ca.openosp.openo.commn.model.EmailAttachment;
@@ -36,16 +37,20 @@ public class EmailCompose2Action extends ActionSupport {
 
     public String prepareComposeEFormMailer() {
         LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
-        boolean attachEFormItSelf = (boolean) request.getAttribute("attachEFormItSelf");
-        String fdid = attachEFormItSelf ? (String) request.getAttribute("fdid") : "";
-        String demographicId = (String) request.getAttribute("demographicId");
-        String emailPDFPassword = (String) request.getAttribute("emailPDFPassword");
-        String emailPDFPasswordClue = (String) request.getAttribute("emailPDFPasswordClue");
-        String[] attachedDocuments = (String[]) request.getAttribute("attachedDocuments");
-        String[] attachedLabs = (String[]) request.getAttribute("attachedLabs");
-        String[] attachedForms = (String[]) request.getAttribute("attachedForms");
-        String[] attachedEForms = (String[]) request.getAttribute("attachedEForms");
-        String[] attachedHRMDocuments = (String[]) request.getAttribute("attachedHRMDocuments");
+
+        // Get email information from session.
+        HttpSession session = request.getSession();
+        Boolean attachEFormItSelfObj = (Boolean) session.getAttribute("attachEFormItSelf");
+        boolean attachEFormItSelf = attachEFormItSelfObj != null && attachEFormItSelfObj;
+        String fdid = attachEFormItSelf ? (String) session.getAttribute("fdid") : "";
+        String demographicId = (String) session.getAttribute("demographicId");
+        String emailPDFPassword = (String) session.getAttribute("emailPDFPassword");
+        String emailPDFPasswordClue = (String) session.getAttribute("emailPDFPasswordClue");
+        String[] attachedDocuments = (String[]) session.getAttribute("attachedDocuments");
+        String[] attachedLabs = (String[]) session.getAttribute("attachedLabs");
+        String[] attachedForms = (String[]) session.getAttribute("attachedForms");
+        String[] attachedEForms = (String[]) session.getAttribute("attachedEForms");
+        String[] attachedHRMDocuments = (String[]) session.getAttribute("attachedHRMDocuments");
 
         String[] emailConsent = emailComposeManager.getEmailConsentStatus(loggedInInfo, Integer.parseInt(demographicId));
 


### PR DESCRIPTION
## Changes made
- Store and access email data in the HTTP session.
  - Using the HTTP session persists email data across redirects.

## Summary by Sourcery

Persist email-related parameters in HTTP session to fix 500 errors when composing eForms post-redirect

Bug Fixes:
- Ensure email attachments and related flags survive redirects to prevent NullPointerExceptions causing 500 errors

Enhancements:
- Replace request attribute storage with session attribute storage for email attachments in AddEForm2Action
- Update EmailCompose2Action to retrieve email parameters from session instead of request