### PR TITLE
Fixed null values when nothing is inputted, and fixed broken drop downs not being sent correctly in AddReaction2.jsp

### DIFF
--- a/src/main/webapp/oscarRx/AddReaction2.jsp
+++ b/src/main/webapp/oscarRx/AddReaction2.jsp
@@ -29,6 +29,8 @@
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+
+<%@page import="org.owasp.encoder.Encode" %>
 <%
     String roleName2$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;
@@ -192,7 +194,7 @@
                                 <tr valign="center">
                                     <td>
                                         <span class="label">Comment: </span>
-                                        <textarea name="reactionDescription" cols="40" rows="3"><%=reaction%></textarea>
+                                        <textarea name="reactionDescription" cols="40" rows="3"><%=Encode.forHtml(reaction)%></textarea>
                                         <input type="hidden" name="ID" value="<%=drugrefId%>"/>
                                         <input type="hidden" name="name" id="name" value="<%=name%>"/>
                                         <input type="hidden" name="allergyToArchive" id="allergyToArchive" value="<%=allergyToArchive%>"/>


### PR DESCRIPTION
In this PR, I have fixed:
- null values being shown when nothing is inputted into AddReaction2.jsp
- Broken drop downs not showing the correct result when set in AddReaction2.jsp
- missing name and id for allergy form (which caused input validation to be skipped on modified indicator)

I have tested this by:
- Comparing functionality between this branch and Magenta main

## Summary by Sourcery

Improve handling of allergy reaction form defaults and dropdown selections in AddReaction2.jsp.

Bug Fixes:
- Prevent null values from being displayed when allergy reaction fields are missing in AddReaction2.jsp.
- Ensure life stage, severity, and onset-of-reaction dropdowns correctly reflect the saved selection and default values in AddReaction2.jsp.

Enhancements:
- Simplify reaction comment textarea rendering to avoid unintended whitespace and formatting issues.

## Summary by Sourcery

Improve handling of allergy reaction form defaults and dropdown selections in AddReaction2.jsp.

Bug Fixes:
- Prevent null values from being displayed when allergy reaction fields are missing in AddReaction2.jsp.
- Ensure life stage, severity, and onset-of-reaction dropdowns correctly reflect the saved or default selection.
- Restore client-side validation by adding missing name and id attributes to the allergy form in AddReaction2.jsp.

Enhancements:
- Simplify rendering of the reaction comment textarea to avoid unintended whitespace and formatting issues.