### PR TITLE
Updated struts execute methods with some missing method mappings

### DIFF
--- a/src/main/java/ca/openosp/openo/documentManager/actions/ManageDocument2Action.java
+++ b/src/main/java/ca/openosp/openo/documentManager/actions/ManageDocument2Action.java
@@ -126,6 +126,10 @@ public class ManageDocument2Action extends ActionSupport {
         ACTIONS.put("displayIncomingDocs", ctx -> { ctx.displayIncomingDocs(); return null; });
         ACTIONS.put("documentUpdate", ctx -> { ctx.documentUpdate(); return null; });
         ACTIONS.put("documentUpdateAjax", ctx -> { ctx.documentUpdateAjax(); return null; });
+        ACTIONS.put("getDemoNameAjax", ctx -> { ctx.getDemoNameAjax(); return null; });
+        ACTIONS.put("showPage", ctx -> { ctx.showPage(); return null; });
+        ACTIONS.put("view", ctx -> { ctx.view(); return null; });
+        ACTIONS.put("addIncomingDocument", ctx -> ctx.addIncomingDocument());
         //  Enable calling the method to remove providers
         ACTIONS.put("removeLinkFromDocument", new ActionHandler() {
             public String handle(ManageDocument2Action action) {
@@ -133,6 +137,7 @@ public class ManageDocument2Action extends ActionSupport {
                 return null;
             }
         });
+        ACTIONS.put("viewDocumentInfo", ctx -> { ctx.viewDocumentInfo(); return null; });
     }
 
     // Called on default by struts.xml, finds the correct method to use by finding what the URL "method" param is equal to

--- a/src/main/java/ca/openosp/openo/form/eCARES/EcaresForm2Action.java
+++ b/src/main/java/ca/openosp/openo/form/eCARES/EcaresForm2Action.java
@@ -54,9 +54,22 @@ public class EcaresForm2Action extends ActionSupport {
     private final SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
     ;
 
-    public String exexute() {
-        if ("getTickler".equals(request.getParameter("method"))) {
+    public String execute() {
+        String method = request.getParameter("method");
+        if ("getTickler".equals(method)) {
             return getTickler();
+        } else if ("get".equals(method)) {
+            get();
+            return null;
+        } else if ("save".equals(method)) {
+            save();
+            return null;
+        } else if ("createTickler".equals(method)) {
+            createTickler();
+            return null;
+        } else if ("export".equals(method)) {
+            export();
+            return null;
         }
         return fetch();
     }


### PR DESCRIPTION
In this PR, I have fixed:
- Some missing method mappings in the execute/hashmap implementations
- A typo in the "execute" method name, was "exexute"

I have tested this by:
- Smoke testing the application

## Summary by Sourcery

Align Struts action dispatching with available controller methods for eCARES and document management flows.

Bug Fixes:
- Correct the main action entrypoint name in EcaresForm2Action so Struts can invoke it properly.
- Wire previously unreachable eCARES form methods (get, save, createTickler, export) into the execute dispatch based on the request method parameter.
- Register missing method mappings in ManageDocument2Action so additional document-related actions can be invoked via the method parameter.