### PR TITLE
Fix prescription duration unit handling in demographic export

### DIFF
--- a/src/main/java/ca/openosp/openo/demographic/pageUtil/DemographicExportAction42Action.java
+++ b/src/main/java/ca/openosp/openo/demographic/pageUtil/DemographicExportAction42Action.java
@@ -1715,8 +1715,9 @@ public class DemographicExportAction42Action extends ActionSupport {
                                 if (StringUtils.filled(duration)) {
                                     String durunit = StringUtils.noNull(arr[p].getDurationUnit());
                                     Integer fctr = 1;
-                                    if (durunit.equals("W")) fctr = 7;
-                                    else if (durunit.equals("M")) fctr = 30;
+                                    if (durunit.equalsIgnoreCase("W")) fctr = 7;
+                                    else if (durunit.equalsIgnoreCase("M")) fctr = 30;
+                                    else if (durunit.equalsIgnoreCase("Y")) fctr = 365;
 
                                     if (NumberUtils.isDigits(duration)) {
                                         duration = String.valueOf(Integer.parseInt(duration) * fctr);

--- a/src/main/java/ca/openosp/openo/prescript/data/RxPrescriptionData.java
+++ b/src/main/java/ca/openosp/openo/prescript/data/RxPrescriptionData.java
@@ -273,7 +273,7 @@ public class RxPrescriptionData {
         p.setTakeMax(drug.getTakeMax());
         p.setFrequencyCode(drug.getFreqCode());
         p.setDuration(drug.getDuration());
-        p.setDurationUnit(drug.getDuration());
+        p.setDurationUnit(drug.getDurUnit());
         p.setQuantity(drug.getQuantity());
         p.setRepeat(drug.getRepeat());
         p.setLastRefillDate(drug.getLastRefillDate());


### PR DESCRIPTION
- Fixed duration unit comparison in demographic export to be case-insensitive for "W" (week) and "M" (month)
- Added support for yearly duration units ("Y" = 365 days) in export calculations
- Corrected setDurationUnit call to use `getDurUnit()` instead of `getDuration()` in export mapping