### PR TITLE
Fix missing report media type mapping in demographic export

### DIFF
--- a/src/main/java/ca/openosp/openo/demographic/pageUtil/DemographicExportAction42Action.java
+++ b/src/main/java/ca/openosp/openo/demographic/pageUtil/DemographicExportAction42Action.java
@@ -2017,6 +2017,12 @@ public class DemographicExportAction42Action extends ActionSupport {
                                     exportError.add("Error! Document \"" + f.getName() + "\" too big to be exported. Not enough memory!");
                                 } else {
                                     Reports rpr = patientRec.addNewReports();
+                                    if (edoc.getType() != null) {
+                                        cdsDt.ReportMedia.Enum mediaEnum = cdsDt.ReportMedia.Enum.forString(formatHrmEnum(edoc.getType()));
+                                        if (mediaEnum != null) {
+                                            rpr.setMedia(mediaEnum);
+                                        }
+                                    }
                                     rpr.setFormat(cdsDt.ReportFormat.TEXT);
 
                                     cdsDt.ReportContent rpc = rpr.addNewContent();


### PR DESCRIPTION
Added missing report media type mapping for reports in demographic export

## Summary by Sourcery

Bug Fixes:
- Set the report media field based on the electronic document type during demographic export when a valid mapping exists.