### PR TITLE
Add missing execute() method to Ocean eReferral action for attachment handling

### DIFF
--- a/src/main/java/ca/openosp/openo/encounter/oceanEReferal/pageUtil/ERefer2Action.java
+++ b/src/main/java/ca/openosp/openo/encounter/oceanEReferal/pageUtil/ERefer2Action.java
@@ -30,6 +30,19 @@ public class ERefer2Action extends ActionSupport {
     private static final Logger logger = MiscUtils.getLogger();
     private final DocumentAttachmentManager documentAttachmentManager = SpringUtils.getBean(DocumentAttachmentManager.class);
 
+    public String execute() {
+        String method = request.getParameter("method");
+
+        if (method != null) {
+            if (method.equalsIgnoreCase("attachOceanEReferralConsult"))
+                attachOceanEReferralConsult();
+            else if (method.equalsIgnoreCase("editOceanEReferralConsult"))
+                editOceanEReferralConsult();
+        }
+
+        return SUCCESS;
+    }
+
     // Documents (attachments) originate from the consult request window.
     // Users can attach these documents using the attachment GUI on the consult request form.
     // All documents are internal to Oscar.

--- a/src/main/webapp/WEB-INF/classes/struts.xml
+++ b/src/main/webapp/WEB-INF/classes/struts.xml
@@ -950,7 +950,6 @@
             <result name="success">/oscarEncounter/oscarConsultationRequest/ConsultationFormRequest.jsp</result>
         </action>
         <action name="oscarEncounter/eRefer" class="ca.openosp.openo.encounter.oceanEReferal.pageUtil.ERefer2Action">
-            <result name="success">/oscarEncounter/oscarConsultationRequest/ConsultationFormRequest.jsp</result>
         </action>
         <action name="oscarEncounter/RequestConsultation" class="ca.openosp.openo.encounter.oscarConsultationRequest.pageUtil.EctConsultationFormRequest2Action">
             <result name="success">/oscarEncounter/oscarConsultationRequest/ConfirmConsultationRequest.jsp</result>


### PR DESCRIPTION
## Problem
  When sending eReferrals from Oscar to Ocean, document attachments were not being sent with the referral. Users could attach documents in the consultation request form, but these attachments failed to transfer to Ocean.

  ## Root Cause
  The `ERefer2Action` class was missing the `execute()` method required by Struts2 to handle incoming requests. Without this method, the action could not route requests to the appropriate attachment handling methods (`attachOceanEReferralConsult` and `editOceanEReferralConsult`).

  ## Solution
  Added `execute()` method to `ERefer2Action`.

## Summary by Sourcery

Add request-dispatching logic to the Ocean eReferral Struts action so that attachment-related operations are correctly invoked when the action is called.

Bug Fixes:
- Ensure document attachments on Ocean eReferrals are processed by invoking the appropriate attachment handling methods via the Struts action entry point.

Enhancements:
- Simplify Struts configuration for the Ocean eReferral action by relying on the default success result instead of an explicit mapping.