### PR TITLE
Fixed labs pdf showing incorrect total number of pages on footer section

### DIFF
--- a/src/main/java/ca/openosp/openo/casemgmt/service/PageNumberStamper.java
+++ b/src/main/java/ca/openosp/openo/casemgmt/service/PageNumberStamper.java
@@ -71,7 +71,7 @@ public class PageNumberStamper extends FooterSupport {
         total.beginText();
         total.setFontAndSize(getFont(), getFontSize());
         total.setTextMatrix(0, 0);
-        total.showText(String.valueOf(writer.getPageNumber() - 1));
+        total.showText(String.valueOf(writer.getPageNumber()));
         total.endText();
     }
 


### PR DESCRIPTION
In this PR, I have fixed:
- labs pdf's showing incorrect total number of pages on footer section

I have tested this by:
- Comparing lab pdf's created before, and after this branch change, ensuring that the total amount of pages on the footer is correct in the new version

In terms of why I think this was set to -1 before, most likely due to some logic change as to what is considered the end of a document (possibly increased by 1 in older itext versions), or maybe just a bug in older version where page total count was not correct.

## Summary by Sourcery

Bug Fixes:
- Fix incorrect total page count in lab PDF footer by using the actual page number instead of subtracting one

## Summary by Sourcery

Bug Fixes:
- Use actual page number instead of subtracting one when stamping total pages in the PDF footer