### PR TITLE
docs: add comprehensive JavaDoc to AbstractModel.java

### DIFF
--- a/src/main/java/ca/openosp/openo/ws/AbstractModel.java
+++ b/src/main/java/ca/openosp/openo/ws/AbstractModel.java
@@ -53,7 +53,7 @@ import java.io.Serializable;
  *
  * @since 2026-01-18
  * @see Client
- * @see ca.openosp.openo.ws.rest.HnrWs
+ * @see ca.openosp.openo.caisi_integrator.ws.HnrWs
  * @see javax.xml.bind.annotation.XmlAccessorType
  * @see javax.xml.bind.annotation.XmlType
  * @see java.io.Serializable


### PR DESCRIPTION
## Summary

Adds comprehensive JavaDoc documentation to `AbstractModel.java` per CLAUDE.md standards.

## Changes

- Add class-level JavaDoc with JAXB configuration details
- Document serialization and healthcare context
- Add inline documentation for serialVersionUID
- Include @since tag (2026-01-18) and @see references
- Add usage example for JAXB marshalling
- Document PHI handling requirements per HIPAA/PIPEDA

## Documentation Coverage

- ✅ Class-level JavaDoc with healthcare context
- ✅ Field-level JavaDoc for serialVersionUID
- ✅ @since tag with accurate date from git log
- ✅ @see tags for related classes
- ✅ No @author tags (per CLAUDE.md)
- ✅ Zero code logic changes

Fixes #1590

---

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add comprehensive JavaDoc to AbstractModel.java to document JAXB field access, XML type, Java serialization, and PHI handling guidance. Addresses #1590 by improving DTO documentation with a JAXB marshalling example and @since/@see tags; no code logic changes.

<sup>Written for commit e81fd4e9e77b983b1ec4c4de50e847f4fd12bde1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved internal technical documentation and serialization metadata to aid maintenance and future compatibility. No changes to public interfaces or user-facing behavior; this update is maintenance-only and does not affect application functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->