### PR TITLE
Fix Sign and Save failing with checked unresolved issues (missing code from old OpenO)

### DIFF
--- a/src/main/webapp/casemgmt/noteIssueList.jsp
+++ b/src/main/webapp/casemgmt/noteIssueList.jsp
@@ -272,6 +272,7 @@
                 <c:set var="winame" value="${fn:replace(winame, ' ', '_')}" />
                 <c:set var="winame" value="${fn:replace(winame, '/', '_')}" />
                 <c:set var="winame" value="${fn:replace(winame, '*', '_')}" />
+                <c:set var="winame" value="${fn:replace(winame, \"'\", '')}" />
 
                 <c:set var="submitString" value="this.form.method.value='issueChange'; this.form.lineId.value='${status.index}'; return ajaxUpdateIssues('issueChange', $('noteIssues').up().id);" />
                 <c:set var="id" value="noteIssue${status.index}" />
@@ -350,6 +351,7 @@
         <c:set var="winame" value="${fn:replace(winame, ' ', '_')}" />
         <c:set var="winame" value="${fn:replace(winame, '/', '_')}" />
         <c:set var="winame" value="${fn:replace(winame, '*', '_')}" />
+        <c:set var="winame" value="${fn:replace(winame, \"'\", '')}" />
         <c:set var="winame" value="${fn:escapeXml(winame)}" />
         <c:set var="countUnresolvedIssue" value="${status.index + 1}" />
 
@@ -364,7 +366,7 @@
             <c:set var="writeAccess" value="${issueCheckList.issueDisplay.writeAccess}" />
             <c:set var="disabled" value="${!writeAccess}" />
 
-            <input type="checkbox" id="${id}" name="issueCheckList" value="${status.index}" ${disabled ? 'disabled' : ''} />
+            <input type="checkbox" id="${id}" name="issueCheckList[${status.index}].checked" ${disabled ? 'disabled="disabled"' : ''} />
 
             <a href="#" onclick="return displayIssue('${winame}');">
                 ${issueCheckList.issueDisplay.description}


### PR DESCRIPTION
## Summary
  - Fixes 404 error when checking ANY unresolved issue checkbox and clicking "Sign and Save"
  - Also adds apostrophe removal logic missing from old OpenO migration

  ## Problem
  When a user checks **any** unresolved issue checkbox (e.g., "Diabetes", "Hypertension", "Alzheimer's disease") and clicks "Sign and Save", the form submission fails with a **404 error**. This happens regardless of whether the issue name contains apostrophes - the root cause is the incorrect checkbox name attribute.


  **Root Cause**: The unresolved issues checkbox was incorrectly migrated. The old OpenO Struts 1 code used the `nested:checkbox` tag with `indexed="true"` which automatically generates proper array notation. During migration to plain HTML, this critical detail was lost in the unresolved issues section (but correctly preserved in resolved issues).

 Additional fixes from old OpenO:
  - Line 275: Added apostrophe removal for resolved issues (prevents JavaScript syntax errors)
  - Line 354: Added apostrophe removal for unresolved issues (prevents JavaScript syntax errors)
  - Both sections now match the old OpenO behavior of stripping apostrophes before generating onclick handlers

## Summary by Sourcery

Fix form submission for unresolved issues in noteIssueList.jsp and align name handling with legacy behavior.

Bug Fixes:
- Resolve 404 errors when submitting the form after checking unresolved issue checkboxes by correcting the checkbox name binding.

Enhancements:
- Normalize issue display names by stripping apostrophes before generating onclick handlers for both resolved and unresolved issues to prevent JavaScript syntax issues.