### PR TITLE
Updated the sorting of the data table in the demographic consultations page to be sorted by referral date

### DIFF
--- a/src/main/webapp/oscarEncounter/oscarConsultationRequest/DisplayDemographicConsultationRequests.jsp
+++ b/src/main/webapp/oscarEncounter/oscarConsultationRequest/DisplayDemographicConsultationRequests.jsp
@@ -130,7 +130,7 @@
       jQuery(document).ready( function () {
         jQuery('#consultTable').DataTable({
           "lengthMenu": [ [25, 50, 100, -1], [25, 50, 100, "<fmt:message key="oscarEncounter.LeftNavBar.AllLabs"/>"] ],
-          "order": [[5,'desc']],
+          "order": [[7, 'desc']], // Column 7 = Referral Date
           "language": {
             "url": "<%=request.getContextPath() %>/library/DataTables/i18n/<fmt:message key="global.i18nLanguagecode"/>.json"
           },


### PR DESCRIPTION
In this PR, I have fixed:
- The sorting of the data table in the demographic consultations page so that it is sorted by the referral date column instead of the service column

I have tested this by:
- Viewing the demoraphic consultations page and ensuring that the table displayed is sorted by referral date in descending order

## Summary by Sourcery

Bug Fixes:
- Correct the default sort column of the demographic consultation requests table from service to referral date.