### PR TITLE
Fix transaction error in demographic import, restore correct edit link logic, and correctly parse binary/text content

### DIFF
--- a/src/main/java/ca/openosp/openo/casemgmt/service/CaseManagementManager.java
+++ b/src/main/java/ca/openosp/openo/casemgmt/service/CaseManagementManager.java
@@ -209,6 +209,8 @@ public interface CaseManagementManager {
 
     public Issue getIssueInfoByTypeAndCode(String type, String code);
 
+    public void saveIssue(Issue issue);
+
     public List<Issue> getIssueInfoBySearch(String providerNo, String search, List accessRight);
 
     public void addNewIssueToConcern(String demoNo, String issueName);

--- a/src/main/java/ca/openosp/openo/casemgmt/service/CaseManagementManagerImpl.java
+++ b/src/main/java/ca/openosp/openo/casemgmt/service/CaseManagementManagerImpl.java
@@ -849,6 +849,11 @@ public class CaseManagementManagerImpl implements CaseManagementManager {
     }
 
     @Override
+    public void saveIssue(Issue issue) {
+        issueDAO.saveIssue(issue);
+    }
+
+    @Override
     public List<Issue> getIssueInfoBySearch(String providerNo, String search, List accessRight) {
         List<Issue> issList = issueDAO.findIssueBySearch(search);
         // filter the issue list by role

--- a/src/main/java/ca/openosp/openo/demographic/pageUtil/ImportDemographicDataAction42Action.java
+++ b/src/main/java/ca/openosp/openo/demographic/pageUtil/ImportDemographicDataAction42Action.java
@@ -3672,7 +3672,7 @@ public class ImportDemographicDataAction42Action extends ActionSupport {
 
                 isu.setType(type);
                 isu.setUpdate_date(new Date());
-                issueDao.saveIssue(isu);
+                caseManagementManager.saveIssue(isu);
             }
             if (isu != null && isu.getId() != null) {
                 CaseManagementIssue cmIssu = new CaseManagementIssue();
@@ -3719,7 +3719,7 @@ public class ImportDemographicDataAction42Action extends ActionSupport {
                 }
                 isu.setType(type);
                 isu.setUpdate_date(new Date());
-                issueDao.saveIssue(isu);
+                caseManagementManager.saveIssue(isu);
             }
             if (isu != null && isu.getId() != null) {
                 CaseManagementIssue cmIssu = new CaseManagementIssue();

--- a/src/main/java/ca/openosp/openo/demographic/pageUtil/ImportDemographicDataAction42Action.java
+++ b/src/main/java/ca/openosp/openo/demographic/pageUtil/ImportDemographicDataAction42Action.java
@@ -62,6 +62,7 @@ import cdsDt.DiabetesMotivationalCounselling.CounsellingPerformed;
 import cdsDt.PersonNameStandard.LegalName;
 import cdsDt.PersonNameStandard.OtherNames;
 import com.opensymphony.xwork2.ActionSupport;
+import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
@@ -2660,7 +2661,17 @@ public class ImportDemographicDataAction42Action extends ActionSupport {
 
                         byte[] b = null;
                         if (repCt != null && repCt.getMedia() != null) b = repCt.getMedia();
-                        else if (repCt != null && repCt.getTextContent() != null) b = repCt.getTextContent().getBytes();
+                        else if (repCt != null && repCt.getTextContent() != null) {
+                            // TextContent may contain base64-encoded binary data (for images, PDFs, etc.)
+                            // or actual text content. Check if it's binary format and decode accordingly.
+                            if (binaryFormat) {
+                                // Binary formats (images, PDFs, etc.) are base64-encoded in TextContent
+                                b = Base64.decodeBase64(repCt.getTextContent());
+                            } else {
+                                // Text formats are stored as-is
+                                b = repCt.getTextContent().getBytes();
+                            }
+                        }
                         if (b == null && filePath == null) {
                             err_othe.add("Error! No report file in xml (" + (i + 1) + ")");
                         } else {

--- a/src/main/webapp/casemgmt/ChartNotesAjax.jsp
+++ b/src/main/webapp/casemgmt/ChartNotesAjax.jsp
@@ -553,10 +553,8 @@ EmailComposeManager emailComposeManager = SpringUtils.getBean(EmailComposeManage
                 {
                     if (!note.isReadOnly()) {
             %>
-            <div>
                 <a title="<fmt:setBundle basename="oscarResources"/><fmt:message key="oscarEncounter.edit.msgEdit"/>" id="edit<%=globalNoteId%>"
-                   href="javascript:void(0);" onclick="<%=editWarn?"noPrivs(event);":"editNote(event);"%> return false;"
-                   style="float: right; margin-right: 5px;">
+                   href="javascript:void(0);" onclick="<%=editUrl%> return false;" style="<%=bgColour%> order: 1; padding: 2px 5px;">
                     <fmt:setBundle basename="oscarResources"/><fmt:message key="oscarEncounter.edit.msgEdit"/>
                 </a>
             <%


### PR DESCRIPTION
Summary
-------
This PR includes three fixes:

1. Fixes a transaction exception during demographic import when saving ICD-related issues  
   - This restores proper Action → Manager → DAO layering and prevents read-only transaction failures.
2. Restores the correct edit-link logic in encounter notes (synced with OpenO main)  
   - Replaced with correct logic from OpenO main
3. Correctly handles binary vs text content when parsing `TextContent` elements in reports  
   - Prevents corrupted binary attachments
   - Correctly handles text vs binary formats
   - Aligns with OMD report content structure
