### PR TITLE
Added functionality to show a "Last Updated Date" field in the allergies page

### DIFF
--- a/src/main/java/ca/openosp/openo/prescript/pageUtil/AllergyDisplay.java
+++ b/src/main/java/ca/openosp/openo/prescript/pageUtil/AllergyDisplay.java
@@ -39,6 +39,7 @@ public final class AllergyDisplay {
     private String reaction;
     private String startDate;
     private String archived;
+    private String lastUpdateDate;
 
     public Integer getId() {
         return (id);
@@ -130,6 +131,14 @@ public final class AllergyDisplay {
 
     public void setArchived(String archived) {
         this.archived = archived;
+    }
+
+    public String getLastUpdateDate() {
+        return lastUpdateDate;
+    }
+
+    public void setLastUpdateDate(String lastUpdateDate) {
+        this.lastUpdateDate = lastUpdateDate;
     }
 
 }

--- a/src/main/java/ca/openosp/openo/prescript/pageUtil/AllergyHelperBean.java
+++ b/src/main/java/ca/openosp/openo/prescript/pageUtil/AllergyHelperBean.java
@@ -84,8 +84,10 @@ public final class AllergyHelperBean {
 
             String entryDate = partialDateDao.getDatePartial(allergy.getEntryDate(), PartialDate.ALLERGIES, allergy.getAllergyId(), PartialDate.ALLERGIES_ENTRYDATE);
             String startDate = partialDateDao.getDatePartial(allergy.getStartDate(), PartialDate.ALLERGIES, allergy.getAllergyId(), PartialDate.ALLERGIES_STARTDATE);
+            String lastUpdateDate = DateUtils.formatDate(allergy.getLastUpdateDate(), locale);
             allergyDisplay.setEntryDate(entryDate);
             allergyDisplay.setStartDate(startDate);
+            allergyDisplay.setLastUpdateDate(lastUpdateDate);
 
             results.add(allergyDisplay);
         }

--- a/src/main/webapp/oscarRx/ShowAllergies.jsp
+++ b/src/main/webapp/oscarRx/ShowAllergies.jsp
@@ -295,6 +295,7 @@
                                                 <td>&nbsp;</td>
                                                 <td><b>Status</b></td>
                                                 <td><b>Entry Date</b></td>
+                                                <td><b>Last Updated Date</b></td>
                                                 <td><b>Description</b></td>
                                                 <td><b>Allergy Type</b></td>
                                                 <td><b>Severity</b></td>
@@ -375,6 +376,8 @@
                                                     <td><%=labelStatus%>
                                                     </td>
                                                     <td><%=StringEscapeUtils.escapeHtml4(displayAllergy.getEntryDate())%>
+                                                    </td>
+                                                    <td><%=StringEscapeUtils.escapeHtml4(displayAllergy.getLastUpdateDate() != null ? displayAllergy.getLastUpdateDate() : "")%>
                                                     </td>
                                                     <td><%=StringEscapeUtils.escapeHtml4(displayAllergy.getDescription())%>
                                                     </td>

--- a/src/main/webapp/oscarRx/ShowAllergies2.jsp
+++ b/src/main/webapp/oscarRx/ShowAllergies2.jsp
@@ -43,6 +43,7 @@
 <%@ page import="ca.openosp.openo.prescript.pageUtil.RxSessionBean" %>
 <%@ page import="ca.openosp.openo.prescript.data.RxPatientData" %>
 <%@ page import="ca.openosp.openo.commn.model.Allergy" %>
+<%@ page import="ca.openosp.openo.util.DateUtils" %>
 
 <%
     String roleName2$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
@@ -474,6 +475,7 @@
                                             <tr>
                                                 <td><b>Status</b></td>
                                                 <td><b>Entry Date</b></td>
+                                                <td><b>Last Updated Date</b></td>
                                                 <td><b>Description</b></td>
                                                 <td><b>Allergy Type</b></td>
 
@@ -559,6 +561,8 @@
                                                 <td><%=labelStatus%>
                                                 </td>
                                                 <td><%=entryDate == null ? "" : entryDate %>
+                                                </td>
+                                                <td><%=allergy.getLastUpdateDate() != null ? DateUtils.formatDate(allergy.getLastUpdateDate(), request.getLocale()) : "" %>
                                                 </td>
                                                 <td <%=title%> ><%=allergy.getDescription() %>
                                                 </td>


### PR DESCRIPTION
In this PR, I have added:
- New functionality to get and display the "Last Updated Date" database field, set on each allergy in the "ShowAllergies" and "ShowAllergies2" jsp pages

## Summary by Sourcery

Display the last updated date for allergies in the allergies pages and plumb this field through the view model.

New Features:
- Add a last updated date field to the allergy display model and expose getters/setters.
- Show a Last Updated Date column in the allergies listing views, populated from the allergy model and formatted per locale.

Enhancements:
- Format and pass through the allergy last updated date from backend data into the allergy display view objects.

## Summary by Sourcery

Display the allergy last updated date in both allergies JSP pages by plumbing the field through the allergy display model from backend data.

New Features:
- Add a lastUpdateDate field to the AllergyDisplay view model with accessors.
- Show a Last Updated Date column in the ShowAllergies and ShowAllergies2 pages, sourced from the allergy model and formatted for the user locale.

Enhancements:
- Populate and format the allergy last updated date in AllergyHelperBean when building AllergyDisplay instances.