### PR TITLE
Fixed note revision history missing the "signed by" provider info

### DIFF
--- a/src/main/webapp/casemgmt/showHistory.jsp
+++ b/src/main/webapp/casemgmt/showHistory.jsp
@@ -45,6 +45,7 @@
 <%
     WebApplicationContext ctx = WebApplicationContextUtils.getRequiredWebApplicationContext(getServletContext());
     ProviderManager pMgr = (ProviderManager) ctx.getBean(ProviderManager.class);
+    pageContext.setAttribute("pMgr", pMgr);
 %>
 <html>
 <head>


### PR DESCRIPTION
In this PR, I have fixed:
- The missing "signed by" provider info in the note revision history page

I have tested this by:
- Comparing the functionality of Magenta main, with this branch

## Summary by Sourcery

Bug Fixes:
- Restore display of the "signed by" provider information in the note revision history page.