### PR TITLE
Fix: potential null pointer exception in tabletSignature.jsp if the user is not logged into the session and tries to access page

### DIFF
--- a/src/main/webapp/signature_pad/tabletSignature.jsp
+++ b/src/main/webapp/signature_pad/tabletSignature.jsp
@@ -16,7 +16,13 @@ is hosted in an IFrame and that the IFrame's parent window implements signatureH
 <%@ page import="ca.openosp.openo.utility.LoggedInInfo" %>
 <%@ page import="ca.openosp.openo.ui.servlet.ImageRenderingServlet" %>
 <%@ page import="ca.openosp.openo.commn.model.enumerator.ModuleType" %>
-
+<%
+    LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
+    if (loggedInInfo == null || loggedInInfo.getLoggedInProviderNo() == null) {
+        response.sendRedirect(request.getContextPath() + "/index.jsp");
+        return;
+    }
+%>
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -34,11 +40,6 @@ is hosted in an IFrame and that the IFrame's parent window implements signatureH
 
 </head>
 <%
-    LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
-    if (loggedInInfo == null || loggedInInfo.getLoggedInProviderNo() == null) {
-        response.sendRedirect(request.getContextPath() + "/index.jsp");
-        return;
-    }
     String requestIdKey = request.getParameter(DigitalSignatureUtils.SIGNATURE_REQUEST_ID_KEY);
     if (requestIdKey == null) {
         requestIdKey = DigitalSignatureUtils.generateSignatureRequestId(loggedInInfo.getLoggedInProviderNo());


### PR DESCRIPTION
## In this PR, I have fixed:
- A potential null pointer exception in tabletSignature.jsp if the user is not logged into the session and tries to access the page

## I have tested this by:
- Testing non logged in attempt directly to the tabletSignature URL, to ensure that it redirects back to the main login page in this case

## Summary by Sourcery

Bug Fixes:
- Prevent a potential null pointer exception on the tablet signature page when accessed without a valid logged-in session.