### PR TITLE
Fix regression: incorrect label on Security Record pages by separating i18n keys

### DIFF
--- a/src/main/resources/oscarResources_en.properties
+++ b/src/main/resources/oscarResources_en.properties
@@ -1883,7 +1883,7 @@ admin.securityaddarecord.description=ADD A LOGIN USER
 admin.securityaddarecord.onlyInternet=(only for Internet access.)
 admin.securityaddarecord.btnSubmit=Add Record
 
-admin.securityrecord.formUserName=Provider last name
+admin.securityrecord.formUserName=User Name
 admin.securityrecord.formPassword=Password
 admin.securityrecord.formConfirm=Confirm
 admin.securityrecord.formProviderNo=Provider No.
@@ -7994,7 +7994,7 @@ admin.provideraddrole.msgyoumusttype=You must type in a role name.
 appointment.addappointment.title2=Appointment Types
 appointment.addappointment.editappointmenttype=EDIT APPOINTMENT TYPE
 admin.providerrole.title2=Provider-Role List
-
+admin.providerrole.formSearch=Provider last name
 
 
 # Fin Etienne

--- a/src/main/resources/oscarResources_es.properties
+++ b/src/main/resources/oscarResources_es.properties
@@ -1330,6 +1330,7 @@ admin.search.btnLastPage=Pagina anterior
 admin.search.btnNextPage=Pagina siguiente
 admin.providersearch.formName=Nombre
 admin.providersearch.formLastName=Apellido
+admin.providerrole.formSearch=Apellido del proveedor
 admin.providersearch.formNo=Numero prestador
 admin.providersearch.formAllStatus=Busca todo
 admin.providersearch.formActiveStatus=Solo activos
@@ -6473,4 +6474,3 @@ inbox.inboxmanager.msgEndDate=Fecha de finalización
 inbox.inboxmanager.msgStartDate=Fecha de inicio
 inbox.inboxmanager.msgFiled=Archivado
 inbox.inboxmanager.msgPhysicianSearchType=Buscar tipo de médico
-

--- a/src/main/resources/oscarResources_fr.properties
+++ b/src/main/resources/oscarResources_fr.properties
@@ -5934,6 +5934,7 @@ admin.provideraddrole.msgyoumusttype=Vous devez entrer un nom de r\u00f4le.
 appointment.addappointment.title2=Types De RDV
 appointment.addappointment.editappointmenttype=\u00c9DITION - TYPE DE RDV
 admin.providerrole.title2=Liste Des R\u00f4les
+admin.providerrole.formSearch=Nom de famille du fournisseur
 
 
 
@@ -6185,4 +6186,3 @@ inbox.inboxmanager.msgEndDate=Date de fin
 inbox.inboxmanager.msgStartDate=Date de d&#x00E9;but
 inbox.inboxmanager.msgFiled=Class&#x00E9;
 inbox.inboxmanager.msgPhysicianSearchType=Rechercher le type de m&#x00E9;decin
-

--- a/src/main/resources/oscarResources_pl.properties
+++ b/src/main/resources/oscarResources_pl.properties
@@ -1109,6 +1109,7 @@ admin.search.btnLastPage=Ostatnia strona
 admin.search.btnNextPage=Nast&#X119;pna strona
 admin.providersearch.formName=Nazwa
 admin.providersearch.formLastName=Nazwisko
+admin.providerrole.formSearch=Nazwisko dostawcy
 admin.providersearch.formNo=Nr Dostawca
 admin.providersearch.formAllStatus=Przeszukaj wszystko
 admin.providersearch.formActiveStatus=aktywne tylko wtedy,
@@ -5733,4 +5734,3 @@ inbox.inboxmanager.msgEndDate=Data zako&#x0144;czenia
 inbox.inboxmanager.msgStartDate=Data rozpocz&#x0119;cia
 inbox.inboxmanager.msgFiled=Z&#x0142;o&#x017C;ono
 inbox.inboxmanager.msgPhysicianSearchType=Wyszukaj typ lekarza
-

