### PR TITLE
Fix annotation popup not opening in allergy management

### DIFF
--- a/src/main/webapp/oscarRx/ShowAllergies2.jsp
+++ b/src/main/webapp/oscarRx/ShowAllergies2.jsp
@@ -588,9 +588,7 @@
                                                     <%
                                                         if (!allergy.isIntegratorResult()) {
                                                     %>
-                                                    <a href="#" title="Annotation"
-                                                       onclick="window.open('<%= request.getContextPath() %>/annotation/annotation.jsp?display=<%=annotation_display%>&table_id=<%=String.valueOf(allergy.getAllergyId())%>&demo=
-                                                           ${patient.getDemographicNo() }','anwin','width=400,height=500');">
+                                                    <a href="#" title="Annotation" onclick="window.open('<%= request.getContextPath() %>/annotation/annotation.jsp?display=<%=annotation_display%>&table_id=<%=String.valueOf(allergy.getAllergyId())%>&demo=${patient.getDemographicNo()}','anwin','width=400,height=500');">
                                                         <% if (existingAnnots.size() > 0) {%>
                                                         <img src="<%= request.getContextPath() %>/images/filledNotes.gif" border="0"/>
                                                         <% } else { %>


### PR DESCRIPTION
## Problem
  When clicking the annotation icon next to allergy records, the popup window was not opening. 

  **Root Cause**: The `onclick` attribute contained a line break in the middle of the JavaScript string (lines 591-593), which caused the HTML parser to incorrectly terminate the attribute, making the JavaScript invalid.

  ## Solution
  Consolidated the `onclick` attribute to a single line, ensuring the HTML attribute parses correctly and the JavaScript executes.

## Summary by Sourcery

Bug Fixes:
- Resolve a broken onclick handler in the allergy list annotation link that prevented the annotation popup from opening.