### PR TITLE
Use RA_FORWORD property for Billing Reconciliation link to show report list instead of upload form

### DIFF
--- a/src/main/webapp/admin/admin.jsp
+++ b/src/main/webapp/admin/admin.jsp
@@ -353,7 +353,7 @@
                     <li><a href="#" onclick='popupPage(600,900, "${pageContext.request.contextPath}/billing/CA/ON/viewMOHFiles.jsp");return false;'><fmt:setBundle basename="oscarResources"/><fmt:message key="admin.admin.viewMOHFiles"/></a></li>
                     <% } %>
                     <li><a href="#"
-                           onclick='popupPage(600,900, "${pageContext.request.contextPath}/billing/CA/ON/billingRA.jsp");return false;'><fmt:setBundle basename="oscarResources"/><fmt:message key="admin.admin.btnBillingReconciliation"/></a></li>
+                           onclick='popupPage(600,900, "${pageContext.request.contextPath}<%= oscarVariables.getProperty("RA_FORWORD", "/billing/CA/ON/genRA.jsp") %>");return false;'><fmt:setBundle basename="oscarResources"/><fmt:message key="admin.admin.btnBillingReconciliation"/></a></li>
                     <!-- li><a href="#" onclick ='popupPage(600,1000,"${pageContext.request.contextPath}/billing/CA/ON/billingOBECEA.jsp");return false;'><fmt:setBundle basename="oscarResources"/><fmt:message key="admin.admin.btnEDTBillingReportGenerator"/></a></li-->
                     <li>
                         <a href="#" onclick='popupPage(800,1000,"${pageContext.request.contextPath}/mcedt/mcedt.do");return false;'><fmt:setBundle basename="oscarResources"/><fmt:message key="admin.admin.mcedt"/></a>

--- a/src/main/webapp/administration/leftNav.jspf
+++ b/src/main/webapp/administration/leftNav.jspf
@@ -206,7 +206,7 @@ String curProvider_no = (String)session.getAttribute("user");
 					</li>
 					</oscar:oscarPropertiesCheck>
 					<li><a href='javascript:void(0);'
-						class="xlink" rel="${ctx}/billing/CA/ON/billingRA.jsp"><fmt:setBundle basename="oscarResources"/><fmt:message key="admin.admin.btnBillingReconciliation"/></a></li>
+						class="xlink" rel="${ctx}<%= oscarVariables.getProperty("RA_FORWORD", "/billing/CA/ON/genRA.jsp") %>"><fmt:setBundle basename="oscarResources"/><fmt:message key="admin.admin.btnBillingReconciliation"/></a></li>
 					<!--  li><a href='javascript:void(0);' onclick ='popupPage(600,1000,"${ctx}/billing/CA/ON/billingOBECEA.jsp");return false;'><fmt:setBundle basename="oscarResources"/><fmt:message key="admin.admin.btnEDTBillingReportGenerator"/></a></li-->
 					<li><a href='javascript:void(0);'
 						class="xlink" rel="${ctx}/billing/CA/ON/billStatus.jsp"><fmt:setBundle basename="oscarResources"/><fmt:message key="admin.admin.invoiceRpts"/></a></li>


### PR DESCRIPTION
## Summary
  Fixes the "Billing Reconciliation" link in the Administration menu to display the list of existing reconciliation reports instead of showing a duplicate upload form.

  ## Problem
  After the Struts 2 migration, the "Billing Reconciliation" link was hardcoded to `/billing/CA/ON/billingRA.jsp`, which is an upload form. This duplicated the functionality of the "Upload MOH File" link and prevented users from viewing existing reconciliation reports.


  ## Solution
  Updated both `admin.jsp` and `leftNav.jspf` to use the `RA_FORWORD` property from `oscar.properties` instead of hardcoding the path. This property correctly points to `/billing/CA/ON/genRA.jsp`, which displays the reconciliation reports list.

## Summary by Sourcery

Enhancements:
- Replace the hardcoded Billing Reconciliation link path with a value sourced from the RA_FORWORD configuration property to correctly route users to the reconciliation reports list.