### PR TITLE
Updated node-forge to version 1.3.3 to fix security vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12573,9 +12573,9 @@
       }
     },
     "node_modules/node-forge": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
-      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.3.tgz",
+      "integrity": "sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==",
       "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
         "node": ">= 6.13.0"


### PR DESCRIPTION
In this PR, I have updated:
- node-forge (transitive dependency, has a security vulnerability)

## Summary by Sourcery

Build:
- Update the node-forge dependency version in lockfile to incorporate security fixes.