### PR TITLE
Update to remove apache tika dependency

### DIFF
--- a/dependencies-lock-modern.json
+++ b/dependencies-lock-modern.json
@@ -2379,14 +2379,6 @@
     "optional" : false,
     "integrity" : "sha512:6t+uUpMgr3cUbXNb/dD4h69D25eM3TIoH9yl0bBYFOaOj2N0JIz2hdiolkRxz2U1zknw+VU+/JjPSlH4ChlGlw=="
   }, {
-    "groupId" : "org.apache.tika",
-    "artifactId" : "tika-core",
-    "version" : "1.28.5",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:XOr3rZ5itO/1EsAFQcd/gH13oHN6EdUlAdCyUCS4xXjnt+ivekad5vblSr8c4Co10zVozzXUhSwALBBXYve7nQ=="
-  }, {
     "groupId" : "org.apache.velocity.tools",
     "artifactId" : "velocity-tools-generic",
     "version" : "3.1",

--- a/dependencies-lock.json
+++ b/dependencies-lock.json
@@ -2379,14 +2379,6 @@
     "optional" : false,
     "integrity" : "sha512:6t+uUpMgr3cUbXNb/dD4h69D25eM3TIoH9yl0bBYFOaOj2N0JIz2hdiolkRxz2U1zknw+VU+/JjPSlH4ChlGlw=="
   }, {
-    "groupId" : "org.apache.tika",
-    "artifactId" : "tika-core",
-    "version" : "1.28.5",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:XOr3rZ5itO/1EsAFQcd/gH13oHN6EdUlAdCyUCS4xXjnt+ivekad5vblSr8c4Co10zVozzXUhSwALBBXYve7nQ=="
-  }, {
     "groupId" : "org.apache.velocity.tools",
     "artifactId" : "velocity-tools-generic",
     "version" : "3.1",

--- a/pom.xml
+++ b/pom.xml
@@ -1147,13 +1147,6 @@
             <version>8.3.3</version>
         </dependency>
 
-        <!-- Apache Tika - MimeType handling for downloaded files (ie. XDS) -->
-        <dependency>
-            <groupId>org.apache.tika</groupId>
-            <artifactId>tika-core</artifactId>
-            <version>1.28.5</version>
-        </dependency>
-
         <dependency>
             <groupId>com.atlassian.commonmark</groupId>
             <artifactId>commonmark</artifactId>

--- a/src/main/java/ca/openosp/openo/PMmodule/caisi_integrator/CaisiIntegratorUpdateTask.java
+++ b/src/main/java/ca/openosp/openo/PMmodule/caisi_integrator/CaisiIntegratorUpdateTask.java
@@ -76,7 +76,7 @@ import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
-import org.apache.tika.io.IOUtils;
+import org.apache.commons.io.IOUtils;
 import ca.openosp.openo.PMmodule.dao.ProgramDao;
 import ca.openosp.openo.PMmodule.dao.ProviderDao;
 import ca.openosp.openo.PMmodule.dao.SecUserRoleDao;

--- a/src/main/java/ca/openosp/openo/lab/ca/all/pageUtil/LabPDFCreator.java
+++ b/src/main/java/ca/openosp/openo/lab/ca/all/pageUtil/LabPDFCreator.java
@@ -56,7 +56,7 @@ import com.itextpdf.text.pdf.*;
 import com.lowagie.text.rtf.RtfWriter2;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.tika.io.IOUtils;
+import org.apache.commons.io.IOUtils;
 import ca.openosp.openo.commn.dao.Hl7TextMessageDao;
 import ca.openosp.openo.commn.model.Hl7TextMessage;
 import ca.openosp.openo.commn.printing.FontSettings;


### PR DESCRIPTION
In this PR, I have:
- Removed the apache tika dependency from the project
     - This was for a fix for a security vulnerability, the reason why it was deleted and not modified is that the only method calls from this package, were actually methods that were migrated over to the `apache commons io` package, meaning that apache tika is not used at all when updating it to the required version for the security fix.
     -  See the attached ticket comments for explanation about develop/dogfish and Magenta's release branch diffs with this package.


## Summary by Sourcery

Remove unused Apache Tika dependency from the project configuration.

Build:
- Drop Apache Tika tika-core dependency from pom.xml and update dependency lockfiles accordingly.

Chores:
- Clean up references to Apache Tika in source files now that mime type handling has migrated to commons-io.

## Summary by Sourcery

Remove the unused Apache Tika dependency from the project and clean up related references now that mime type handling is provided by other libraries.

Build:
- Drop the org.apache.tika:tika-core dependency from pom.xml and update dependency lockfiles accordingly.

Chores:
- Remove or adjust source references associated with Apache Tika usage that are no longer needed.