### PR TITLE
Restore saved letterhead values when loading existing consultation

### DIFF
--- a/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/pageUtil/EctViewRequest2Action.java
+++ b/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/pageUtil/EctViewRequest2Action.java
@@ -128,16 +128,16 @@ public class EctViewRequest2Action extends ActionSupport {
     }
 
 
-        public static void fillFormValues(LoggedInInfo loggedInInfo, EctConsultationFormRequest2Form thisForm, Integer requestId) {
-        	checkPrivilege(loggedInInfo);
+    public static void fillFormValues(LoggedInInfo loggedInInfo, EctConsultationFormRequest2Form thisForm, Integer requestId) {
+        checkPrivilege(loggedInInfo);
 
-            ConsultationManager consultationManager = SpringUtils.getBean(ConsultationManager.class);
-            ConsultationRequestExtDao consultationRequestExtDao = SpringUtils.getBean(ConsultationRequestExtDao.class);
-            List<ConsultationRequestExt> extras = consultationRequestExtDao.getConsultationRequestExts(requestId);
-            Map<String, String> extraMap = consultationManager.getExtValuesAsMap(extras);
+        ConsultationManager consultationManager = SpringUtils.getBean(ConsultationManager.class);
+        ConsultationRequestExtDao consultationRequestExtDao = SpringUtils.getBean(ConsultationRequestExtDao.class);
+        List<ConsultationRequestExt> extras = consultationRequestExtDao.getConsultationRequestExts(requestId);
+        Map<String, String> extraMap = consultationManager.getExtValuesAsMap(extras);
 
-            ConsultationRequestDao consultDao = (ConsultationRequestDao)SpringUtils.getBean(ConsultationRequestDao.class);;
-            ConsultationRequest consult = consultDao.find(requestId);
+        ConsultationRequestDao consultDao = (ConsultationRequestDao)SpringUtils.getBean(ConsultationRequestDao.class);;
+        ConsultationRequest consult = consultDao.find(requestId);
 
         thisForm.setAllergies(consult.getAllergies());
         thisForm.setReasonForConsultation(consult.getReasonForReferral());
@@ -190,16 +190,21 @@ public class EctViewRequest2Action extends ActionSupport {
         Provider prov = provDao.getProvider(consult.getProviderNo());
         thisForm.setProviderName(prov.getFormattedName());
 
-            boolean isEReferral = extraMap.containsKey(ConsultationRequestExtKey.EREFERRAL_REF.getKey());
-            thisForm.seteReferral(isEReferral);
-            if (isEReferral) {
-                thisForm.setProfessionalSpecialistName(extraMap.getOrDefault(ConsultationRequestExtKey.EREFERRAL_DOCTOR.getKey(), ""));
-                thisForm.seteReferralService(extraMap.getOrDefault(ConsultationRequestExtKey.EREFERRAL_SERVICE.getKey(), ""));
-                thisForm.seteReferralId(extraMap.get(ConsultationRequestExtKey.EREFERRAL_REF.getKey()));
-            }
-
-            thisForm.setFdid(consult.getFdid());
+        boolean isEReferral = extraMap.containsKey(ConsultationRequestExtKey.EREFERRAL_REF.getKey());
+        thisForm.seteReferral(isEReferral);
+        if (isEReferral) {
+            thisForm.setProfessionalSpecialistName(extraMap.getOrDefault(ConsultationRequestExtKey.EREFERRAL_DOCTOR.getKey(), ""));
+            thisForm.seteReferralService(extraMap.getOrDefault(ConsultationRequestExtKey.EREFERRAL_SERVICE.getKey(), ""));
+            thisForm.seteReferralId(extraMap.get(ConsultationRequestExtKey.EREFERRAL_REF.getKey()));
         }
+
+        thisForm.setLetterheadName(consult.getLetterheadName());
+        thisForm.setLetterheadAddress(consult.getLetterheadAddress());
+        thisForm.setLetterheadPhone(consult.getLetterheadPhone());
+        thisForm.setLetterheadFax(consult.getLetterheadFax());
+
+        thisForm.setFdid(consult.getFdid());
+    }
 
     public static void fillFormValues(EctConsultationFormRequest2Form thisForm, EctConsultationFormRequestUtil consultUtil) {
         thisForm.setAllergies(consultUtil.allergies);
@@ -242,6 +247,11 @@ public class EctViewRequest2Action extends ActionSupport {
         thisForm.setPatientAge(consultUtil.patientAge);
 
         thisForm.setProviderName(consultUtil.getProviderName(consultUtil.providerNo));
+
+        thisForm.setLetterheadName(consultUtil.letterheadName);
+        thisForm.setLetterheadAddress(consultUtil.letterheadAddress);
+        thisForm.setLetterheadPhone(consultUtil.letterheadPhone);
+        thisForm.setLetterheadFax(consultUtil.letterheadFax);
 
         thisForm.seteReferral(false);
 


### PR DESCRIPTION
## Summary
  Fixes the letterhead name, address, phone, and fax fields to properly display saved values when loading an existing consultation request.

  ## Problem
  When opening a saved consultation request, the letterhead fields (name, address, phone, fax) were reverting to the logged-in user's information instead of displaying the values that were saved with the consultation.

  **Root causes:**
  1. Backend: `EctViewRequest2Action.fillFormValues()` was not populating the letterhead fields from the database
  2. Frontend: Page initialization JavaScript only handled new consultations (empty letterhead), but had no logic to restore saved letterhead values for existing consultations
  
 Files Changed

  - src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/pageUtil/EctViewRequest2Action.java - Added letterhead field population from database
  - src/main/webapp/oscarEncounter/oscarConsultationRequest/ConsultationFormRequest.jsp - Added saved letterhead restoration logic, fixed encoding, added null checks

Closes #1062

## Summary by Sourcery

Restore consultation form letterhead fields when loading existing requests so previously saved values are displayed instead of defaulting to the logged-in user or clinic.

Bug Fixes:
- Populate letterhead name, address, phone, and fax on the server side when loading an existing consultation request.
- Ensure the consultation form JavaScript restores saved letterhead selections for existing consultations instead of always applying defaults.
- Prevent potential runtime errors when initializing fax account options by adding null checks.

Enhancements:
- Improve output encoding for letterhead fax values using OWASP Java Encoder tags to ensure safer rendering in the JSP.