### PR TITLE
Fix: missing owasp output encoding on error page outputs

### DIFF
--- a/src/main/webapp/failure.jsp
+++ b/src/main/webapp/failure.jsp
@@ -24,6 +24,7 @@
 
 --%>
 <%@ page session="true" %>
+<%@ page import="org.owasp.encoder.Encode" %>
 <html>
 
     <html>
@@ -37,7 +38,7 @@
     <div class="action-errors">
         <ul>
             <% for (String error : actionErrors) { %>
-                <li><%= error %></li>
+                <li><%= Encode.forHtml(error) %></li>
             <% } %>
         </ul>
     </div>

--- a/src/main/webapp/loginfailed.jsp
+++ b/src/main/webapp/loginfailed.jsp
@@ -25,7 +25,8 @@
 --%>
 
 <%@page
-        import="ca.openosp.OscarProperties" %>
+        import="ca.openosp.OscarProperties,
+                org.owasp.encoder.Encode" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 <%
     String errormsg = request.getParameter("errormsg");
@@ -40,7 +41,7 @@
     <body>
     <!--h2>OSCAR has encountered the following fatal error:</h2>
       <hr-->
-    <p><%=errormsg%>
+    <p><%= Encode.forHtml(errormsg) %>
     <p>Please correct and try again.
     </body>
 </html>

--- a/src/main/webapp/securityError.jsp
+++ b/src/main/webapp/securityError.jsp
@@ -23,7 +23,8 @@
     Ontario, Canada
 
 --%>
-<%@ page import="java.util.List" %>
+<%@ page import="java.util.List,
+                 org.owasp.encoder.Encode" %>
 
 <html>
 <head>
@@ -39,7 +40,7 @@ You tried to access a resource with insufficient privileges.
     if (vals != null) {
         for (String val : vals) {
 %>
-<h5>Object:<%=val %>
+<h5>Object:<%= Encode.forHtml(val) %>
 </h5>
 <%
         }
@@ -52,7 +53,7 @@ You tried to access a resource with insufficient privileges.
     <div class="action-errors">
         <ul>
             <% for (String error : actionErrors) { %>
-                <li><%= error %></li>
+                <li><%= Encode.forHtml(error) %></li>
             <% } %>
         </ul>
     </div>


### PR DESCRIPTION
## In this PR, I have fixed
- Missing OWASP output encoding on error page outputs

## I have tested this by
- Ensuring that the encoding type matches the output type expected with the selected OWASP methods