### PR TITLE
Fixed: ensure that nonDrug field is only checked when it exists

### DIFF
--- a/src/main/webapp/oscarRx/AddReaction2.jsp
+++ b/src/main/webapp/oscarRx/AddReaction2.jsp
@@ -161,8 +161,8 @@
                                 }
 
                                 function doSubmit() {
-
-                                    if (document.forms.RxAddAllergyForm.nonDrug.value == '') {
+                                    var nonDrugField = document.forms.RxAddAllergyForm.nonDrug;
+                                    if (nonDrugField && nonDrugField.value == '') {
                                         alert("Please choose value for non-drug");
                                         return false;
                                     }


### PR DESCRIPTION
## In this PR, I have fixed
- A browser console error, that happens due to a field that may or may not exist when adding a new allergy

## I have tested this by
- Testing adding an allergy, ensuring that the error does not pop up in the browser console logs

## Summary by Sourcery

Bug Fixes:
- Prevent JavaScript errors by checking for the existence of the nonDrug field before validating its value in the allergy form.

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes a console error when adding an allergy by only validating the nonDrug field if it exists. Addresses Linear issue "browser-console-error-when-adding-allergy-1656."

<sup>Written for commit e0c62be4982456819738df53fc113768f5a34d41. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Bug Fixes:
- Avoid console errors when submitting the allergy form by only validating the nonDrug field if it is present.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation for reaction form submissions to prevent potential errors during form processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->