### PR TITLE
Correct Jackson JsonNode handling in ProviderService.search() endpoint

### DIFF
--- a/src/main/java/ca/openosp/openo/webserv/rest/ProviderService.java
+++ b/src/main/java/ca/openosp/openo/webserv/rest/ProviderService.java
@@ -43,6 +43,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
 import ca.openosp.openo.webserv.rest.to.OscarSearchResponse;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -280,11 +281,11 @@ public class ProviderService extends AbstractServiceImpl {
             // 1) Validate and coerce 'active'
             Boolean active = null;
             if (json.has("active")) {
-                Object a = json.get("active");
-                if (a instanceof Boolean) {
-                    active = (Boolean) a;
-                } else if (a instanceof String) {
-                    String s = ((String) a).trim().toLowerCase();
+                JsonNode activeNode = json.get("active");
+                if (activeNode.isBoolean()) {
+                    active = activeNode.asBoolean();
+                } else if (activeNode.isTextual()) {
+                    String s = activeNode.asText().trim().toLowerCase();
                     if ("true".equals(s))      active = true;
                     else if ("false".equals(s)) active = false;
                     else throw new WebApplicationException(


### PR DESCRIPTION
## Problem
  The provider search REST API endpoint (`ProviderService.search()`) was failing when Ocean attempted to search for providers using the `active` parameter. 

  ## Root Cause
  The code was incorrectly handling Jackson's `JsonNode` API for parameter parsing:
  - Used `json.get("active")` which returns a `JsonNode` wrapper object
  - Attempted to use `instanceof Boolean` and `instanceof String` checks on the JsonNode
  - These checks would **always fail** because JsonNode is not a primitive type or String
  - This caused the `active` parameter to be mishandled, breaking the search functionality

  ## Solution
  Corrected the JsonNode handling to use proper Jackson API methods:
  - Changed from `Object a = json.get("active")` to `JsonNode activeNode = json.get("active")`
  - Replaced `instanceof Boolean` with `activeNode.isBoolean()` and `asBoolean()`
  - Replaced `instanceof String` with `activeNode.isTextual()` and `asText()`
  - This properly extracts and validates the boolean value from the JsonNode wrapper

## Summary by Sourcery

Bug Fixes:
- Correct parsing of the 'active' field in ProviderService.search() by using appropriate JsonNode boolean and text accessors, ensuring provider searches with the 'active' filter work as intended.