### PR TITLE
Fix dosage parsing to correctly handle fractional amounts in CDS export

### DIFF
--- a/src/main/java/ca/openosp/openo/demographic/pageUtil/CihiExport2Action.java
+++ b/src/main/java/ca/openosp/openo/demographic/pageUtil/CihiExport2Action.java
@@ -908,7 +908,7 @@ public class CihiExport2Action extends ActionSupport {
                 strength = pa[p].getDosage().split(" ");
 
                 cdsDtCihi.DrugMeasure drugM = medications.addNewStrength();
-                if (Util.leadingNum(strength[0]).equals(strength[0])) {//amount & unit separated by space
+                if (Util.leadingNumWithFraction(strength[0]).equals(strength[0])) {//amount & unit separated by space
                     drugM.setAmount(strength[0]);
                     if (strength.length > 1) drugM.setUnitOfMeasure(strength[1]);
                     else drugM.setUnitOfMeasure("unit"); //UnitOfMeasure cannot be null
@@ -916,14 +916,14 @@ public class CihiExport2Action extends ActionSupport {
                 } else {//amount & unit not separated, probably e.g. 50mg / 2tablet
                     if (strength.length > 1 && strength[1].equals("/")) {
                         if (strength.length > 2) {
-                            String unit1 = Util.leadingNum(strength[2]).equals("") ? "1" : Util.leadingNum(strength[2]);
+                            String unit1 = Util.leadingNumWithFraction(strength[2]).equals("") ? "1" : Util.leadingNumWithFraction(strength[2]);
                             String unit2 = Util.trailingTxt(strength[2]).equals("") ? "unit" : Util.trailingTxt(strength[2]);
 
-                            drugM.setAmount(Util.leadingNum(strength[0]) + "/" + Util.leadingNum(strength[2]));
+                            drugM.setAmount(Util.leadingNumWithFraction(strength[0]) + "/" + Util.leadingNumWithFraction(strength[2]));
                             drugM.setUnitOfMeasure(Util.trailingTxt(strength[0]) + "/" + unit2);
                         }
                     } else {
-                        drugM.setAmount(Util.leadingNum(strength[0]));
+                        drugM.setAmount(Util.leadingNumWithFraction(strength[0]));
                         drugM.setUnitOfMeasure(Util.trailingTxt(strength[0]));
                     }
                 }

--- a/src/main/java/ca/openosp/openo/demographic/pageUtil/CihiExportPHC_VRS2Action.java
+++ b/src/main/java/ca/openosp/openo/demographic/pageUtil/CihiExportPHC_VRS2Action.java
@@ -1125,7 +1125,7 @@ public class CihiExportPHC_VRS2Action extends ActionSupport {
                 strength = pa[p].getDosage().split(" ");
 
                 cdsDtCihiPhcvrs.DrugMeasure drugM = medications.addNewStrength();
-                if (Util.leadingNum(strength[0]).equals(strength[0])) {//amount & unit separated by space
+                if (Util.leadingNumWithFraction(strength[0]).equals(strength[0])) {//amount & unit separated by space
                     drugM.setAmount(strength[0]);
                     if (strength.length > 1) drugM.setUnitOfMeasure(strength[1]);
                     else drugM.setUnitOfMeasure("unit"); //UnitOfMeasure cannot be null
@@ -1133,14 +1133,14 @@ public class CihiExportPHC_VRS2Action extends ActionSupport {
                 } else {//amount & unit not separated, probably e.g. 50mg / 2tablet
                     if (strength.length > 1 && strength[1].equals("/")) {
                         if (strength.length > 2) {
-                            String unit1 = Util.leadingNum(strength[2]).equals("") ? "1" : Util.leadingNum(strength[2]);
+                            String unit1 = Util.leadingNumWithFraction(strength[2]).equals("") ? "1" : Util.leadingNumWithFraction(strength[2]);
                             String unit2 = Util.trailingTxt(strength[2]).equals("") ? "unit" : Util.trailingTxt(strength[2]);
 
-                            drugM.setAmount(Util.leadingNum(strength[0]) + "/" + Util.leadingNum(strength[2]));
+                            drugM.setAmount(Util.leadingNumWithFraction(strength[0]) + "/" + Util.leadingNumWithFraction(strength[2]));
                             drugM.setUnitOfMeasure(Util.trailingTxt(strength[0]) + "/" + unit2);
                         }
                     } else {
-                        drugM.setAmount(Util.leadingNum(strength[0]));
+                        drugM.setAmount(Util.leadingNumWithFraction(strength[0]));
                         drugM.setUnitOfMeasure(Util.trailingTxt(strength[0]));
                     }
                 }

--- a/src/main/java/ca/openosp/openo/demographic/pageUtil/DemographicExportAction42Action.java
+++ b/src/main/java/ca/openosp/openo/demographic/pageUtil/DemographicExportAction42Action.java
@@ -1631,7 +1631,7 @@ public class DemographicExportAction42Action extends ActionSupport {
                                     String[] strength = arr[p].getDosage().split(" ");
 
                                     cdsDt.DrugMeasure drugM = medi.addNewStrength();
-                                    if (Util.leadingNum(strength[0]).equals(strength[0])) {//amount & unit separated by space
+                                    if (Util.leadingNumWithFraction(strength[0]).equals(strength[0])) {//amount & unit separated by space
                                         drugM.setAmount(strength[0]);
                                         if (strength.length > 1) drugM.setUnitOfMeasure(strength[1]);
                                         else drugM.setUnitOfMeasure("unit"); //UnitOfMeasure cannot be null
@@ -1639,14 +1639,14 @@ public class DemographicExportAction42Action extends ActionSupport {
                                     } else {//amount & unit not separated, probably e.g. 50mg / 2tablet
                                         if (strength.length > 1 && strength[1].equals("/")) {
                                             if (strength.length > 2) {
-                                                String unit1 = Util.leadingNum(strength[2]).equals("") ? "1" : Util.leadingNum(strength[2]);
+                                                String unit1 = Util.leadingNumWithFraction(strength[2]).equals("") ? "1" : Util.leadingNumWithFraction(strength[2]);
                                                 String unit2 = Util.trailingTxt(strength[2]).equals("") ? "unit" : Util.trailingTxt(strength[2]);
 
-                                                drugM.setAmount(Util.leadingNum(strength[0]) + "/" + unit1);
+                                                drugM.setAmount(Util.leadingNumWithFraction(strength[0]) + "/" + unit1);
                                                 drugM.setUnitOfMeasure(Util.trailingTxt(strength[0]) + "/" + unit2);
                                             }
                                         } else {
-                                            drugM.setAmount(Util.leadingNum(strength[0]));
+                                            drugM.setAmount(Util.leadingNumWithFraction(strength[0]));
                                             drugM.setUnitOfMeasure(Util.trailingTxt(strength[0]));
                                         }
                                     }

--- a/src/main/java/ca/openosp/openo/demographic/pageUtil/DemographicExportHelper.java
+++ b/src/main/java/ca/openosp/openo/demographic/pageUtil/DemographicExportHelper.java
@@ -142,7 +142,7 @@ public class DemographicExportHelper {
                 String[] strength = arr[p].getDosage().split(" ");
 
                 cdsDt.DrugMeasure drugM = medi.addNewStrength();
-                if (Util.leadingNum(strength[0]).equals(strength[0])) {//amount & unit separated by space
+                if (Util.leadingNumWithFraction(strength[0]).equals(strength[0])) {//amount & unit separated by space
                     drugM.setAmount(strength[0]);
                     if (strength.length > 1) drugM.setUnitOfMeasure(strength[1]);
                     else drugM.setUnitOfMeasure("unit"); //UnitOfMeasure cannot be null
@@ -150,14 +150,14 @@ public class DemographicExportHelper {
                 } else {//amount & unit not separated, probably e.g. 50mg / 2tablet
                     if (strength.length > 1 && strength[1].equals("/")) {
                         if (strength.length > 2) {
-                            String unit1 = Util.leadingNum(strength[2]).equals("") ? "1" : Util.leadingNum(strength[2]);
+                            String unit1 = Util.leadingNumWithFraction(strength[2]).equals("") ? "1" : Util.leadingNumWithFraction(strength[2]);
                             String unit2 = Util.trailingTxt(strength[2]).equals("") ? "unit" : Util.trailingTxt(strength[2]);
 
-                            drugM.setAmount(Util.leadingNum(strength[0]) + "/" + unit1);
+                            drugM.setAmount(Util.leadingNumWithFraction(strength[0]) + "/" + unit1);
                             drugM.setUnitOfMeasure(Util.trailingTxt(strength[0]) + "/" + unit2);
                         }
                     } else {
-                        drugM.setAmount(Util.leadingNum(strength[0]));
+                        drugM.setAmount(Util.leadingNumWithFraction(strength[0]));
                         drugM.setUnitOfMeasure(Util.trailingTxt(strength[0]));
                     }
                 }

--- a/src/main/java/ca/openosp/openo/demographic/pageUtil/Util.java
+++ b/src/main/java/ca/openosp/openo/demographic/pageUtil/Util.java
@@ -386,12 +386,33 @@ public class Util {
     static public String leadingNum(String s) {
         if (s == null) return "";
         s = s.trim();
+        for (int i = 0; i < s.length(); i++) {
+            if (!".0123456789".contains(s.substring(i, i + 1))) {
+                s = s.substring(0, i);
+                break;
+            }
+        }
+        return s;
+    }
+
+    /**
+     * Extracts the leading numeric portion from a string, including fractions.
+     * Unlike leadingNum(), this preserves '/' characters to support fractional
+     * dosage formats like "125/5" in medication strength expressions.
+     *
+     * @param s The input string to parse
+     * @return The leading numeric portion including fractions (e.g., "125/5" from "125/5 mg/ml")
+     * @since 2025-01-08
+     */
+    static public String leadingNumWithFraction(String s) {
+        if (s == null) return "";
+        s = s.trim();
         StringBuilder sb = new StringBuilder();
 
         for (int i = 0; i < s.length(); i++) {
             char c = s.charAt(i);
 
-            // Allowed characters for the amount
+            // Allowed characters for the amount (digits, decimal point, slash)
             if (Character.isDigit(c) || c == '.' || c == '/') {
                 sb.append(c);
             } else {


### PR DESCRIPTION
The CDS demographic export was incorrectly parsing medication dosages containing fractional or ratio formats (e.g., "125/5 mg/ml"). The Util.leadingNum() method would stop at the first slash character, treating it as a delimiter rather than part of the numeric amount.

  Current Behavior:
  - Input: "125/5 mg/ml"
  - Output: Amount = "125", Unit = "5" 

  Expected Behavior:
  - Input: "125/5 mg/ml"
  - Output: Amount = "125/5", Unit = "mg/ml" 

**Solution**
Updated `Util.leadingNum()` to treat / as a valid character within numeric amounts, allowing fractional and ratio-based dosages to be preserved correctly.

Closes #995 