### PR TITLE
Add missing semicolon

### DIFF
--- a/src/main/java/ca/openosp/openo/lab/ca/all/parsers/MDSHandler.java
+++ b/src/main/java/ca/openosp/openo/lab/ca/all/parsers/MDSHandler.java
@@ -700,7 +700,7 @@ public class MDSHandler implements MessageHandler {
             }
 
             if (nteIndex >= MAX_NTE_COUNT) {
-                logger.warn("Reached maximum NTE count limit: " + MAX_NTE_COUNT + ". Some NTE segments may have been omitted due to truncation.")
+                logger.warn("Reached maximum NTE count limit: " + MAX_NTE_COUNT + ". Some NTE segments may have been omitted due to truncation.");
             }
 
             return allComments.toString();


### PR DESCRIPTION
After updating the warning message suggested by Sourcery, I forgot to add the semicolon.

Closes #866 