### PR TITLE
Security: excluded old itext pdf transitive dependency from displaytag, openpdf is used instead

### DIFF
--- a/dependencies-lock-modern.json
+++ b/dependencies-lock-modern.json
@@ -632,14 +632,6 @@
     "optional" : false,
     "integrity" : "sha512:sXIDC0TFQB6WcoCJMct5WDDV0d1azfWtRBgt73w6s5EA5W5YMljGsXf0Y93XG5wXSGaMSgZOwuQMsZq9WFO/Dg=="
   }, {
-    "groupId" : "com.lowagie",
-    "artifactId" : "itext",
-    "version" : "1.3",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:x3dYRKcfTUGrzs4+YAKh4PWEhzuqCEblE55l4D9r6R5n+iYAU54ZNpo197s1xfCeLCvxlyQB+72OY6CANf20xw=="
-  }, {
     "groupId" : "com.medseek.clinical.service",
     "artifactId" : "SSOClinicalConnect",
     "version" : "20171101",

--- a/dependencies-lock.json
+++ b/dependencies-lock.json
@@ -632,14 +632,6 @@
     "optional" : false,
     "integrity" : "sha512:sXIDC0TFQB6WcoCJMct5WDDV0d1azfWtRBgt73w6s5EA5W5YMljGsXf0Y93XG5wXSGaMSgZOwuQMsZq9WFO/Dg=="
   }, {
-    "groupId" : "com.lowagie",
-    "artifactId" : "itext",
-    "version" : "1.3",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:x3dYRKcfTUGrzs4+YAKh4PWEhzuqCEblE55l4D9r6R5n+iYAU54ZNpo197s1xfCeLCvxlyQB+72OY6CANf20xw=="
-  }, {
     "groupId" : "com.medseek.clinical.service",
     "artifactId" : "SSOClinicalConnect",
     "version" : "20171101",

--- a/pom.xml
+++ b/pom.xml
@@ -788,6 +788,12 @@
                     <groupId>commons-lang</groupId>
                     <artifactId>commons-lang</artifactId>
                 </exclusion>
+                <!-- Excluded vulnerable iText 1.3 (XXE vulnerability) -->
+                <!-- com.lowagie.text.* classes provided by openpdf (via openrtf) instead -->
+                <exclusion>
+                    <groupId>com.lowagie</groupId>
+                    <artifactId>itext</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 


### PR DESCRIPTION
## In this PR, I have:
- Removed an old itext transitive dependency from displaytag (has a security vulnerability)

## I have tested this by:
- Testing PDF functionality (displaying PDF's, exporting PDF's, etc)

## Summary by Sourcery

Build:
- Exclude the vulnerable transitive dependency com.lowagie:itext from the Maven build configuration and refresh dependency lock files accordingly.

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the vulnerable iText 1.3 transitive dependency to prevent XXE. We now rely on OpenPDF (via openrtf) for com.lowagie.text.* classes.

- **Dependencies**
  - Added exclusion for com.lowagie:itext in pom.xml.
  - Updated dependency lock files to remove iText; OpenPDF remains the PDF implementation.

<sup>Written for commit b31fcdee7b340a468f65b92e0136b99239183b23. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Build:
- Exclude com.lowagie:itext from the displaytag dependency in the Maven build configuration and refresh dependency lock files to drop the old iText library.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Removed itext library from project dependencies, including build configuration and dependency lock files. This update streamlines the project's dependency tree.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->