### PR TITLE
Fixed filtering flowsheets not always working based on number of elements, and placement of the elements (based on date filter)

### DIFF
--- a/src/main/webapp/oscarEncounter/oscarMeasurements/TemplateFlowSheetPage.jspf
+++ b/src/main/webapp/oscarEncounter/oscarMeasurements/TemplateFlowSheetPage.jspf
@@ -767,7 +767,6 @@ div.recommendations ul{
     </div>
     <%  int k = 0;
         for (EctMeasurementsDataBean mdb:alist){
-            k++;
             mFlowsheet.runRulesForMeasurement(LoggedInInfo.getLoggedInInfoFromSession(request), mdb);
             Hashtable hdata = new Hashtable();//(Hashtable) alist.get(k);
             hdata.put("age",mdb.getDataField());
@@ -789,18 +788,22 @@ div.recommendations ul{
             }
             Date itDate = mdb.getDateObservedAsDate();
 
-            if(sdate != null) {
-            	 if (itDate.before(sdate)){
-                     hider = "style=\"display:none\"";
-             	}
+            // Check if item passes date filter first
+            boolean passesDateFilter = true;
+            if(sdate != null && itDate.before(sdate)) {
+                passesDateFilter = false;
+                hider = "style=\"display:none\"";
             }
-            if(edate != null) {
-           	 if (itDate.after(edate)){
-                    hider = "style=\"display:none\"";
-            	}
+            if(edate != null && itDate.after(edate)) {
+                passesDateFilter = false;
+                hider = "style=\"display:none\"";
             }
-            if(k > num) {
-            	 hider = "style=\"display:none;\"";
+            // Only count items that pass the date filter for the element limit
+            if(passesDateFilter) {
+                k++;
+                if(k > num) {
+                    hider = "style=\"display:none;\"";
+                }
             }
 
             String indColour = "";


### PR DESCRIPTION
In this PR, I have fixed:
- Fixed flowsheet filtering so that counter for number of elements only counts elements that match the filter dates (between start and end date), instead of counting ALL elements no matter the filter

I have tested this by:
- ensuring that flowsheet elements are filtered per match of the inputted filters, by comparing what the result was in the flowsheet screen before the fix and after

## Summary by Sourcery

Bug Fixes:
- Correct flowsheet element counter to exclude measurements outside the active date filter range.