### PR TITLE
Fixed the health card swipe feature which doesn't work when editing a demographic

### DIFF
--- a/src/main/webapp/demographic/zdemographicswipe.jsp
+++ b/src/main/webapp/demographic/zdemographicswipe.jsp
@@ -79,7 +79,7 @@
             Swipe card
         </p>
         <p class="span">
-            <input type="checkbox" name="magneticStripe" size="79" />
+            <input type="text" name="magneticStripe" size="79" />
         </p>
         </p>
 


### PR DESCRIPTION
In this PR, I have fixed:
- The demographic swipe to fix an issue where a previous input text was set to input checkbox

I have tested this by:
- Comparing the attached tickets value to the output between this branch and Magenta's latest release branch, in both the add and edit demographic functionality

When talking about this issue in the meeting, I misunderstood some parts of the description (I thought that the URL was different and that was causing the issues, going to an outdated jsp file). But it was actually just a struts 2 migration issue with the text input being a checkbox, and the other expected result picture is what should happen when adding a new demographic. While editing (which is what the ticket was about), is actually correctly pointing already to the JSP page on this branch.

## Summary by Sourcery

Bug Fixes:
- Fix the health card swipe field so magnetic stripe data is captured via a text input rather than a checkbox in the demographic edit view.

## Summary by Sourcery

Bug Fixes:
- Fix the demographic health card swipe input so magnetic stripe data is captured via a text field instead of a checkbox when editing demographics.