### PR TITLE
Re-add missing HCN empty-string check (from PR #114)

### DIFF
--- a/src/main/java/ca/openosp/openo/lab/ca/all/upload/MessageUploader.java
+++ b/src/main/java/ca/openosp/openo/lab/ca/all/upload/MessageUploader.java
@@ -677,7 +677,7 @@ public final class MessageUploader {
 
 
 				// HIN is ALWAYS required for lab matching. Please do not revert this code. Previous iterations have caused fatal patient miss-matches.
-				if( hinMod != null ) {
+				if(hinMod != null && !hinMod.trim().isEmpty()) {
 					if (OscarProperties.getInstance().getBooleanProperty("LAB_NOMATCH_NAMES", "yes")) {
 						sql = "select demographic_no, provider_no from demographic where hin='" + hinMod + "' and " + " year_of_birth like '" + dobYear + "' and " + " month_of_birth like '" + dobMonth + "' and " + " date_of_birth like '" + dobDay + "' and " + " sex like '" + sex + "%' ";
 					} else {


### PR DESCRIPTION
This PR restores the demographic matching fix originally merged in PR [#114](https://github.com/open-osp/Open-O/pull/114) in the OpenO main repo.

Closes #894 

## Summary by Sourcery

Bug Fixes:
- Add check to ensure HIN is non-null and non-empty before querying demographic matching