### PR TITLE
Fixed import logic for ResultNormalAbnormalFlag showing raw XML

### DIFF
--- a/src/main/java/ca/openosp/openo/demographic/pageUtil/ImportDemographicDataAction42Action.java
+++ b/src/main/java/ca/openosp/openo/demographic/pageUtil/ImportDemographicDataAction42Action.java
@@ -3846,15 +3846,17 @@ public class ImportDemographicDataAction42Action extends ActionSupport {
 
     /**
      * Extracts the string value from a ResultNormalAbnormalFlag complex type.
-     * The field contains either resultNormalAbnormalFlagAsEnum or resultNormalAbnormalFlagAsPlainText.
+     * Per the XSD schema, this is defined as xs:choice so valid XML should only have one child element set.
+     * If both are unexpectedly set, enum takes precedence for consistency with HL7CreateFile.java.
      *
      * @param flag the ResultNormalAbnormalFlag object to extract from
-     * @return the flag value as a string, or null if the flag is null
+     * @return the flag value as a string (e.g., "H", "L", "N"), or null if the flag is null
      */
     String getResultNormalAbnormalFlag(cdsDt.ResultNormalAbnormalFlag flag) {
         if (flag == null) return null;
 
         if (flag.getResultNormalAbnormalFlagAsEnum() != null) {
+            // Using toString() to match HL7CreateFile.java pattern; returns HL7 abnormal flag codes (e.g., "H", "L", "A")
             return flag.getResultNormalAbnormalFlagAsEnum().toString();
         }
         if (flag.getResultNormalAbnormalFlagAsPlainText() != null) {


### PR DESCRIPTION
In this PR, I have:
- Fixed underlying import issue with ResultNormalAbnormalFlag field showing raw XML

I have tested this by:
- Importing the sample patients from OMD, and ensuring that the field is no longer showing raw XML data, as well as looking for any similar issues that could arise (was not able to find any other problematic areas in data or display past this field)

## Summary by Sourcery

Bug Fixes:
- Fix ResultNormalAbnormalFlag import so the field stores and displays a clean string value rather than raw XML content.

## Summary by Sourcery

Bug Fixes:
- Correct ResultNormalAbnormalFlag extraction by selecting the enum or plain-text value rather than serializing the complex XML type.