### PR TITLE
chore: remove add pre-reqs from playwright install as already install…

### DIFF
--- a/.devcontainer/development/Dockerfile
+++ b/.devcontainer/development/Dockerfile
@@ -70,10 +70,11 @@ RUN npm install -g @google/gemini-cli
 RUN npm install -g playwright@1.40.0 && \
     echo "✅ Playwright CLI installed: $(npx playwright --version)"
 
-# Install all Playwright browsers (Chromium, Chrome, Firefox) with system dependencies
-# Note: --with-deps installs required system libraries for each browser
-# This runs during image build, so browsers are baked into the image
-RUN npx playwright install --with-deps chromium chrome firefox && \
+# Install all Playwright browsers (Chromium, Chrome, Firefox)
+# Note: System dependencies are already installed above with Ubuntu 24.04 t64 package names.
+# Do NOT use --with-deps as Playwright's dependency list contains deprecated package names
+# (e.g., libasound2 instead of libasound2t64) that don't exist in Ubuntu 24.04.
+RUN npx playwright install chromium chrome firefox && \
     echo "✅ Playwright browsers installed (Chromium, Chrome, Firefox)"
 
 # Install pipx and Aider AI coding assistant


### PR DESCRIPTION
…ed and t-lib confusions

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the --with-deps flag from Playwright browser install in the devcontainer Dockerfile to avoid deprecated Ubuntu packages. Dependencies are already present on Ubuntu 24.04 (t64 names), so installs succeed and image builds stop failing.

<sup>Written for commit 0193cce6ac247fe2d4dc6e456b959f993530129f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development environment browser dependencies configuration to improve compatibility with system package management and remove deprecated dependencies.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->