### PR TITLE
mdast-util-to-hast dependency update to fix a security vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10468,9 +10468,9 @@
       }
     },
     "node_modules/mdast-util-to-hast": {
-      "version": "13.2.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.0.tgz",
-      "integrity": "sha512-QGYKEuUsYT9ykKBCMOEDLsU5JRObWQusAolFMeko/tYPufNkRffBAQjIE+99jbA87xv6FgmjLtwjh9wBWajwAA==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",


### PR DESCRIPTION
In this PR, I have updated:
- mdast-util-to-hast (transitive dependency, has a security vulnerability)


## Summary by Sourcery

Update npm lockfile dependency versions to address a security vulnerability in mdast-util-to-hast and related packages.

Build:
- Refresh package-lock.json to capture updated mdast-util-to-hast dependency versions with security fixes.

Chores:
- Regenerate lockfile entries to align with updated dependency tree.