### PR TITLE
Fixed preventions in flowsheets being displayed in the wrong order

### DIFF
--- a/src/main/java/ca/openosp/openo/commn/dao/PreventionDaoImpl.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/PreventionDaoImpl.java
@@ -184,7 +184,7 @@ public class PreventionDaoImpl extends AbstractDaoImpl<Prevention> implements Pr
 
     @Override
     public List<Prevention> findByTypeAndDemoNo(String preventionType, Integer demoNo) {
-        String sqlCommand = "select x from " + modelClass.getSimpleName() + " x where preventionType=?1 and demographicId=?2 and deleted='0' order by preventionDate DESC";
+        String sqlCommand = "select x from " + modelClass.getSimpleName() + " x where preventionType=?1 and demographicId=?2 and deleted='0' order by preventionDate desc";
 
         Query query = entityManager.createQuery(sqlCommand);
         query.setParameter(1, preventionType);


### PR DESCRIPTION
In this PR, I have fixed:
- Preventions in flowsheets being displayed in the wrong order (was ordered by ascending, instead of descending)

I have tested this by:
- Ensuring that preventions in flowsheets are being displayed in the same order (descending by date), like how disease registry is outputted

## Summary by Sourcery

Bug Fixes:
- Correct the ordering of prevention records so that newer entries appear before older ones in flowsheets.

## Summary by Sourcery

Bug Fixes:
- Fix flowsheet prevention queries to sort prevention records in descending date order instead of ascending.