### PR TITLE
Relax flowsheet update permissions

### DIFF
--- a/src/main/java/ca/openosp/openo/commn/web/FlowSheetCustom2Action.java
+++ b/src/main/java/ca/openosp/openo/commn/web/FlowSheetCustom2Action.java
@@ -138,7 +138,7 @@ public class FlowSheetCustom2Action extends ActionSupport {
 
     /**
      * Validates all customization permissions for the given scope and demographic.
-     * Checks: demographic access, scope permission (admin for clinic), and patient-level edit permission.
+     * Checks: demographic access and scope permission (admin for clinic).
      *
      * @param scope the scope ("clinic", or null for provider/patient)
      * @param demographicNo the demographic number ("0" for clinic/provider, patient ID otherwise)
@@ -153,12 +153,6 @@ public class FlowSheetCustom2Action extends ActionSupport {
         }
 
         flowSheetCustomizationService.validateScopePermission(loggedInInfo, scope);
-
-        boolean isPatientScope = demographicNo != null && !"0".equals(demographicNo);
-        if (isPatientScope &&
-            !flowSheetCustomizationService.canEditPatientLevelCustomization(loggedInInfo, demographicNo)) {
-            throw new SecurityException("Only providers registered to this patient can edit patient-level customizations");
-        }
 
         return loggedInInfo;
     }

--- a/src/main/webapp/oscarEncounter/oscarMeasurements/adminFlowsheet/UpdateFlowsheet.jsp
+++ b/src/main/webapp/oscarEncounter/oscarMeasurements/adminFlowsheet/UpdateFlowsheet.jsp
@@ -54,9 +54,6 @@
 <%@ page import="ca.openosp.openo.encounter.oscarMeasurements.util.TargetCondition" %>
 <%@ page import="ca.openosp.openo.encounter.oscarMeasurements.util.TargetColour" %>
 <%@ page import="ca.openosp.openo.commn.dao.FlowSheetCustomizationDao" %>
-<%@ page import="ca.openosp.openo.commn.service.FlowSheetCustomizationService" %>
-<%@ page import="ca.openosp.openo.utility.SpringUtils" %>
-<%@ page import="ca.openosp.openo.utility.LoggedInInfo" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 
 <%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar" %>
@@ -112,15 +109,6 @@ if(scope != null && "clinic".equals(scope)) {
     List<Recommendation> dsR = mFlowsheet.getDSElements((String) h2.get("measurement_type"));
     FlowSheetItem fsi = mFlowsheet.getFlowSheetItem(measurement);
 
-    // Check if current user can edit patient-level customizations
-    // Only providers registered to the patient (primary + extended team) can edit
-    boolean canEditPatientLevel = true; // Default to true for non-patient scopes
-    boolean isPatientScope = demographic != null && !demographic.isEmpty();
-    if (isPatientScope) {
-        FlowSheetCustomizationService flowSheetCustomizationService = SpringUtils.getBean(FlowSheetCustomizationService.class);
-        LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
-        canEditPatientLevel = flowSheetCustomizationService.canEditPatientLevelCustomization(loggedInInfo, demographic);
-    }
 //EctMeasurementTypeBeanHandler mType = new EctMeasurementTypeBeanHandler();
 %>
 
@@ -175,14 +163,8 @@ display:inline-block;
 
 <div class="container-fluid" id="container-main">
 
-        <% if (isPatientScope && !canEditPatientLevel) { %>
-        <div class="alert alert-warning">
-            <strong>View Only:</strong> Only providers registered to this patient can update measurements at the patient level.
-        </div>
-        <% } %>
-
         <div class="span8">
-<form action="FlowSheetCustomAction.do" onsubmit="<%= (isPatientScope && !canEditPatientLevel) ? "alert('Only registered providers can edit patient-level customizations'); return false;" : "return validateRuleValue();" %>">
+<form action="FlowSheetCustomAction.do" onsubmit="return validateRuleValue();">
                 <input type="hidden" name="method" value="update"/>
                 <input type="hidden" name="flowsheet" value="<%=flowsheet%>"/>
                 <input type="hidden" name="measurement" value="<%=measurement%>"/>
@@ -504,7 +486,7 @@ display:inline-block;
                         <a href="EditFlowsheet.jsp?flowsheet=<%=flowsheet%>&demographic=<%=demographic%><%=htQueryString%><%=scope != null ? "&scope=" + scope : ""%>"
                            class="btn">Cancel</a>
                         <%} %>
-                        <input type="submit" class="btn btn-primary" value="Update" <%= (isPatientScope && !canEditPatientLevel) ? "disabled" : "" %>/>
+                        <input type="submit" class="btn btn-primary" value="Update"/>
                     </div>
 
                 </fieldset>


### PR DESCRIPTION
## Changes made
- Removed the **patient-level** permission checks for flowsheet measurement updates.
- Permissions are still enforced at the admin panel level.
- If a provider has the flowsheet privilege, they will be able to edit flowsheet permissions for any other patient.

## Summary by Sourcery

Relax flowsheet patient-level edit restrictions so that any provider with the flowsheet privilege can edit flowsheet configurations for any patient.

Enhancements:
- Remove patient-level provider registration checks when editing flowsheet customizations.
- Simplify flowsheet customization service and JSPs by dropping demographic-based edit gating and related read-only UI states.