### PR TITLE
Fixed Missing ExcellerisON lab fields in labDisplay.jsp

### DIFF
--- a/src/main/webapp/lab/CA/ALL/labDisplay.jsp
+++ b/src/main/webapp/lab/CA/ALL/labDisplay.jsp
@@ -1529,6 +1529,21 @@ request.setAttribute("missingTests", missingTests);
                                         </td>
                                     </tr>
 
+                                    <% if ("ExcellerisON".equals(handler.getMsgType())) { %>
+                                        <tr>
+                                            <td>
+                                                <div class="FieldData">
+                                                    <strong>Reported on:</strong>
+                                                </div>
+                                            </td>
+                                            <td>
+                                                <div class="FieldData" nowrap="nowrap">
+                                                    <%= ((ExcellerisOntarioHandler) handler).getReportStatusChangeDate() %>
+                                                </div>
+                                            </td>
+                                        </tr>
+                                    <% } %>
+
                                     <tr>
                                         <td>
                                             <div class="FieldData">


### PR DESCRIPTION
In this PR, I have fixed:

- Missing lab fields in labDisplay.jsp when the type of lab is set as "ExcellerisON" (these additions were pulled from related diffs from the OpenOSP main version of this page)

I have tested this by:
- Comparing the lab fields with ExcellerisON labs from Magenta main and this branch (Deval has also tested this branch and said that it looks good)

Additionally, I have reviewed the full labDisplay.jsp and ExcellerisOntarioHandler.java diffs, the remaining diffs between the two versions being:
- Formatting changes (removed/added spaces or lines)
- Struts 2 migration (JSTL fmt from struts bean, etc)
- Package namespace changes (to new openosp namespace)
- Library updates (removal of net.sf.json when upgrading to apache commons lang 3)
- Removal of Indivo PHR code (was removed previously)

This update is for both issue tickets 840 and 841.

## Summary by Sourcery

Add missing data fields and custom rendering logic in labDisplay.jsp to fully support ExcellerisON lab type

Bug Fixes:
- Include a “Reported on” date field for ExcellerisON labs
- Render order status rows for ExcellerisON labs while skipping deleted orders
- Exclude ExcellerisON labs from the generic OBR row generation logic

Enhancements:
- Display OBX sub-identifier and observation value in italics for ExcellerisON labs when available