--- a/src/main/resources/oscarResources_pt_BR.properties
+++ b/src/main/resources/oscarResources_pt_BR.properties
@@ -7805,6 +7805,7 @@ admin.provideraddrole.msgyoumusttype=Voc\u00EA deve digitar um nome de fun\u00E7
 appointment.addappointment.title2=Tipos de consultas
 appointment.addappointment.editappointmenttype=EDITAR TIPO DE CONSULTAS
 admin.providerrole.title2=Lista de pap\u00E9is do provedor
+admin.providerrole.formSearch=Sobrenome do provedor
 
 
 
@@ -8084,4 +8085,3 @@ inbox.inboxmanager.msgEndDate=Data final
 inbox.inboxmanager.msgStartDate=Data de in&#x00ED;cio
 inbox.inboxmanager.msgFiled=Arquivado
 inbox.inboxmanager.msgPhysicianSearchType=Pesquisar tipo de m&#x00E9;dico
-

--- a/src/main/webapp/admin/providerRole.jsp
+++ b/src/main/webapp/admin/providerRole.jsp
@@ -490,7 +490,7 @@
 
         <div class="controls">
             <div class="input-append">
-                <input type="text" placeholder="<fmt:setBundle basename="oscarResources"/><fmt:message key="admin.securityrecord.formUserName"/>" name="keyword"
+                <input type="text" placeholder="<fmt:setBundle basename="oscarResources"/><fmt:message key="admin.providerrole.formSearch"/>" name="keyword"
                        value="<%=Encode.forHtmlAttribute(keyword)%>"/>
                 <input type="submit" class="btn btn-primary" name="search" value="Filter" >
             </div>


### PR DESCRIPTION
A regression introduced in commit  https://github.com/openo-beta/Open-O/commit/26f14de6f70fab12f222b871a71dc7d388202d1e was intended to update the label text for the **Provider Role** page (`providerRole.jsp`).  
However, the change unintentionally affected the **Security Record** pages as well because both pages were using the same shared i18n label key.

As a result, the **Security Record** UI displayed an incorrect label (“Provider last name”) instead of the expected “User Name”.

This PR fixes the issue by separating the i18n keys so each page uses a context-appropriate label.

---

## Fix Summary

### I18n Key Organization

**File**: `src/main/webapp/admin/providerRole.jsp`
- Changed the search placeholder key from  
  `admin.securityrecord.formUserName`  
  to  
  `admin.providerrole.formSearch`
- Provides clear context separation between:
  - Generic user name fields (Security Records)
  - Provider-specific search fields (Provider Role)

---

**Files**: `src/main/resources/oscarResources_*.properties`
- Reverted `admin.securityrecord.formUserName` to **"User Name"**
- Added a new context-specific key:  
  `admin.providerrole.formSearch = "Provider last name"`
- Applied translations across all language files:
  - English (`en`)
  - Spanish (`es`)
  - French (`fr`)
  - Polish (`pl`)
  - Portuguese Brazil (`pt_BR`)

Closes #1646

## Summary by Sourcery

Restore correct user name labeling on Security Record and Provider Role pages by separating their i18n keys.

Bug Fixes:
- Correct the Security Record user name label to display "User Name" instead of a provider-specific label.

Enhancements:
- Introduce a dedicated i18n key for the Provider Role search placeholder, with translations across supported languages (en, es, fr, pl, pt_BR).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a regression that showed “Provider last name” on Security Record pages by separating i18n keys. Security Record now correctly shows “User Name,” and Provider Role has its own search placeholder.

- **Bug Fixes**
  - Split the shared label into context-specific keys: admin.securityrecord.formUserName and admin.providerrole.formSearch.
  - Updated providerRole.jsp to use the new provider role key.
  - Added translations for en, es, fr, pl, pt_BR.

<sup>Written for commit f2fea6f014b993b4bdef824e124a0657fef455e9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected security record field label for improved accuracy.

* **Chores**
  * Updated provider role search form with localized field labels across all supported languages (English, Spanish, French, Polish, Portuguese).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->