### PR TITLE
Fixed update date not being set to the correct imported date, but to the current date

### DIFF
--- a/src/main/java/ca/openosp/openo/casemgmt/dao/CaseManagementNoteDAOImpl.java
+++ b/src/main/java/ca/openosp/openo/casemgmt/dao/CaseManagementNoteDAOImpl.java
@@ -518,7 +518,9 @@ public class CaseManagementNoteDAOImpl extends HibernateDaoSupport implements Ca
             UUID uuid = UUID.randomUUID();
             note.setUuid(uuid.toString());
         }
-        note.setUpdate_date(new Date());
+        if (note.getUpdate_date() == null) {
+            note.setUpdate_date(new Date());
+        }
         this.getHibernateTemplate().save(note);
         this.getHibernateTemplate().flush();
     }
@@ -530,7 +532,9 @@ public class CaseManagementNoteDAOImpl extends HibernateDaoSupport implements Ca
             UUID uuid = UUID.randomUUID();
             note.setUuid(uuid.toString());
         }
-        note.setUpdate_date(new Date());
+        if (note.getUpdate_date() == null) {
+            note.setUpdate_date(new Date());
+        }
         return this.getHibernateTemplate().save(note);
     }
 


### PR DESCRIPTION
In this PR, I have fixed:
- The update date not being set to the correct imported date, but to the current date

I have tested this by:
- Importing the attached tickets demographic, finding the connected note, and checked to see if the dates match the XML data

## Summary by Sourcery

Bug Fixes:
- Ensure note update_date is only set to the current date when it is not already provided, preventing imported timestamps from being overwritten.

## Summary by Sourcery

Bug Fixes:
- Preserve an existing update_date on CaseManagementNote entities during save operations, only defaulting to the current date when no update_date is provided.