### PR TITLE
Updated log4j versions to 2.25.3 to fix a security vulnerability

### DIFF
--- a/dependencies-lock-modern.json
+++ b/dependencies-lock-modern.json
@@ -2293,27 +2293,27 @@
   }, {
     "groupId" : "org.apache.logging.log4j",
     "artifactId" : "log4j-1.2-api",
-    "version" : "2.25.1",
+    "version" : "2.25.3",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:9gIDIIkxLfapzAG0Zrxumud03wE83uMLhlmN3NnB+e6WTR6L0o5/XSlIyBx+f9Afw9rlawUaQYzFyZ0/88W3IQ=="
+    "integrity" : "sha512:6XW4Fau8O/cuUR+Z4dHK5/vLjbOHE+Lx90kOkzQe70nkXV4ZTWO/axvz+20YdANpY4uXZjDiALQJ/gZKp3RgFA=="
   }, {
     "groupId" : "org.apache.logging.log4j",
     "artifactId" : "log4j-api",
-    "version" : "2.25.1",
+    "version" : "2.25.3",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:BCJQDkUirSdS82N1j/Cr6lW3MZXPOHhDKLntF/SzNWVGkj1rfGfeSmu7jVTkIGPm3y9FSOthNtqZoEUkN7IKrg=="
+    "integrity" : "sha512:zpqvW+7A+4y+2MSuipGljT9pNccxIgspTXDxVpEotf82fhv5TWlXLderBb/ypjveX/dInrl0Powwe2ROrq28UA=="
   }, {
     "groupId" : "org.apache.logging.log4j",
     "artifactId" : "log4j-core",
-    "version" : "2.25.1",
+    "version" : "2.25.3",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:+YBXlHegB1mILkPsYIQqP3kmTRbLSCPeJxREopGeLocz/ttGzrsw6AmCS6Ex3cEL7zIQbMGvowV2WaKaJJN0eQ=="
+    "integrity" : "sha512:ZKB3at/QsIL4Dkn0r7iZjBXTDFFaNEGgdDZNN0eaL8BZvddGlMP2CbH64dLsoMuINH4a/Yh3SsaYpCuHRL8lnw=="
   }, {
     "groupId" : "org.apache.neethi",
     "artifactId" : "neethi",

--- a/dependencies-lock.json
+++ b/dependencies-lock.json
@@ -2293,27 +2293,27 @@
   }, {
     "groupId" : "org.apache.logging.log4j",
     "artifactId" : "log4j-1.2-api",
-    "version" : "2.25.1",
+    "version" : "2.25.3",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:9gIDIIkxLfapzAG0Zrxumud03wE83uMLhlmN3NnB+e6WTR6L0o5/XSlIyBx+f9Afw9rlawUaQYzFyZ0/88W3IQ=="
+    "integrity" : "sha512:6XW4Fau8O/cuUR+Z4dHK5/vLjbOHE+Lx90kOkzQe70nkXV4ZTWO/axvz+20YdANpY4uXZjDiALQJ/gZKp3RgFA=="
   }, {
     "groupId" : "org.apache.logging.log4j",
     "artifactId" : "log4j-api",
-    "version" : "2.25.1",
+    "version" : "2.25.3",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:BCJQDkUirSdS82N1j/Cr6lW3MZXPOHhDKLntF/SzNWVGkj1rfGfeSmu7jVTkIGPm3y9FSOthNtqZoEUkN7IKrg=="
+    "integrity" : "sha512:zpqvW+7A+4y+2MSuipGljT9pNccxIgspTXDxVpEotf82fhv5TWlXLderBb/ypjveX/dInrl0Powwe2ROrq28UA=="
   }, {
     "groupId" : "org.apache.logging.log4j",
     "artifactId" : "log4j-core",
-    "version" : "2.25.1",
+    "version" : "2.25.3",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:+YBXlHegB1mILkPsYIQqP3kmTRbLSCPeJxREopGeLocz/ttGzrsw6AmCS6Ex3cEL7zIQbMGvowV2WaKaJJN0eQ=="
+    "integrity" : "sha512:ZKB3at/QsIL4Dkn0r7iZjBXTDFFaNEGgdDZNN0eaL8BZvddGlMP2CbH64dLsoMuINH4a/Yh3SsaYpCuHRL8lnw=="
   }, {
     "groupId" : "org.apache.neethi",
     "artifactId" : "neethi",

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <!-- Log4j Version -->
-        <log4j2.version>2.25.1</log4j2.version>
+        <log4j2.version>2.25.3</log4j2.version>
         <!-- Slf4j Version -->
         <slf4j.version>2.0.17</slf4j.version>
         <!-- Hapi Fhir Version -->


### PR DESCRIPTION
In this PR, I have:
- Updated log4j versions to 2.25.3 to fix a security vulnerability

I have tested this by:
- Smoke testing the application, comparing to logs from the develop/dogfish branch

## Summary by Sourcery

Update Log4j dependencies to the latest patched 2.25.3 release to address security concerns.

Bug Fixes:
- Address known security vulnerabilities by upgrading Log4j from 2.25.1 to 2.25.3 in the build configuration.

Build:
- Bump the shared Log4j version property in pom.xml and refresh dependency lock files to use Log4j 2.25.3.

## Summary by Sourcery

Upgrade Log4j dependencies to a patched 2.25.3 release to address security concerns and refresh dependency locks accordingly.

Bug Fixes:
- Mitigate known Log4j security vulnerabilities by upgrading from version 2.25.1 to 2.25.3.

Build:
- Update the shared Log4j version property in pom.xml and regenerate dependency lock files to use Log4j 2.25.3.