### PR TITLE
Fixed 404 errors on view/dl/delete letters options in ManageLetters.jsp

### DIFF
--- a/src/main/webapp/report/ManageLetters.jsp
+++ b/src/main/webapp/report/ManageLetters.jsp
@@ -42,7 +42,7 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
 "http://www.w3.org/TR/html4/loose.dtd">
 <%@page
-        import="ca.openosp.openo.demographic.data.*,java.util.*,ca.openosp.openo.prevention.*,ca.openosp.openo.providers.data.*,ca.openosp.openo.util.*,ca.openosp.openo.report.data.*,ca.openosp.openo.prevention.pageUtil.*,java.net.*,ca.openosp.openo.eform.*" %>
+        import="ca.openosp.openo.demographic.data.*,java.util.*,ca.openosp.openo.prevention.*,ca.openosp.openo.providers.data.*,ca.openosp.openo.util.*,ca.openosp.openo.report.data.*,ca.openosp.openo.prevention.pageUtil.*,java.net.*,ca.openosp.openo.eform.*,org.owasp.encoder.Encode" %>
 <%@ page import="ca.openosp.openo.report.data.ManageLetters" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 
@@ -221,17 +221,17 @@
                         Hashtable h = (Hashtable) list.get(i);
                     %>
                     <tr>
-                        <td><%=h.get("ID")%>
+                        <td><%= Encode.forHtml(String.valueOf(h.get("ID"))) %>
                         </td>
-                        <td><%=h.get("provider_no")%>
+                        <td><%= Encode.forHtml(String.valueOf(h.get("provider_no"))) %>
                         </td>
-                        <td><%=h.get("report_name")%>
+                        <td><%= Encode.forHtml(String.valueOf(h.get("report_name"))) %>
                         </td>
-                        <td><a href="<%= request.getContextPath() %>/report/DownloadLetter.do?reportID=<%=h.get("ID")%>"><%=h.get("file_name")%>
+                        <td><a href="<%= request.getContextPath() %>/report/DownloadLetter.do?reportID=<%= Encode.forHtmlAttribute(String.valueOf(h.get("ID")))%>"><%= Encode.forHtml(String.valueOf(h.get("file_name")))%>
                         </a></td>
-                        <td><%=h.get("date_time")%>
+                        <td><%= Encode.forHtml(String.valueOf(h.get("date_time"))) %>
                         </td>
-                        <td><a href="<%= request.getContextPath() %>/report/DeleteLetter.do?reportID=<%=h.get("ID")%>">del</a></td>
+                        <td><form method="POST" action="<%= request.getContextPath() %>/report/DeleteLetter.do" style="display:inline;margin:0;"><input type="hidden" name="reportID" value="<%= Encode.forHtmlAttribute(String.valueOf(h.get("ID"))) %>"/><button type="submit" style="background:none;border:none;color:blue;text-decoration:underline;cursor:pointer;padding:0;">del</button></form></td>
                     </tr>
                     <%}%>
                 </table>


### PR DESCRIPTION
In this PR, I have:
- Fixed action paths to view, download and delete letter actions in ManageLetters.jsp
- Added encoding to outputs on the page

I have tested this by:
- Comparing this branches functionality to Magenta's release branch

## Summary by Sourcery

Bug Fixes:
- Correct letter download and delete link paths in ManageLetters.jsp to prevent 404 errors.

## Summary by Sourcery

Fix broken letter management links in ManageLetters.jsp to use context-aware download and delete URLs.

Bug Fixes:
- Correct letter download link in ManageLetters.jsp to point to the context-aware /report/DownloadLetter.do path.
- Correct letter delete link in ManageLetters.jsp to point to the context-aware /report/DeleteLetter.do path.