### PR TITLE
Fix: document uploader not setting provider value

### DIFF
--- a/src/main/webapp/documentManager/documentUploader.jsp
+++ b/src/main/webapp/documentManager/documentUploader.jsp
@@ -136,7 +136,7 @@
             <button id="cancel" type="reset" class="cancel">Cancel upload</button>
             <br>
             <span>
-				<input type="hidden" id="provider" name="providers" value="<%=provider%>"/>
+				<input type="hidden" id="providers" name="providers" value="<%=provider%>"/>
 				<input type="hidden" id="queue" name="queue" value="<%=queueId%>"/>
                                 <input type="hidden" id="destination" name="destination" value="<%=destination%>"/>
                                 <input type="hidden" id="destFolder" name="destFolder" value="<%=destFolder%>"/>


### PR DESCRIPTION
- Fixed bug in documentUploader.jsp where hidden input value wasn't being set due to incorrect id attribute
 - JavaScript was looking for element with id "providers" but element had id "provider"

## Summary by Sourcery

Bug Fixes:
- Correct the hidden provider input ID in documentUploader.jsp so JavaScript can locate it and set its value.