### PR TITLE
Fix eForm email sending failures - downgrade jakarta.mail for Spring 5.3 compatibility

### DIFF
--- a/dependencies-lock.json
+++ b/dependencies-lock.json
@@ -754,11 +754,11 @@
   }, {
     "groupId" : "com.sun.activation",
     "artifactId" : "jakarta.activation",
-    "version" : "2.0.1",
+    "version" : "1.2.1",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:0cIU0tbsxhu6OW2RPGbJd0GOdN/pblVYlRzPmaYM/Kat/qP8ZLbi0V9pjjDayHC49ujXoi4N/5dfjdg4ZHFPxQ=="
+    "integrity" : "sha512:ViQ9QtC0V5ro3Ouzu5wIB9VPaON68aQ8E3nZh4/ajPLTn0/frLSA3B1YuuNXyYldpqGd1dAbRRSwHyqp+HAafA=="
   }, {
     "groupId" : "com.sun.istack",
     "artifactId" : "istack-commons-runtime",
@@ -778,11 +778,11 @@
   }, {
     "groupId" : "com.sun.mail",
     "artifactId" : "jakarta.mail",
-    "version" : "2.0.1",
+    "version" : "1.6.8",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:NktwX+PlGxphL3gSzU5Xz/O27YRMo1ZsIGGV1lEmZGYbD8wTjs0ihO4zhV+jeKQpaEJmj8ZuNEfV3Fofw+nEPQ=="
+    "integrity" : "sha512:wSTwG8iUGA8109j4Es0mWPnW2RWxoch9x2raz+si78XGQPq4ezeBYX91Gp8tNnh2fvY4wTcr5SvdHxsYMqcdaw=="
   }, {
     "groupId" : "com.sun.xml.bind.external",
     "artifactId" : "relaxng-datatype",

--- a/pom.xml
+++ b/pom.xml
@@ -697,7 +697,7 @@
         <dependency>
             <groupId>com.sun.mail</groupId>
             <artifactId>jakarta.mail</artifactId>
-            <version>2.0.1</version>
+            <version>1.6.8</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.jfree/jfreechart -->


### PR DESCRIPTION
## Summary

  Fixes eForm email button failures by downgrading jakarta.mail to restore compatibility with Spring Framework 5.3.39.

  ## Problem

  **Issue**: Sending emails from eForm Email button fails with SMTP/namespace errors

## Solution

  Downgraded dependencies to Spring 5.3-compatible versions:
  - **jakarta.mail**: 2.0.1 → 1.6.8 (uses `javax.mail.*` namespace)
  - **jakarta.activation**: 2.0.1 → 1.2.1 (transitive dependency)

## Security Note

  ✅ **No Known Vulnerabilities in version 1.6.8**

  According to [CVE Details](https://www.cvedetails.com/version-list/10410/180844/1/Eclipse-Jakarta-Mail.html) and [Snyk Security](https://security.snyk.io/package/maven/com.sun.mail%3Ajakarta.mail/versions), **jakarta.mail 1.6.8 has no reported CVEs**.

Closes #885

## Summary by Sourcery

Downgrade jakarta.mail and jakarta.activation to Spring Framework 5.3-compatible versions to fix eForm email sending failures

Bug Fixes:
- Restore eForm Email button functionality by resolving SMTP/namespace errors

Build:
- Downgrade com.sun.mail:jakarta.mail from 2.0.1 to 1.6.8 in pom.xml
- Downgrade jakarta.activation from 2.0.1 to 1.2.1 via dependencies-lock.json