### PR TITLE
Update main to match open-osp

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,7 +21,17 @@
                 "java.compile.nullAnalysis.mode": "automatic",
                 "java.configuration.updateBuildConfiguration": "interactive",
                 "java.jdt.ls.vmargs": "-XX:+UseParallelGC -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xmx4G -Xms512m -Xlog:disable",
-                "java.maven.downloadSources": false
+                "java.maven.downloadSources": false,
+                "claude.mcpServers": {
+                    "playwright": {
+                        "command": "npx",
+                        "args": ["@executeautomation/playwright-mcp-server"],
+                        "env": {
+                            "PLAYWRIGHT_BROWSER": "firefox",
+                            "PLAYWRIGHT_HEADLESS": "true"
+                        }
+                    }
+                }
               }
         }
     },

--- a/.devcontainer/development/Dockerfile
+++ b/.devcontainer/development/Dockerfile
@@ -61,6 +61,10 @@ RUN npm install -g @anthropic-ai/claude-code @docusaurus/core @docusaurus/preset
 # Install Gemini CLI.
 RUN npm install -g @google/gemini-cli
 
+# Install Playwright and Playwright MCP server
+RUN npm install -g @executeautomation/playwright-mcp-server playwright && \
+    npx playwright install chromium firefox --with-deps
+
 # Install pipx and Aider AI coding assistant
 RUN apt-get update && apt-get install -y pipx && \
     pipx install aider-chat && \

--- a/src/main/java/ca/openosp/openo/PMmodule/caisi_integrator/AuthenticationOutWSS4JInterceptorForIntegrator.java
+++ b/src/main/java/ca/openosp/openo/PMmodule/caisi_integrator/AuthenticationOutWSS4JInterceptorForIntegrator.java
@@ -47,17 +47,56 @@ import org.apache.wss4j.dom.handler.WSHandlerConstants;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
+/**
+ * CXF outbound interceptor for WS-Security authentication with custom CAISI provider identification.
+ * <p>
+ * This interceptor extends the standard WSS4J interceptor to add both WS-Security username token
+ * authentication and a custom SOAP header containing the requesting CAISI provider number. This
+ * dual authentication/identification approach is required for the integrator system to:
+ * <ul>
+ *   <li>Authenticate the facility making the request via WS-Security username/password</li>
+ *   <li>Identify the individual provider within that facility making the request</li>
+ *   <li>Enable proper audit logging and access control at the provider level</li>
+ * </ul>
+ * </p>
+ * <p>
+ * The interceptor is configured on CXF client proxies when establishing connections to
+ * integrator web services, ensuring all outbound SOAP messages contain both authentication
+ * credentials and provider identification.
+ * </p>
+ *
+ * @see org.apache.cxf.ws.security.wss4j.WSS4JOutInterceptor
+ * @see javax.security.auth.callback.CallbackHandler
+ */
 public class AuthenticationOutWSS4JInterceptorForIntegrator extends WSS4JOutInterceptor implements CallbackHandler {
+    /** Key used for the custom SOAP header identifying the requesting provider */
     private static final String REQUESTING_CAISI_PROVIDER_NO_KEY = "requestingCaisiProviderNo";
+    
+    /** QName for the custom SOAP header with namespace and prefix */
     private static QName REQUESTING_CAISI_PROVIDER_NO_QNAME = new QName("http://oscarehr.org/caisi", REQUESTING_CAISI_PROVIDER_NO_KEY, "caisi");
 
+    /** Password for WS-Security authentication */
     private String password = null;
+    
+    /** Provider number of the requesting CAISI provider */
     private String oscarProviderNo = null;
 
+    /**
+     * Constructs the interceptor with authentication credentials and provider identification.
+     * <p>
+     * Initializes both the WS-Security username token authentication (via WSS4J) and stores
+     * the provider number for inclusion in custom SOAP headers.
+     * </p>
+     * 
+     * @param user the username for facility authentication
+     * @param password the password for facility authentication
+     * @param oscarProviderNo the provider number making the request (may be null for facility-level calls)
+     */
     public AuthenticationOutWSS4JInterceptorForIntegrator(String user, String password, String oscarProviderNo) {
         this.password = password;
         this.oscarProviderNo = oscarProviderNo;
 
+        // Configure WSS4J properties for username token authentication
         HashMap<String, Object> properties = new HashMap<String, Object>();
         properties.put(WSHandlerConstants.ACTION, WSHandlerConstants.USERNAME_TOKEN);
         properties.put(WSHandlerConstants.USER, user);
@@ -67,36 +106,84 @@ public class AuthenticationOutWSS4JInterceptorForIntegrator extends WSS4JOutInte
         setProperties(properties);
     }
 
+    /**
+     * Callback handler for providing the password to WSS4J.
+     * <p>
+     * This method is called by the WSS4J framework when it needs the password
+     * to include in the WS-Security username token.
+     * </p>
+     * 
+     * @param callbacks array of callback objects to handle
+     * @throws IOException if an I/O error occurs
+     * @throws UnsupportedCallbackException if a callback type is not supported
+     */
     // don't like @override until jdk1.6?
     // @Override
     public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
         for (Callback callback : callbacks) {
             if (callback instanceof WSPasswordCallback) {
                 WSPasswordCallback wsPasswordCallback = (WSPasswordCallback) callback;
+                // Provide the password for WS-Security authentication
                 wsPasswordCallback.setPassword(password);
             }
         }
     }
 
+    /**
+     * Handles outbound SOAP messages by adding custom provider header and invoking parent processing.
+     * <p>
+     * This method intercepts outbound messages before they are sent to add the custom CAISI
+     * provider number header, then delegates to the parent WSS4JOutInterceptor to add the
+     * WS-Security authentication token.
+     * </p>
+     * 
+     * @param message the outbound SOAP message to process
+     * @throws Fault if an error occurs during message processing
+     */
     public void handleMessage(SoapMessage message) throws Fault {
+        // Add custom header identifying the requesting provider
         addRequestingCaisiProviderNo(message, oscarProviderNo);
+        // Delegate to parent to add WS-Security token
         super.handleMessage(message);
     }
 
+    /**
+     * Adds the requesting CAISI provider number as a custom SOAP header.
+     * <p>
+     * The provider number is only added if it is not null. This allows the integrator
+     * service to log and audit which specific provider made the request, even though
+     * the facility credentials are used for authentication.
+     * </p>
+     * 
+     * @param message the SOAP message to add the header to
+     * @param providerNo the provider number to include, or null to skip
+     */
     private static void addRequestingCaisiProviderNo(SoapMessage message, String providerNo) {
         List<Header> headers = message.getHeaders();
 
         if (providerNo != null) {
+            // Create and add the custom SOAP header
             headers.add(createHeader(REQUESTING_CAISI_PROVIDER_NO_QNAME, REQUESTING_CAISI_PROVIDER_NO_KEY, providerNo));
         }
     }
 
+    /**
+     * Creates a SOAP header element with the specified QName, element name, and text value.
+     * 
+     * @param qName the qualified name for the header (includes namespace and prefix)
+     * @param key the local name of the header element
+     * @param value the text content of the header
+     * @return a CXF Header object ready to be added to the message
+     */
     private static Header createHeader(QName qName, String key, String value) {
+        // Create a new DOM document for the header element
         Document document = DOMUtils.createDocument();
 
+        // Create the header element in the CAISI namespace
         Element element = document.createElementNS("http://oscarehr.org/caisi", "caisi:" + key);
         element.setTextContent(value);
 
+        // Wrap in a CXF SOAP header
         SoapHeader header = new SoapHeader(qName, element);
         return (header);
     }

--- a/src/main/java/ca/openosp/openo/PMmodule/caisi_integrator/ByteWrapper.java
+++ b/src/main/java/ca/openosp/openo/PMmodule/caisi_integrator/ByteWrapper.java
@@ -2,21 +2,50 @@ package ca.openosp.openo.PMmodule.caisi_integrator;
 
 import java.io.Serializable;
 
+/**
+ * Simple wrapper class for byte arrays that implements Serializable.
+ * <p>
+ * This class provides a serializable container for byte array data, allowing
+ * raw byte data to be easily passed between distributed systems or stored
+ * in serialized form. Used primarily in integrator data transfer operations.
+ * </p>
+ * 
+ * @see java.io.Serializable
+ */
 public class ByteWrapper implements Serializable
 {
+    /** The wrapped byte array data */
     private byte[] data;
     
+    /**
+     * Default constructor creating an empty ByteWrapper.
+     */
     public ByteWrapper() {
     }
     
+    /**
+     * Constructs a ByteWrapper containing the specified byte array.
+     * 
+     * @param data the byte array to wrap
+     */
     public ByteWrapper(final byte[] data) {
         this.data = data;
     }
     
+    /**
+     * Retrieves the wrapped byte array.
+     * 
+     * @return the byte array stored in this wrapper, or null if not set
+     */
     public byte[] getData() {
         return this.data;
     }
     
+    /**
+     * Sets the byte array to be wrapped.
+     * 
+     * @param data the byte array to store in this wrapper
+     */
     public void setData(final byte[] data) {
         this.data = data;
     }

--- a/src/main/java/ca/openosp/openo/PMmodule/caisi_integrator/CaisiIntegratorManager.java
+++ b/src/main/java/ca/openosp/openo/PMmodule/caisi_integrator/CaisiIntegratorManager.java
@@ -85,29 +85,95 @@ import ca.openosp.openo.webserv.rest.to.model.DemographicSearchRequest.SEARCHMOD
 
 
 /**
- * This class is a manager for integration related functionality. <br />
- * <br />
- * Disregarding the current code base which may not properly conform to the standards... <br />
- * <br />
- * All privacy related data access should be logged (read and write). As a result, if data is cached locally, the cached read must also be logged locally. If we currently can not log the access locally for what ever reason (such as current schema is a mess
- * and we don't have a good logging facility), then the data should not be cached and individual requests should be made to the service providers. This presumes the service providers conforms to access logging standards and therefore you push the logging
- * responsibility to the other application since we are currently unable to provide that locally. When and if a good local logging facility is made available, local caching can then occur. <br />
- * <br />
- * Note that not all data is privacy related, examples include a Facility and it's information is not covered under the regulations for privacy of an individual. Note also that for some reason we're only concerned about client privacy, providers seem to
- * not be covered and or have no expectation of privacy (although we could be wrong in this interpretation).
+ * Central manager for all CAISI integrator web service interactions and data caching.
+ * <p>
+ * This class provides the primary interface for accessing the CAISI integrator system, which
+ * enables data sharing and integration across multiple healthcare facilities. It manages:
+ * <ul>
+ *   <li>Web service client creation and authentication</li>
+ *   <li>Facility discovery and metadata retrieval</li>
+ *   <li>Demographic data exchange and linking</li>
+ *   <li>Provider and program information synchronization</li>
+ *   <li>Clinical data access (notes, preventions, measurements, etc.)</li>
+ *   <li>Consent management for data sharing</li>
+ *   <li>Health Network Registry (HNR) interactions</li>
+ *   <li>Integrated referrals between facilities</li>
+ * </ul>
+ * </p>
+ * <p>
+ * <strong>Caching Strategy:</strong>
+ * The class implements a two-tier caching strategy:
+ * <ol>
+ *   <li><strong>Basic Data Cache:</strong> For non-audited, facility-level data (facilities, 
+ *       programs, providers) that doesn't contain PHI. Cache duration: 1 hour.</li>
+ *   <li><strong>Segmented Data Cache:</strong> For provider-specific data access (linked notes, 
+ *       preventions, measurements). Keyed by facility, provider, and demographic. Also 1 hour.</li>
+ * </ol>
+ * </p>
+ * <p>
+ * <strong>Privacy and Audit Compliance:</strong><br/>
+ * As noted in the original documentation, all privacy-related data access should be logged 
+ * (read and write). This class delegates audit logging responsibility to the integrator service 
+ * providers when data is not cached locally. Client privacy (demographic PHI) is strictly 
+ * controlled; provider information has reduced privacy expectations.
+ * </p>
+ * <p>
+ * <strong>Connection Management:</strong><br/>
+ * The class handles integrator connectivity issues by:
+ * <ul>
+ *   <li>Setting offline status in the session when connection exceptions occur</li>
+ *   <li>Configuring CXF client proxies with authentication interceptors</li>
+ *   <li>Building web service endpoints dynamically from facility configuration</li>
+ * </ul>
+ * </p>
+ * <p>
+ * <strong>Key Web Service Types:</strong>
+ * <ul>
+ *   <li>{@link FacilityWs} - Facility metadata and synchronization status</li>
+ *   <li>{@link DemographicWs} - Patient demographic data and linking</li>
+ *   <li>{@link ProgramWs} - Program information and referral capabilities</li>
+ *   <li>{@link ProviderWs} - Provider directory and communications</li>
+ *   <li>{@link ReferralWs} - Integrated referrals between facilities</li>
+ *   <li>{@link HnrWs} - Health Network Registry for patient matching</li>
+ * </ul>
+ * </p>
+ * 
+ * @see IntegratorFallBackManager
+ * @see CaisiIntegratorUpdateTask
+ * @see AuthenticationOutWSS4JInterceptorForIntegrator
  */
 public class CaisiIntegratorManager {
 
     /**
-     * only non-audited data should be cached in here
+     * Cache for non-audited, basic data (facilities, programs, providers).
+     * <p>
+     * This cache stores data that is not privacy-sensitive and doesn't require
+     * per-access audit logging. Capacity: 100 items, TTL: 1 hour.
+     * </p>
      */
     private static QueueCache<String, Object> basicDataCache = new QueueCache<String, Object>(4, 100, org.apache.commons.lang3.time.DateUtils.MILLIS_PER_HOUR, null);
 
     /**
-     * data put here should be segmented by the requesting providers as part of the cache key
+     * Cache for provider-segmented data access (notes, preventions, measurements).
+     * <p>
+     * Data in this cache MUST be segmented by the requesting provider as part of the cache key
+     * to ensure proper access control. This prevents one provider from accessing another
+     * provider's cached view of patient data. Capacity: 100 items, TTL: 1 hour.
+     * </p>
      */
     private static QueueCache<String, Object> segmentedDataCache = new QueueCache<String, Object>(4, 100, org.apache.commons.lang3.time.DateUtils.MILLIS_PER_HOUR, null);
 
+    /**
+     * Sets the integrator offline status in the HTTP session.
+     * <p>
+     * When set to true, this flag indicates that the integrator service is unreachable.
+     * UI components can check this flag to disable integrator-dependent features and
+     * display appropriate user messaging.
+     * </p>
+     * 
+     * @param session the HTTP session to store the status in
+     * @param status true to mark as offline, false to clear offline status
+     */
     public static void setIntegratorOffline(HttpSession session, boolean status) {
         if (status) {
             session.setAttribute(SessionConstants.INTEGRATOR_OFFLINE, true);
@@ -116,15 +182,34 @@ public class CaisiIntegratorManager {
         }
     }
 
+    /**
+     * Checks if an exception indicates a connection failure and sets offline status if so.
+     * <p>
+     * This method examines the root cause of an exception chain to detect network-level
+     * failures (ConnectException, SocketTimeoutException). When detected, it automatically
+     * sets the integrator offline status in the session.
+     * </p>
+     * 
+     * @param session the HTTP session to update
+     * @param exception the exception to analyze
+     */
     public static void checkForConnectionError(HttpSession session, Throwable exception) {
+        // Drill down to the root cause
         Throwable rootException = ExceptionUtils.getRootCause(exception);
         MiscUtils.getLogger().debug("Exception: " + exception.getClass().getName() + " --- " + rootException.getClass().getName());
 
+        // Check if it's a connectivity issue
         if (rootException instanceof java.net.ConnectException || rootException instanceof java.net.SocketTimeoutException) {
             setIntegratorOffline(session, true);
         }
     }
 
+    /**
+     * Checks if the integrator is currently marked as offline in the session.
+     * 
+     * @param session the HTTP session to check
+     * @return true if integrator is offline, false otherwise
+     */
     public static boolean isIntegratorOffline(HttpSession session) {
         Object object = session.getAttribute(SessionConstants.INTEGRATOR_OFFLINE);
         if (object != null) {
@@ -133,21 +218,91 @@ public class CaisiIntegratorManager {
         return false;
     }
 
+    /**
+     * Determines if integrated referrals are enabled for a facility.
+     * <p>
+     * Requires both the integrator to be enabled AND the specific integrated referrals
+     * feature to be turned on for the facility.
+     * </p>
+     * 
+     * @param facility the facility to check
+     * @return true if integrated referrals should be available
+     */
     public static boolean isEnableIntegratedReferrals(Facility facility) {
         return (facility.isIntegratorEnabled() && facility.isEnableIntegratedReferrals());
     }
 
+    /**
+     * Adds WS-Security authentication interceptor to a web service client.
+     * <p>
+     * This configures the CXF client to include:
+     * <ul>
+     *   <li>WS-Security username/password token for facility authentication</li>
+     *   <li>Custom SOAP header with the requesting provider number for audit trails</li>
+     * </ul>
+     * </p>
+     * 
+     * @param loggedInInfo the current user session (for provider number)
+     * @param facility the facility configuration (for credentials and URL)
+     * @param wsPort the web service port proxy to configure
+     */
     private static void addAuthenticationInterceptor(LoggedInInfo loggedInInfo, Facility facility, Object wsPort) {
+        // Get the underlying CXF client from the JAX-WS proxy
         Client cxfClient = ClientProxy.getClient(wsPort);
         String providerNo = null;
         if (loggedInInfo != null) providerNo = loggedInInfo.getLoggedInProviderNo();
+        // Add the authentication interceptor to the outbound chain
         cxfClient.getOutInterceptors().add(new AuthenticationOutWSS4JInterceptorForIntegrator(facility.getIntegratorUser(), facility.getIntegratorPassword(), providerNo));
     }
 
+    /**
+     * Builds a web service endpoint URL from facility configuration.
+     * 
+     * @param facility the facility configuration
+     * @param servicePoint the service name (e.g., "FacilityService", "DemographicService")
+     * @return the complete WSDL URL
+     * @throws MalformedURLException if the URL cannot be constructed
+     */
     private static URL buildURL(Facility facility, String servicePoint) throws MalformedURLException {
         return (new URL(facility.getIntegratorUrl() + '/' + servicePoint + "?wsdl"));
     }
 
+    /*
+     * Web Service Client Factory Methods
+     * ===================================
+     * 
+     * The following methods follow a consistent pattern for creating configured web service clients:
+     * 
+     * 1. get<Service>Ws(loggedInInfo, facility):
+     *    - Creates a service instance from the WSDL URL
+     *    - Retrieves the port (JAX-WS proxy)
+     *    - Configures CXF client connection settings (timeouts, etc.)
+     *    - Adds authentication interceptor for WS-Security
+     *    - Returns the configured port ready for use
+     * 
+     * Services include:
+     * - FacilityWs: Facility metadata and synchronization
+     * - DemographicWs: Patient demographics and linking
+     * - ProgramWs: Program information and referrals
+     * - ProviderWs: Provider directory and communications
+     * - ReferralWs: Integrated referrals
+     * - HnrWs: Health Network Registry for patient matching
+     * 
+     * All web service calls should use these factory methods to ensure proper
+     * authentication and configuration.
+     */
+
+    /**
+     * Creates and configures a Facility web service client.
+     * <p>
+     * Used for facility discovery, synchronization status checks, and facility metadata retrieval.
+     * </p>
+     * 
+     * @param loggedInInfo the current user session
+     * @param facility the facility configuration
+     * @return configured facility web service port
+     * @throws MalformedURLException if the service URL is invalid
+     */
     public static FacilityWs getFacilityWs(LoggedInInfo loggedInInfo, Facility facility) throws MalformedURLException {
         FacilityWsService service = new FacilityWsService(buildURL(facility, "FacilityService"));
         FacilityWs port = service.getFacilityWsPort();

--- a/src/main/java/ca/openosp/openo/PMmodule/caisi_integrator/CaisiIntegratorUpdateTask.java
+++ b/src/main/java/ca/openosp/openo/PMmodule/caisi_integrator/CaisiIntegratorUpdateTask.java
@@ -195,8 +195,146 @@ import ca.openosp.openo.lab.ca.all.web.LabDisplayHelper;
 import ca.openosp.openo.lab.ca.on.CommonLabResultData;
 import ca.openosp.openo.lab.ca.on.LabResultData;
 
+/**
+ * Scheduled background task for pushing local data to the CAISI integrator system.
+ * <p>
+ * This {@link TimerTask} implements the core data synchronization mechanism that periodically
+ * exports local facility data to the integrator for sharing with other facilities. It runs as
+ * a daemon thread and handles the complete lifecycle of data export, packaging, and transmission.
+ * </p>
+ * 
+ * <h2>Core Functionality</h2>
+ * <ul>
+ *   <li><strong>Incremental Updates:</strong> Tracks the last push timestamp and only exports
+ *       data modified since then (unless a full push is requested)</li>
+ *   <li><strong>Multi-Facility Support:</strong> Processes all integrator-enabled facilities
+ *       in a single run, with independent synchronization for each</li>
+ *   <li><strong>Comprehensive Data Export:</strong> Pushes demographics, clinical data, programs,
+ *       providers, and documents</li>
+ *   <li><strong>File-Based Transfer:</strong> Serializes data to files with checksums for
+ *       integrity verification and dependency tracking</li>
+ *   <li><strong>Patient Consent Integration:</strong> Respects patient consent settings when
+ *       the consent module is active</li>
+ * </ul>
+ * 
+ * <h2>Data Types Exported</h2>
+ * <p>For each demographic, the task exports:</p>
+ * <ul>
+ *   <li>Demographic information (name, DOB, HIN, contact details)</li>
+ *   <li>Clinical issues and diagnoses</li>
+ *   <li>Case management notes</li>
+ *   <li>Preventions (immunizations, screenings)</li>
+ *   <li>Medications (current and historical)</li>
+ *   <li>Admissions to programs</li>
+ *   <li>Appointments</li>
+ *   <li>Measurements (vitals, lab values)</li>
+ *   <li>Allergies</li>
+ *   <li>Documents (with optional compression)</li>
+ *   <li>Forms (e.g., lab requisitions)</li>
+ *   <li>Lab results (CML, MDS, Pathnet, HL7)</li>
+ *   <li>DxResearch codes</li>
+ *   <li>Billing items (Ontario only)</li>
+ *   <li>E-forms</li>
+ * </ul>
+ * 
+ * <h2>File Format and Structure</h2>
+ * <p>
+ * The task creates serialized files with the following structure:
+ * <ol>
+ *   <li><strong>Header ({@link IntegratorFileHeader}):</strong> Contains metadata including
+ *       timestamps, facility info, and dependency checksums</li>
+ *   <li><strong>Facility Data:</strong> Programs, providers, and facility metadata</li>
+ *   <li><strong>Demographic Data:</strong> Split across multiple files (500 demographics per file)
+ *       for manageability</li>
+ *   <li><strong>Footer ({@link IntegratorFileFooter}):</strong> Marks end of data stream</li>
+ * </ol>
+ * Files are compressed (ZIP or TAR.GZ) and checksummed (MD5) for integrity.
+ * </p>
+ * 
+ * <h2>Scheduling and Configuration</h2>
+ * <p>
+ * The task is scheduled via {@link #startTask()} and controlled by:
+ * <ul>
+ *   <li><strong>INTEGRATOR_UPDATE_PERIOD:</strong> Milliseconds between runs (from properties)</li>
+ *   <li><strong>INTEGRATOR_USER:</strong> Provider used for system-level operations</li>
+ *   <li><strong>INTEGRATOR_OUTPUT_DIR:</strong> Directory for output files (defaults to DOCUMENT_DIR)</li>
+ *   <li><strong>DisableIntegratorPushes:</strong> User property to disable pushes</li>
+ *   <li><strong>INTEGRATOR_FULL_PUSH:</strong> Forces full data push instead of incremental</li>
+ * </ul>
+ * </p>
+ * 
+ * <h2>Patient Consent Handling</h2>
+ * <p>
+ * When {@code USE_NEW_PATIENT_CONSENT_MODULE} is enabled:
+ * <ul>
+ *   <li>Only demographics with active consent are pushed</li>
+ *   <li>Consent changes trigger full demographic pushes (all data re-sent)</li>
+ *   <li>Consent status is synchronized via web services before data push</li>
+ * </ul>
+ * </p>
+ * 
+ * <h2>Document Handling</h2>
+ * <p>
+ * Documents can be handled two ways:
+ * <ol>
+ *   <li><strong>Java Compression:</strong> Default - documents are collected and zipped by Java code</li>
+ *   <li><strong>Shell Script:</strong> If {@code build_doc_zip.sh} exists in output directory,
+ *       delegates compression to external script for better performance</li>
+ * </ol>
+ * Document metadata is tracked in a separate manifest file for reference.
+ * </p>
+ * 
+ * <h2>Error Handling and Reliability</h2>
+ * <ul>
+ *   <li><strong>Per-Demographic Error Isolation:</strong> Failures processing one demographic
+ *       don't prevent processing others</li>
+ *   <li><strong>Connection Error Detection:</strong> Web service exceptions are caught and logged</li>
+ *   <li><strong>File Integrity:</strong> MD5 checksums verify data integrity</li>
+ *   <li><strong>Dependency Tracking:</strong> Each push references the checksum of the previous
+ *       push it depends on</li>
+ *   <li><strong>Transactional Publish:</strong> Files are written to .zipTemp then atomically
+ *       renamed to .zip when complete</li>
+ * </ul>
+ * 
+ * <h2>Performance Optimizations</h2>
+ * <ul>
+ *   <li><strong>Batching:</strong> Writes are batched (e.g., 50 providers at a time)</li>
+ *   <li><strong>File Splitting:</strong> Large datasets split across multiple files (500 demographics)</li>
+ *   <li><strong>Selective Queries:</strong> Database queries limited to modified data based on timestamps</li>
+ *   <li><strong>Resource Cleanup:</strong> Database connections explicitly released after each demographic</li>
+ *   <li><strong>Streaming I/O:</strong> Uses ObjectOutputStream for efficient serialization</li>
+ * </ul>
+ * 
+ * <h2>Message Synchronization</h2>
+ * <p>
+ * In addition to pushing data out, the task also:
+ * <ul>
+ *   <li>Fetches new provider messages from the integrator</li>
+ *   <li>Converts integrator messages to local Oscar Messenger format</li>
+ *   <li>Marks retrieved messages as processed</li>
+ * </ul>
+ * </p>
+ * 
+ * <h2>Audit and Conformance</h2>
+ * <p>
+ * When conformance testing is enabled ({@code ENABLE_CONFORMANCE_ONLY_FEATURES}), all data
+ * sends are logged for audit purposes via {@link ConformanceTestHelper}.
+ * </p>
+ * 
+ * <h2>Thread Safety</h2>
+ * <p>
+ * The task uses synchronized methods for start/stop operations to prevent concurrent execution.
+ * Only one instance of the task should run at a time per JVM.
+ * </p>
+ * 
+ * @see CaisiIntegratorManager
+ * @see IntegratorFileHeader
+ * @see IntegratorFileFooter
+ * @see IntegratorFallBackManager
+ */
 public class CaisiIntegratorUpdateTask extends TimerTask {
 
+    /** Logger for this class */
     private static final Logger logger = MiscUtils.getLogger();
 
     private static final String COMPRESSION_SHELL_SCRIPT = "build_doc_zip.sh";

--- a/src/main/java/ca/openosp/openo/PMmodule/caisi_integrator/ConformanceTestHelper.java
+++ b/src/main/java/ca/openosp/openo/PMmodule/caisi_integrator/ConformanceTestHelper.java
@@ -51,20 +51,68 @@ import ca.openosp.OscarProperties;
 import ca.openosp.openo.tickler.TicklerCreator;
 import ca.openosp.openo.util.DateUtils;
 
+/**
+ * Utility class providing helper methods for integrator conformance testing and data synchronization.
+ * <p>
+ * This class contains static utility methods used primarily during conformance testing and
+ * validation of the integrator system. It provides functionality for:
+ * <ul>
+ *   <li>Creating local ticklers from remote provider follow-up messages</li>
+ *   <li>Copying demographic data from linked remote demographics to local records</li>
+ *   <li>Comparing local and remote demographic data to detect discrepancies</li>
+ * </ul>
+ * </p>
+ * <p>
+ * <strong>Note:</strong> Many methods in this class are controlled by the
+ * {@code ENABLE_CONFORMANCE_ONLY_FEATURES} property and should only be active
+ * during conformance testing, not in production environments.
+ * </p>
+ * 
+ * @see CaisiIntegratorManager
+ */
 public final class ConformanceTestHelper {
+    /** Logger instance for this class */
     private static Logger logger = MiscUtils.getLogger();
+    
+    /** 
+     * Flag indicating whether conformance-only test features are enabled.
+     * Controlled by the ENABLE_CONFORMANCE_ONLY_FEATURES property.
+     */
     public static boolean enableConformanceOnlyTestFeatures = Boolean.parseBoolean(OscarProperties.getInstance().getProperty("ENABLE_CONFORMANCE_ONLY_FEATURES"));
 
+    /**
+     * Creates local ticklers from remote provider communication follow-up messages.
+     * <p>
+     * This method retrieves follow-up provider communications from the integrator service
+     * and creates corresponding ticklers in the local system. It's used to ensure that
+     * follow-up tasks assigned by remote providers are visible to local providers.
+     * </p>
+     * <p>
+     * The method performs the following steps:
+     * <ol>
+     *   <li>Retrieves all active follow-up communications for the logged-in provider</li>
+     *   <li>Extracts the destination demographic and note from each communication</li>
+     *   <li>Creates a local tickler with the remote provider information</li>
+     *   <li>Deactivates the remote communication after processing</li>
+     * </ol>
+     * </p>
+     * 
+     * @param loggedInInfo the current user's session information
+     */
     public static void populateLocalTicklerWithRemoteProviderMessageFollowUps(LoggedInInfo loggedInInfo) {
         try {
+            // Get the provider web service for the current facility
             ProviderWs providerWs = CaisiIntegratorManager.getProviderWs(loggedInInfo, loggedInInfo.getCurrentFacility());
+            // Retrieve all follow-up communications for the logged-in provider
             List<ProviderCommunicationTransfer> followUps = providerWs.getProviderCommunications(loggedInInfo.getLoggedInProviderNo(), "FOLLOWUP", true);
 
             if (followUps == null) return;
 
             logger.debug("Folowups found : " + followUps.size());
 
+            // Process each follow-up communication
             for (ProviderCommunicationTransfer providerCommunication : followUps) {
+                // Parse the XML data to extract demographic and note information
                 Document doc = XmlUtils.toDocument(providerCommunication.getData());
                 Node root = doc.getFirstChild();
                 String demographicId = XmlUtils.getChildNodeTextContents(root, "destinationDemographicId");
@@ -74,16 +122,20 @@ public final class ConformanceTestHelper {
 
                 logger.debug("Create tickler : " + demographicId + ", " + providerCommunication.getDestinationProviderId() + ", " + note);
 
+                // Look up the sending provider's information to add context to the tickler
                 FacilityIdStringCompositePk senderProviderId = new FacilityIdStringCompositePk();
                 senderProviderId.setIntegratorFacilityId(providerCommunication.getSourceIntegratorFacilityId());
                 senderProviderId.setCaisiItemId(providerCommunication.getSourceProviderId());
                 CachedProvider senderProvider = CaisiIntegratorManager.getProvider(loggedInInfo, loggedInInfo.getCurrentFacility(), senderProviderId);
                 if (senderProvider != null) {
+                    // Prepend sender information to the note
                     note = "Sent by remote providers : " + senderProvider.getLastName() + ", " + senderProvider.getFirstName() + "<br />--------------------<br />" + note;
                 }
 
+                // Create the local tickler
                 t.createTickler(loggedInInfo, demographicId, providerCommunication.getDestinationProviderId(), note);
 
+                // Mark the remote communication as processed
                 providerWs.deactivateProviderCommunication(providerCommunication.getId());
             }
         } catch (Exception e) {
@@ -91,25 +143,55 @@ public final class ConformanceTestHelper {
         }
     }
 
+    /**
+     * Copies demographic data from linked remote demographics to the local demographic record.
+     * <p>
+     * This method retrieves all demographics directly linked to a local demographic in the
+     * integrator system and copies non-null field values from the first linked record to
+     * the local record. This is useful for synchronizing demographic information across
+     * facilities.
+     * </p>
+     * <p>
+     * The method updates fields such as:
+     * <ul>
+     *   <li>Name fields (first, last)</li>
+     *   <li>Date of birth</li>
+     *   <li>Health insurance information (HIN, type, version, dates)</li>
+     *   <li>Contact information (address, city, province, phone)</li>
+     *   <li>Gender</li>
+     *   <li>SIN</li>
+     * </ul>
+     * </p>
+     * 
+     * @param loggedInInfo the current user's session information
+     * @param localDemographicId the ID of the local demographic to update
+     */
     public static void copyLinkedDemographicsPropertiesToLocal(LoggedInInfo loggedInInfo, Integer localDemographicId) {
         try {
+            // Get the demographic web service for the current facility
             DemographicWs demographicWs = CaisiIntegratorManager.getDemographicWs(loggedInInfo, loggedInInfo.getCurrentFacility());
+            // Retrieve directly linked demographics from the integrator
             List<DemographicTransfer> directLinks = demographicWs.getDirectlyLinkedDemographicsByDemographicId(localDemographicId);
 
             logger.debug("found linked demographics size:" + directLinks.size());
 
             if (directLinks.size() > 0) {
+                // Use the first linked demographic as the source
                 DemographicTransfer demographicTransfer = directLinks.get(0);
 
                 logger.debug("remoteDemographic:" + ReflectionToStringBuilder.toString(demographicTransfer));
 
+                // Load the local demographic
                 DemographicDao demographicDao = (DemographicDao) SpringUtils.getBean(DemographicDao.class);
                 Demographic demographic = demographicDao.getDemographicById(localDemographicId);
 
+                // Copy all non-null fields from the remote demographic to the local record
                 CaisiIntegratorManager.copyDemographicFieldsIfNotNull(demographicTransfer, demographic);
 
+                // Update the roster date to reflect the synchronization
                 demographic.setRosterDate(new Date());
 
+                // Persist the changes
                 demographicDao.save(demographic);
             }
         } catch (Exception e) {
@@ -117,22 +199,52 @@ public final class ConformanceTestHelper {
         }
     }
 
+    /**
+     * Checks if any directly linked remote demographics have different data than the local record.
+     * <p>
+     * This method compares the local demographic record with the first linked remote demographic
+     * to identify discrepancies. It checks all major demographic fields and returns true if any
+     * differences are detected.
+     * </p>
+     * <p>
+     * Fields compared include:
+     * <ul>
+     *   <li>Birth date</li>
+     *   <li>Name fields</li>
+     *   <li>Address and city</li>
+     *   <li>HIN and related health insurance fields</li>
+     *   <li>Gender</li>
+     *   <li>Province</li>
+     *   <li>SIN</li>
+     *   <li>Phone numbers</li>
+     * </ul>
+     * </p>
+     * 
+     * @param loggedInInfo the current user's session information
+     * @param localDemographicId the ID of the local demographic to compare
+     * @return true if any differences are detected, false otherwise
+     */
     public static boolean hasDifferentRemoteDemographics(LoggedInInfo loggedInInfo, Integer localDemographicId) {
         boolean ret = false;
         try {
+            // Get the demographic web service
             DemographicWs demographicWs = CaisiIntegratorManager.getDemographicWs(loggedInInfo, loggedInInfo.getCurrentFacility());
+            // Retrieve linked demographics
             List<DemographicTransfer> directLinks = demographicWs.getDirectlyLinkedDemographicsByDemographicId(localDemographicId);
 
             logger.debug("found linked demographics size:" + directLinks.size());
 
             if (directLinks.size() > 0) {
+                // Compare with the first linked demographic
                 DemographicTransfer demographicTransfer = directLinks.get(0);
 
                 logger.debug("remoteDemographic:" + ReflectionToStringBuilder.toString(demographicTransfer));
 
+                // Load the local demographic for comparison
                 DemographicDao demographicDao = (DemographicDao) SpringUtils.getBean(DemographicDao.class);
                 Demographic demographic = demographicDao.getDemographicById(localDemographicId);
 
+                // Compare each field, marking as different if remote has a value that differs from local
                 if (demographicTransfer.getBirthDate() != null && !(DateUtils.getNumberOfDaysBetweenTwoDates(demographicTransfer.getBirthDate(), demographic.getBirthDay()) == 0))
                     ret = true;
                 if (demographicTransfer.getCity() != null && !demographicTransfer.getCity().equalsIgnoreCase(demographic.getCity()))
@@ -171,6 +283,25 @@ public final class ConformanceTestHelper {
     }
 
 
+    /**
+     * Determines if a remote date is different from the local date.
+     * <p>
+     * This helper method implements the following logic for date comparison:
+     * <ul>
+     *   <li>If remote is null: not different (local can be anything)</li>
+     *   <li>If remote is not null and local is null: different (missing local value)</li>
+     *   <li>If both are not null: compare dates (different if not the same day)</li>
+     * </ul>
+     * </p>
+     * <p>
+     * This asymmetric comparison prioritizes the remote value - if remote has data that
+     * local doesn't, it's considered different and should potentially be synced.
+     * </p>
+     * 
+     * @param local the local Calendar date (may be null)
+     * @param remote the remote Calendar date (may be null)
+     * @return true if remote has a different (or additional) date value, false otherwise
+     */
     /*
     local remote
     null  null   = false
@@ -182,11 +313,14 @@ public final class ConformanceTestHelper {
         boolean isRemoteDateDifferent = false;
         if (remote != null) {
             if (local == null) {
+                // Remote has a value but local doesn't - they're different
                 isRemoteDateDifferent = true;
             } else if (!(DateUtils.getNumberOfDaysBetweenTwoDates(local, remote) == 0)) {
+                // Both have values but they're different dates
                 isRemoteDateDifferent = true;
             }
         }
+        // If remote is null, we don't care what local is - not different
         return isRemoteDateDifferent;
     }
 

--- a/src/main/java/ca/openosp/openo/PMmodule/caisi_integrator/DeleteCachedDemographicIssuesWrapper.java
+++ b/src/main/java/ca/openosp/openo/PMmodule/caisi_integrator/DeleteCachedDemographicIssuesWrapper.java
@@ -4,31 +4,78 @@ import ca.openosp.openo.caisi_integrator.dao.FacilityIdDemographicIssueComposite
 import java.util.List;
 import java.io.Serializable;
 
+/**
+ * Wrapper class for deletion operations on cached demographic issues in the integrator system.
+ * <p>
+ * This class encapsulates the data needed to identify which demographic issues should
+ * be retained (and implicitly which should be deleted) during synchronization between
+ * facilities in the integrator system. It contains the demographic identifier and a
+ * list of issue keys that should NOT be deleted.
+ * </p>
+ * <p>
+ * Used during integrator push operations to synchronize issue data across facilities,
+ * ensuring that issues deleted at the source facility are also removed at remote facilities.
+ * </p>
+ * 
+ * @see FacilityIdDemographicIssueCompositePk
+ */
 public class DeleteCachedDemographicIssuesWrapper implements Serializable
 {
+    /** The demographic number identifying the patient whose issues are being managed */
     private Integer demographicNo;
+    
+    /** List of composite keys for issues that should be retained (not deleted) */
     private List<FacilityIdDemographicIssueCompositePk> keys;
     
+    /**
+     * Default constructor creating an empty wrapper.
+     */
     public DeleteCachedDemographicIssuesWrapper() {
     }
     
+    /**
+     * Constructs a wrapper with the specified demographic and issue keys.
+     * 
+     * @param demographicNo the demographic number of the patient
+     * @param keys the list of issue keys that should be retained
+     */
     public DeleteCachedDemographicIssuesWrapper(final Integer demographicNo, final List<FacilityIdDemographicIssueCompositePk> keys) {
         this.demographicNo = demographicNo;
         this.keys = keys;
     }
     
+    /**
+     * Gets the demographic number.
+     * 
+     * @return the demographic number of the patient
+     */
     public Integer getDemographicNo() {
         return this.demographicNo;
     }
     
+    /**
+     * Sets the demographic number.
+     * 
+     * @param demographicNo the demographic number to set
+     */
     public void setDemographicNo(final Integer demographicNo) {
         this.demographicNo = demographicNo;
     }
     
+    /**
+     * Gets the list of issue keys to be retained.
+     * 
+     * @return the list of composite keys for issues that should not be deleted
+     */
     public List<FacilityIdDemographicIssueCompositePk> getKeys() {
         return this.keys;
     }
     
+    /**
+     * Sets the list of issue keys to be retained.
+     * 
+     * @param keys the list of composite keys for issues that should not be deleted
+     */
     public void setKeys(final List<FacilityIdDemographicIssueCompositePk> keys) {
         this.keys = keys;
     }

--- a/src/main/java/ca/openosp/openo/PMmodule/caisi_integrator/DeleteCachedDemographicPreventionsWrapper.java
+++ b/src/main/java/ca/openosp/openo/PMmodule/caisi_integrator/DeleteCachedDemographicPreventionsWrapper.java
@@ -3,31 +3,78 @@ package ca.openosp.openo.PMmodule.caisi_integrator;
 import java.util.List;
 import java.io.Serializable;
 
+/**
+ * Wrapper class for deletion operations on cached demographic preventions in the integrator system.
+ * <p>
+ * This class encapsulates the data needed to identify which demographic preventions (immunizations,
+ * screenings, etc.) should be retained during synchronization between facilities in the integrator
+ * system. It contains the demographic identifier and a list of prevention IDs that should NOT be deleted.
+ * </p>
+ * <p>
+ * During integrator synchronization, this wrapper is used to communicate which preventions exist
+ * at the source facility. Preventions not in the nonDeletedIds list may be candidates for removal
+ * at remote facilities if they no longer exist at the source.
+ * </p>
+ * 
+ * @see java.io.Serializable
+ */
 public class DeleteCachedDemographicPreventionsWrapper implements Serializable
 {
+    /** The demographic number identifying the patient whose preventions are being managed */
     private Integer demographicNo;
+    
+    /** List of prevention IDs that should be retained (not deleted) during synchronization */
     private List<Integer> nonDeletedIds;
     
+    /**
+     * Default constructor creating an empty wrapper.
+     */
     public DeleteCachedDemographicPreventionsWrapper() {
     }
     
+    /**
+     * Constructs a wrapper with the specified demographic and prevention IDs.
+     * 
+     * @param demographicNo the demographic number of the patient
+     * @param nonDeletedIds the list of prevention IDs that should be retained
+     */
     public DeleteCachedDemographicPreventionsWrapper(final Integer demographicNo, final List<Integer> nonDeletedIds) {
         this.demographicNo = demographicNo;
         this.nonDeletedIds = nonDeletedIds;
     }
     
+    /**
+     * Gets the demographic number.
+     * 
+     * @return the demographic number of the patient
+     */
     public Integer getDemographicNo() {
         return this.demographicNo;
     }
     
+    /**
+     * Sets the demographic number.
+     * 
+     * @param demographicNo the demographic number to set
+     */
     public void setDemographicNo(final Integer demographicNo) {
         this.demographicNo = demographicNo;
     }
     
+    /**
+     * Gets the list of prevention IDs to be retained.
+     * 
+     * @return the list of prevention IDs that should not be deleted
+     */
     public List<Integer> getNonDeletedIds() {
         return this.nonDeletedIds;
     }
     
+    /**
+     * Sets the list of prevention IDs to be retained.
+     * 
+     * @param nonDeletedIds the list of prevention IDs that should not be deleted
+     */
     public void setNonDeletedIds(final List<Integer> nonDeletedIds) {
         this.nonDeletedIds = nonDeletedIds;
     }

--- a/src/main/java/ca/openosp/openo/PMmodule/caisi_integrator/IntegratorFallBackManager.java
+++ b/src/main/java/ca/openosp/openo/PMmodule/caisi_integrator/IntegratorFallBackManager.java
@@ -50,14 +50,76 @@ import ca.openosp.openo.utility.SpringUtils;
 
 import ca.openosp.OscarProperties;
 
+/**
+ * Local caching and fallback manager for integrator data access.
+ * <p>
+ * This manager provides local storage and retrieval of data retrieved from remote facilities
+ * through the integrator system. It implements a caching layer that:
+ * <ul>
+ *   <li>Stores copies of remote demographic data locally for improved performance</li>
+ *   <li>Enables access to integrated data even when the integrator service is unavailable</li>
+ *   <li>Reduces network traffic by caching frequently accessed remote data</li>
+ *   <li>Supports various data types: notes, issues, preventions, drugs, admissions, etc.</li>
+ * </ul>
+ * </p>
+ * <p>
+ * The manager operates in two modes:
+ * <ol>
+ *   <li><strong>Save mode:</strong> Retrieves data from integrator web services and stores
+ *       serialized copies in the local database</li>
+ *   <li><strong>Retrieve mode:</strong> Loads previously cached data from local storage
+ *       without requiring integrator connectivity</li>
+ * </ol>
+ * </p>
+ * <p>
+ * <strong>Configuration:</strong> Local caching is controlled by the
+ * {@code INTEGRATOR_LOCAL_STORE} property (default: "yes"). When disabled, get methods
+ * return null, forcing direct integrator access.
+ * </p>
+ * <p>
+ * <strong>Data Types Supported:</strong>
+ * <ul>
+ *   <li>Demographic notes and group notes</li>
+ *   <li>Clinical issues</li>
+ *   <li>Preventions (immunizations, screenings)</li>
+ *   <li>Medications (drugs)</li>
+ *   <li>Admissions to programs</li>
+ *   <li>Appointments</li>
+ *   <li>Allergies</li>
+ *   <li>Documents and document contents</li>
+ *   <li>Lab results</li>
+ *   <li>Forms (e.g., formLabReq07)</li>
+ * </ul>
+ * </p>
+ * 
+ * @see CaisiIntegratorManager
+ * @see RemoteIntegratedDataCopyDao
+ */
 public class IntegratorFallBackManager {
+    /** DAO for storing and retrieving serialized remote data copies */
     static RemoteIntegratedDataCopyDao remoteIntegratedDataCopyDao = SpringUtils.getBean(RemoteIntegratedDataCopyDao.class);
+    
+    /** DAO for accessing demographic extended attributes */
     static DemographicExtDao demographicExtDao = SpringUtils.getBean(DemographicExtDao.class);
 
+    /**
+     * Retrieves linked notes for a demographic from local cache.
+     * <p>
+     * This method checks the local cache for previously stored notes from linked remote
+     * demographics. It does NOT contact the integrator service, making it suitable for
+     * fallback scenarios when the integrator is unavailable.
+     * </p>
+     * 
+     * @param loggedInInfo the current user's session information
+     * @param demographicNo the demographic number to retrieve notes for
+     * @return list of cached demographic notes, or null if local store is disabled or no data found
+     */
     public static List<CachedDemographicNote> getLinkedNotes(LoggedInInfo loggedInInfo, Integer demographicNo) {
+        // Check if local caching is enabled
         if (!OscarProperties.getInstance().getBooleanProperty("INTEGRATOR_LOCAL_STORE", "yes")) return null;
 
         List<CachedDemographicNote> linkedNotes = null;
+        // Look up the cached data by demographic and type
         RemoteIntegratedDataCopy remoteIntegratedDataCopy = remoteIntegratedDataCopyDao.findByDemoType(loggedInInfo.getCurrentFacility().getId(), demographicNo, CachedDemographicNote[].class.getName());
 
         if (remoteIntegratedDataCopy == null) {
@@ -65,8 +127,10 @@ public class IntegratorFallBackManager {
         }
 
         try {
+            // Deserialize the cached array of notes
             CachedDemographicNote[] array = remoteIntegratedDataCopyDao.getObjectFrom(CachedDemographicNote[].class, remoteIntegratedDataCopy);
             linkedNotes = new ArrayList<CachedDemographicNote>();
+            // Convert array to list
             for (CachedDemographicNote cdn : array) {
                 linkedNotes.add(cdn);
             }
@@ -76,13 +140,26 @@ public class IntegratorFallBackManager {
         return linkedNotes;
     }
 
+    /**
+     * Saves linked notes for a demographic to local cache.
+     * <p>
+     * This method retrieves notes from the integrator web service and stores a serialized
+     * copy in the local database for future fallback access. This is typically called during
+     * periodic synchronization or when viewing integrated data.
+     * </p>
+     * 
+     * @param loggedInInfo the current user's session information
+     * @param demographicNo the demographic number to save notes for
+     */
     public static void saveLinkNotes(LoggedInInfo loggedInInfo, Integer demographicNo) {
         try {
             try {
+                // Extract the provider number for audit purposes
                 String providerNo = null;
                 if (loggedInInfo != null && loggedInInfo.getLoggedInProvider() != null) {
                     providerNo = loggedInInfo.getLoggedInProviderNo();
                 }
+                // Retrieve notes from the integrator service
                 DemographicWs demographicWs = CaisiIntegratorManager.getDemographicWs(loggedInInfo, loggedInInfo.getCurrentFacility());
                 List<CachedDemographicNote> linkedNotes = Collections.unmodifiableList(demographicWs.getLinkedCachedDemographicNotes(demographicNo));
                 MiscUtils.getLogger().info("Saving remote copy for " + demographicNo + "  linkedNotes : " + linkedNotes.size());
@@ -90,8 +167,10 @@ public class IntegratorFallBackManager {
                 if (linkedNotes.size() == 0) {
                     return;
                 }
+                // Convert to array for serialization
                 CachedDemographicNote[] array = linkedNotes.toArray(new CachedDemographicNote[linkedNotes.size()]);
 
+                // Store the serialized array in the local database
                 remoteIntegratedDataCopyDao.save(demographicNo, array, providerNo, loggedInInfo.getCurrentFacility().getId());
             } catch (Exception e) {
                 MiscUtils.getLogger().error("Error saving remote notes for " + demographicNo, e);
@@ -102,7 +181,18 @@ public class IntegratorFallBackManager {
         }
     }
 
+    /**
+     * Saves remote forms for a demographic to local cache.
+     * <p>
+     * Currently supports form types defined in the tables array. Each form type is
+     * retrieved from the integrator and cached separately with a type-specific key.
+     * </p>
+     * 
+     * @param loggedInInfo the current user's session information
+     * @param demographicNo the demographic number to save forms for
+     */
     public static void saveRemoteForms(LoggedInInfo loggedInInfo, Integer demographicNo) {
+        // Define which form types to cache - this list should be expanded as needed
         String[] tables = {"formLabReq07"};  //Need better way to do this
         List<CachedDemographicForm> remoteForms = null;
 
@@ -113,6 +203,7 @@ public class IntegratorFallBackManager {
                 providerNo = loggedInInfo.getLoggedInProviderNo();
             }
 
+            // Process each form type separately
             for (String table : tables) {
                 DemographicWs demographicWs = CaisiIntegratorManager.getDemographicWs(loggedInInfo, loggedInInfo.getCurrentFacility());
                 remoteForms = demographicWs.getLinkedCachedDemographicForms(demographicNo, table);
@@ -124,6 +215,7 @@ public class IntegratorFallBackManager {
                 CachedDemographicForm[] array = remoteForms.toArray(new CachedDemographicForm[remoteForms.size()]);
                 MiscUtils.getLogger().info("logged in " + loggedInInfo + " " + table + " " + demographicNo);
 
+                // Store with table name appended to type for separate caching per form type
                 remoteIntegratedDataCopyDao.save(demographicNo, array, providerNo, loggedInInfo.getCurrentFacility().getId(), table);
             }
         } catch (Exception e) {
@@ -131,10 +223,19 @@ public class IntegratorFallBackManager {
         }
     }
 
+    /**
+     * Retrieves remote forms for a specific form type from local cache.
+     * 
+     * @param loggedInInfo the current user's session information
+     * @param demographicNo the demographic number to retrieve forms for
+     * @param table the form type identifier (e.g., "formLabReq07")
+     * @return list of cached forms, or null if local store disabled or no data found
+     */
     public static List<CachedDemographicForm> getRemoteForms(LoggedInInfo loggedInInfo, Integer demographicNo, String table) {
         if (!OscarProperties.getInstance().getBooleanProperty("INTEGRATOR_LOCAL_STORE", "yes")) return null;
 
         List<CachedDemographicForm> linkedForms = null;
+        // Lookup includes table name as part of the type key
         RemoteIntegratedDataCopy remoteIntegratedDataCopy = remoteIntegratedDataCopyDao.findByDemoType(loggedInInfo.getCurrentFacility().getId(), demographicNo, CachedDemographicForm[].class.getName() + "+" + table);
 
         if (remoteIntegratedDataCopy == null) {
@@ -155,6 +256,33 @@ public class IntegratorFallBackManager {
 
 
     ////TESTED ^^^^/////
+    
+    /*
+     * The following methods follow a consistent pattern for caching different data types:
+     * 
+     * For each data type (Issues, Preventions, Drugs, Admissions, Appointments, Allergies, Documents, LabResults):
+     * 
+     * 1. save<DataType>(loggedInInfo, demographicNo):
+     *    - Retrieves data from integrator web service
+     *    - Serializes and stores in local database via remoteIntegratedDataCopyDao
+     *    - Used during synchronization to cache remote data locally
+     * 
+     * 2. get<DataType>(loggedInInfo, demographicNo):
+     *    - Checks if local caching is enabled (INTEGRATOR_LOCAL_STORE property)
+     *    - Retrieves cached data from local database
+     *    - Deserializes and returns as list
+     *    - Returns null if caching disabled or no data found
+     * 
+     * This pattern enables fallback access to integrator data when the service is unavailable.
+     */
+    
+    /**
+     * Saves demographic issues from integrator to local cache.
+     * Follows standard save pattern: retrieve from web service, serialize, store locally.
+     * 
+     * @param loggedInInfo the current user's session information
+     * @param demographicNo the demographic number to save issues for
+     */
     public static void saveDemographicIssues(LoggedInInfo loggedInInfo, int demographicNo) {
         List<CachedDemographicIssue> remoteIssues = null;
 
@@ -452,7 +580,21 @@ public class IntegratorFallBackManager {
         return linkedNotes;
     }
 
-
+    /**
+     * Saves demographic documents and their contents to local cache.
+     * <p>
+     * This method is more complex than other save methods because it stores both:
+     * <ol>
+     *   <li>Document metadata (headers) as an array</li>
+     *   <li>Individual document contents, each keyed by facility and document ID</li>
+     * </ol>
+     * This two-level caching allows efficient listing of documents without loading
+     * all content, while still providing fallback access to full document data.
+     * </p>
+     * 
+     * @param loggedInInfo the current user's session information
+     * @param demographicNo the demographic number to save documents for
+     */
     public static void saveDocuments(LoggedInInfo loggedInInfo, int demographicNo) {
         List<CachedDemographicDocument> remoteItems = null;
 
@@ -472,12 +614,16 @@ public class IntegratorFallBackManager {
 
             CachedDemographicDocument[] array = remoteItems.toArray(new CachedDemographicDocument[remoteItems.size()]);
             MiscUtils.getLogger().info("logged in " + loggedInInfo + " " + demographicNo);
+            // Store document metadata (headers)
             remoteIntegratedDataCopyDao.save(demographicNo, array, providerNo, loggedInInfo.getCurrentFacility().getId());
 
+            // For each document, also cache the full content separately
             for (CachedDemographicDocument document : array) {
                 FacilityIdIntegerCompositePk remotePk = document.getFacilityIntegerPk();
+                // Retrieve the actual document content from integrator
                 CachedDemographicDocumentContents remoteDocumentContents = demographicWs.getCachedDemographicDocumentContents(remotePk);
                 MiscUtils.getLogger().debug("what is remotePK " + getPK(remotePk));
+                // Store content separately, keyed by the composite primary key
                 remoteIntegratedDataCopyDao.save(demographicNo, remoteDocumentContents, providerNo, loggedInInfo.getCurrentFacility().getId(), getPK(remotePk));
 
             }
@@ -488,19 +634,52 @@ public class IntegratorFallBackManager {
         }
     }
 
+    /**
+     * Generates a string key from a facility/document composite primary key.
+     * <p>
+     * Format: "facilityId:documentId"
+     * Used to uniquely identify document contents in the cache.
+     * </p>
+     * 
+     * @param remotePk the composite primary key
+     * @return formatted string key
+     */
     private static String getPK(FacilityIdIntegerCompositePk remotePk) {
         return (String.valueOf(remotePk.getIntegratorFacilityId()) + ":" + remotePk.getCaisiItemId());
     }
 
+    /**
+     * Retrieves the demographic number associated with a cached document.
+     * <p>
+     * Useful for reverse lookups when you have a document key but need to know
+     * which demographic it belongs to.
+     * </p>
+     * 
+     * @param loggedInInfo the current user's session information
+     * @param remotePk the document's composite primary key
+     * @return the demographic number, or null if not found
+     */
     public static Integer getDemographicNoFromRemoteDocument(LoggedInInfo loggedInInfo, FacilityIdIntegerCompositePk remotePk) {
         RemoteIntegratedDataCopy remoteIntegratedDataCopy = remoteIntegratedDataCopyDao.findByType(loggedInInfo.getCurrentFacility().getId(), CachedDemographicDocumentContents.class.getName() + "+" + getPK(remotePk));
         return remoteIntegratedDataCopy.getDemographicNo();
     }
 
 
+    /**
+     * Retrieves document contents from local cache by composite key only.
+     * <p>
+     * This version looks up the document without requiring the demographic number,
+     * making it useful when you only have the document identifier.
+     * </p>
+     * 
+     * @param loggedInInfo the current user's session information
+     * @param remotePk the document's composite primary key
+     * @return the document contents, or null if not found
+     */
     public static CachedDemographicDocumentContents getRemoteDocument(LoggedInInfo loggedInInfo, FacilityIdIntegerCompositePk remotePk) {
         CachedDemographicDocumentContents documentContents = null;
 
+        // Lookup without demographic number - searches across all demographics
         RemoteIntegratedDataCopy remoteIntegratedDataCopy = remoteIntegratedDataCopyDao.findByType(loggedInInfo.getCurrentFacility().getId(), CachedDemographicDocumentContents.class.getName() + "+" + getPK(remotePk));
 
         try {
@@ -512,6 +691,18 @@ public class IntegratorFallBackManager {
         return documentContents;
     }
 
+    /**
+     * Retrieves document contents from local cache by demographic and composite key.
+     * <p>
+     * This version is more efficient when you already know the demographic number,
+     * as it narrows the search space.
+     * </p>
+     * 
+     * @param loggedInInfo the current user's session information
+     * @param demographicNo the demographic number the document belongs to
+     * @param remotePk the document's composite primary key
+     * @return the document contents, or null if not found
+     */
     public static CachedDemographicDocumentContents getRemoteDocument(LoggedInInfo loggedInInfo, Integer demographicNo, FacilityIdIntegerCompositePk remotePk) {
         CachedDemographicDocumentContents documentContents = null;
 

--- a/src/main/java/ca/openosp/openo/PMmodule/caisi_integrator/IntegratorFileFooter.java
+++ b/src/main/java/ca/openosp/openo/PMmodule/caisi_integrator/IntegratorFileFooter.java
@@ -2,22 +2,60 @@ package ca.openosp.openo.PMmodule.caisi_integrator;
 
 import java.io.Serializable;
 
+/**
+ * Footer marker class for integrator data transfer files.
+ * <p>
+ * This class serves as a sentinel object placed at the end of serialized integrator
+ * data files to mark the completion of the file. It can optionally contain a checksum
+ * for data integrity verification, though the primary checksum is typically calculated
+ * externally for the complete file.
+ * </p>
+ * <p>
+ * During integrator push operations, this footer is written as the final object in
+ * serialized data streams to signal that all demographic and facility data has been
+ * successfully written.
+ * </p>
+ * 
+ * @see IntegratorFileHeader
+ */
 public class IntegratorFileFooter implements Serializable
 {
+    /** 
+     * Optional checksum value for the data.
+     * Initialized to -1 to indicate no checksum has been set.
+     */
     private int checksum;
     
+    /**
+     * Default constructor creating a footer with no checksum (-1).
+     */
     public IntegratorFileFooter() {
         this.checksum = -1;
     }
     
+    /**
+     * Constructs a footer with the specified checksum value.
+     * 
+     * @param checksum the checksum value to include in the footer
+     */
     public IntegratorFileFooter(final int checksum) {
         this.checksum = checksum;
     }
     
+    /**
+     * Gets the checksum value.
+     * 
+     * @return the checksum, or -1 if no checksum was set
+     */
     public int getChecksum() {
         return this.checksum;
     }
     
+    /**
+     * Sets the checksum value.
+     * 
+     * @param checksum the checksum value to set
+     */
     public void setChecksum(final int checksum) {
         this.checksum = checksum;
     }

--- a/src/main/java/ca/openosp/openo/PMmodule/caisi_integrator/IntegratorFileHeader.java
+++ b/src/main/java/ca/openosp/openo/PMmodule/caisi_integrator/IntegratorFileHeader.java
@@ -3,64 +3,165 @@ package ca.openosp.openo.PMmodule.caisi_integrator;
 import java.util.Date;
 import java.io.Serializable;
 
+/**
+ * Header metadata class for integrator data transfer files.
+ * <p>
+ * This class contains essential metadata that is written at the beginning of serialized
+ * integrator data files. It tracks versioning, dependencies, timestamps, and facility
+ * information necessary for proper synchronization and data integrity checks between
+ * facilities in the integrator system.
+ * </p>
+ * <p>
+ * The header allows receiving facilities to:
+ * <ul>
+ *   <li>Verify the file format version for compatibility</li>
+ *   <li>Track incremental updates through date ranges and dependencies</li>
+ *   <li>Identify the source facility and authentication credentials</li>
+ *   <li>Ensure data integrity through checksum verification</li>
+ * </ul>
+ * </p>
+ * 
+ * @see IntegratorFileFooter
+ */
 public class IntegratorFileHeader implements Serializable
 {
+    /** The date of the last successful data push (start of the update window) */
     private Date lastDate;
+    
+    /** The current date/time of this data push (end of the update window) */
     private Date date;
+    
+    /** MD5 checksum of the previous file this update depends on (for incremental updates) */
     private String dependsOn;
+    
+    /** The integrator facility ID of the facility generating this file */
     private Integer cachedFacilityId;
+    
+    /** The name of the facility generating this file */
     private String cachedFacilityName;
+    
+    /** The username used for authentication to the integrator service */
     private String username;
+    
+    /** 
+     * Current file format version.
+     * This constant should be incremented when breaking changes are made to the file format.
+     */
     public static final int VERSION = 1;
     
+    /**
+     * Gets the current push date.
+     * 
+     * @return the date/time when this data push was generated
+     */
     public Date getDate() {
         return this.date;
     }
     
+    /**
+     * Sets the current push date.
+     * 
+     * @param date the date/time when this data push is being generated
+     */
     public void setDate(final Date date) {
         this.date = date;
     }
     
+    /**
+     * Gets the last successful push date.
+     * 
+     * @return the date of the last successful data push, defining the start of the update window
+     */
     public Date getLastDate() {
         return this.lastDate;
     }
     
+    /**
+     * Sets the last successful push date.
+     * 
+     * @param lastDate the date of the last successful data push
+     */
     public void setLastDate(final Date lastDate) {
         this.lastDate = lastDate;
     }
     
+    /**
+     * Gets the checksum of the file this update depends on.
+     * 
+     * @return the MD5 checksum string of the previous file, or null if this is a full push
+     */
     public String getDependsOn() {
         return this.dependsOn;
     }
     
+    /**
+     * Sets the checksum dependency for incremental updates.
+     * 
+     * @param dependsOn the MD5 checksum of the previous file this update builds upon
+     */
     public void setDependsOn(final String dependsOn) {
         this.dependsOn = dependsOn;
     }
     
+    /**
+     * Gets the file format version.
+     * 
+     * @return the version number (currently always returns 1)
+     */
     public int getVersion() {
         return 1;
     }
     
+    /**
+     * Gets the source facility ID.
+     * 
+     * @return the integrator facility ID of the facility generating this file
+     */
     public Integer getCachedFacilityId() {
         return this.cachedFacilityId;
     }
     
+    /**
+     * Sets the source facility ID.
+     * 
+     * @param cachedFacilityId the integrator facility ID to set
+     */
     public void setCachedFacilityId(final Integer cachedFacilityId) {
         this.cachedFacilityId = cachedFacilityId;
     }
     
+    /**
+     * Gets the source facility name.
+     * 
+     * @return the name of the facility generating this file
+     */
     public String getCachedFacilityName() {
         return this.cachedFacilityName;
     }
     
+    /**
+     * Sets the source facility name.
+     * 
+     * @param cachedFacilityName the facility name to set
+     */
     public void setCachedFacilityName(final String cachedFacilityName) {
         this.cachedFacilityName = cachedFacilityName;
     }
     
+    /**
+     * Gets the integrator authentication username.
+     * 
+     * @return the username used for integrator service authentication
+     */
     public String getUsername() {
         return this.username;
     }
     
+    /**
+     * Sets the integrator authentication username.
+     * 
+     * @param username the username for integrator service authentication
+     */
     public void setUsername(final String username) {
         this.username = username;
     }

--- a/src/main/java/ca/openosp/openo/demographic/pageUtil/CihiExport2Action.java
+++ b/src/main/java/ca/openosp/openo/demographic/pageUtil/CihiExport2Action.java
@@ -908,7 +908,7 @@ public class CihiExport2Action extends ActionSupport {
                 strength = pa[p].getDosage().split(" ");
 
                 cdsDtCihi.DrugMeasure drugM = medications.addNewStrength();
-                if (Util.leadingNum(strength[0]).equals(strength[0])) {//amount & unit separated by space
+                if (Util.leadingNumWithFraction(strength[0]).equals(strength[0])) {//amount & unit separated by space
                     drugM.setAmount(strength[0]);
                     if (strength.length > 1) drugM.setUnitOfMeasure(strength[1]);
                     else drugM.setUnitOfMeasure("unit"); //UnitOfMeasure cannot be null
@@ -916,14 +916,14 @@ public class CihiExport2Action extends ActionSupport {
                 } else {//amount & unit not separated, probably e.g. 50mg / 2tablet
                     if (strength.length > 1 && strength[1].equals("/")) {
                         if (strength.length > 2) {
-                            String unit1 = Util.leadingNum(strength[2]).equals("") ? "1" : Util.leadingNum(strength[2]);
+                            String unit1 = Util.leadingNumWithFraction(strength[2]).equals("") ? "1" : Util.leadingNumWithFraction(strength[2]);
                             String unit2 = Util.trailingTxt(strength[2]).equals("") ? "unit" : Util.trailingTxt(strength[2]);
 
-                            drugM.setAmount(Util.leadingNum(strength[0]) + "/" + Util.leadingNum(strength[2]));
+                            drugM.setAmount(Util.leadingNumWithFraction(strength[0]) + "/" + Util.leadingNumWithFraction(strength[2]));
                             drugM.setUnitOfMeasure(Util.trailingTxt(strength[0]) + "/" + unit2);
                         }
                     } else {
-                        drugM.setAmount(Util.leadingNum(strength[0]));
+                        drugM.setAmount(Util.leadingNumWithFraction(strength[0]));
                         drugM.setUnitOfMeasure(Util.trailingTxt(strength[0]));
                     }
                 }

--- a/src/main/java/ca/openosp/openo/demographic/pageUtil/CihiExportPHC_VRS2Action.java
+++ b/src/main/java/ca/openosp/openo/demographic/pageUtil/CihiExportPHC_VRS2Action.java
@@ -1125,7 +1125,7 @@ public class CihiExportPHC_VRS2Action extends ActionSupport {
                 strength = pa[p].getDosage().split(" ");
 
                 cdsDtCihiPhcvrs.DrugMeasure drugM = medications.addNewStrength();
-                if (Util.leadingNum(strength[0]).equals(strength[0])) {//amount & unit separated by space
+                if (Util.leadingNumWithFraction(strength[0]).equals(strength[0])) {//amount & unit separated by space
                     drugM.setAmount(strength[0]);
                     if (strength.length > 1) drugM.setUnitOfMeasure(strength[1]);
                     else drugM.setUnitOfMeasure("unit"); //UnitOfMeasure cannot be null
@@ -1133,14 +1133,14 @@ public class CihiExportPHC_VRS2Action extends ActionSupport {
                 } else {//amount & unit not separated, probably e.g. 50mg / 2tablet
                     if (strength.length > 1 && strength[1].equals("/")) {
                         if (strength.length > 2) {
-                            String unit1 = Util.leadingNum(strength[2]).equals("") ? "1" : Util.leadingNum(strength[2]);
+                            String unit1 = Util.leadingNumWithFraction(strength[2]).equals("") ? "1" : Util.leadingNumWithFraction(strength[2]);
                             String unit2 = Util.trailingTxt(strength[2]).equals("") ? "unit" : Util.trailingTxt(strength[2]);
 
-                            drugM.setAmount(Util.leadingNum(strength[0]) + "/" + Util.leadingNum(strength[2]));
+                            drugM.setAmount(Util.leadingNumWithFraction(strength[0]) + "/" + Util.leadingNumWithFraction(strength[2]));
                             drugM.setUnitOfMeasure(Util.trailingTxt(strength[0]) + "/" + unit2);
                         }
                     } else {
-                        drugM.setAmount(Util.leadingNum(strength[0]));
+                        drugM.setAmount(Util.leadingNumWithFraction(strength[0]));
                         drugM.setUnitOfMeasure(Util.trailingTxt(strength[0]));
                     }
                 }

--- a/src/main/java/ca/openosp/openo/demographic/pageUtil/DemographicExportAction42Action.java
+++ b/src/main/java/ca/openosp/openo/demographic/pageUtil/DemographicExportAction42Action.java
@@ -1631,7 +1631,7 @@ public class DemographicExportAction42Action extends ActionSupport {
                                     String[] strength = arr[p].getDosage().split(" ");
 
                                     cdsDt.DrugMeasure drugM = medi.addNewStrength();
-                                    if (Util.leadingNum(strength[0]).equals(strength[0])) {//amount & unit separated by space
+                                    if (Util.leadingNumWithFraction(strength[0]).equals(strength[0])) {//amount & unit separated by space
                                         drugM.setAmount(strength[0]);
                                         if (strength.length > 1) drugM.setUnitOfMeasure(strength[1]);
                                         else drugM.setUnitOfMeasure("unit"); //UnitOfMeasure cannot be null
@@ -1639,14 +1639,14 @@ public class DemographicExportAction42Action extends ActionSupport {
                                     } else {//amount & unit not separated, probably e.g. 50mg / 2tablet
                                         if (strength.length > 1 && strength[1].equals("/")) {
                                             if (strength.length > 2) {
-                                                String unit1 = Util.leadingNum(strength[2]).equals("") ? "1" : Util.leadingNum(strength[2]);
+                                                String unit1 = Util.leadingNumWithFraction(strength[2]).equals("") ? "1" : Util.leadingNumWithFraction(strength[2]);
                                                 String unit2 = Util.trailingTxt(strength[2]).equals("") ? "unit" : Util.trailingTxt(strength[2]);
 
-                                                drugM.setAmount(Util.leadingNum(strength[0]) + "/" + unit1);
+                                                drugM.setAmount(Util.leadingNumWithFraction(strength[0]) + "/" + unit1);
                                                 drugM.setUnitOfMeasure(Util.trailingTxt(strength[0]) + "/" + unit2);
                                             }
                                         } else {
-                                            drugM.setAmount(Util.leadingNum(strength[0]));
+                                            drugM.setAmount(Util.leadingNumWithFraction(strength[0]));
                                             drugM.setUnitOfMeasure(Util.trailingTxt(strength[0]));
                                         }
                                     }

--- a/src/main/java/ca/openosp/openo/demographic/pageUtil/DemographicExportHelper.java
+++ b/src/main/java/ca/openosp/openo/demographic/pageUtil/DemographicExportHelper.java
@@ -142,7 +142,7 @@ public class DemographicExportHelper {
                 String[] strength = arr[p].getDosage().split(" ");
 
                 cdsDt.DrugMeasure drugM = medi.addNewStrength();
-                if (Util.leadingNum(strength[0]).equals(strength[0])) {//amount & unit separated by space
+                if (Util.leadingNumWithFraction(strength[0]).equals(strength[0])) {//amount & unit separated by space
                     drugM.setAmount(strength[0]);
                     if (strength.length > 1) drugM.setUnitOfMeasure(strength[1]);
                     else drugM.setUnitOfMeasure("unit"); //UnitOfMeasure cannot be null
@@ -150,14 +150,14 @@ public class DemographicExportHelper {
                 } else {//amount & unit not separated, probably e.g. 50mg / 2tablet
                     if (strength.length > 1 && strength[1].equals("/")) {
                         if (strength.length > 2) {
-                            String unit1 = Util.leadingNum(strength[2]).equals("") ? "1" : Util.leadingNum(strength[2]);
+                            String unit1 = Util.leadingNumWithFraction(strength[2]).equals("") ? "1" : Util.leadingNumWithFraction(strength[2]);
                             String unit2 = Util.trailingTxt(strength[2]).equals("") ? "unit" : Util.trailingTxt(strength[2]);
 
-                            drugM.setAmount(Util.leadingNum(strength[0]) + "/" + unit1);
+                            drugM.setAmount(Util.leadingNumWithFraction(strength[0]) + "/" + unit1);
                             drugM.setUnitOfMeasure(Util.trailingTxt(strength[0]) + "/" + unit2);
                         }
                     } else {
-                        drugM.setAmount(Util.leadingNum(strength[0]));
+                        drugM.setAmount(Util.leadingNumWithFraction(strength[0]));
                         drugM.setUnitOfMeasure(Util.trailingTxt(strength[0]));
                     }
                 }

--- a/src/main/java/ca/openosp/openo/demographic/pageUtil/Util.java
+++ b/src/main/java/ca/openosp/openo/demographic/pageUtil/Util.java
@@ -395,6 +395,34 @@ public class Util {
         return s;
     }
 
+    /**
+     * Extracts the leading numeric portion from a string, including fractions.
+     * Unlike leadingNum(), this preserves '/' characters to support fractional
+     * dosage formats like "125/5" in medication strength expressions.
+     *
+     * @param s The input string to parse
+     * @return The leading numeric portion including fractions (e.g., "125/5" from "125/5 mg/ml")
+     * @since 2025-01-08
+     */
+    static public String leadingNumWithFraction(String s) {
+        if (s == null) return "";
+        s = s.trim();
+        StringBuilder sb = new StringBuilder();
+
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+
+            // Allowed characters for the amount (digits, decimal point, slash)
+            if (Character.isDigit(c) || c == '.' || c == '/') {
+                sb.append(c);
+            } else {
+                break; // stop at anything else (space, letter, %, etc.)
+            }
+        }
+
+        return sb.toString();
+    }
+
     static public float leadingNumF(String s) {
         s = leadingNum(s);
         try {

--- a/src/main/webapp/WEB-INF/classes/struts.xml
+++ b/src/main/webapp/WEB-INF/classes/struts.xml
@@ -8,7 +8,7 @@
     <constant name="struts.enable.SlashesInActionNames" value="true" />
     <constant name="struts.serve.static" value="true" />
     <constant name="struts.serve.static.browserCache" value="true" />
-    <constant name="struts.action.excludePattern" value=".*\.(css|js|png|jpg|gif)$|^/ws/.*" />
+    <constant name="struts.action.excludePattern" value=".*\.(css|js|png|jpg|gif)$|^/ws/.*|^/servlet/(ca\.openosp\.DocumentUploadServlet|oscar\.DocumentTeleplanReportUploadServlet)$" />
     <constant name="struts.custom.i18n.resources" value="oscarResources"/>
     <constant name="struts.custom.i18n.resources" value="oscarResources,MessageResources_mcedt"/>
     <constant name="struts.multipart.maxSize" value="524288000" />

--- a/src/main/webapp/admin/admin.jsp
+++ b/src/main/webapp/admin/admin.jsp
@@ -353,7 +353,7 @@
                     <li><a href="#" onclick='popupPage(600,900, "${pageContext.request.contextPath}/billing/CA/ON/viewMOHFiles.jsp");return false;'><fmt:setBundle basename="oscarResources"/><fmt:message key="admin.admin.viewMOHFiles"/></a></li>
                     <% } %>
                     <li><a href="#"
-                           onclick='popupPage(600,900, "${pageContext.request.contextPath}/billing/CA/ON/billingRA.jsp");return false;'><fmt:setBundle basename="oscarResources"/><fmt:message key="admin.admin.btnBillingReconciliation"/></a></li>
+                           onclick='popupPage(600,900, "${pageContext.request.contextPath}<%= oscarVariables.getProperty("RA_FORWORD", "/billing/CA/ON/genRA.jsp") %>");return false;'><fmt:setBundle basename="oscarResources"/><fmt:message key="admin.admin.btnBillingReconciliation"/></a></li>
                     <!-- li><a href="#" onclick ='popupPage(600,1000,"${pageContext.request.contextPath}/billing/CA/ON/billingOBECEA.jsp");return false;'><fmt:setBundle basename="oscarResources"/><fmt:message key="admin.admin.btnEDTBillingReportGenerator"/></a></li-->
                     <li>
                         <a href="#" onclick='popupPage(800,1000,"${pageContext.request.contextPath}/mcedt/mcedt.do");return false;'><fmt:setBundle basename="oscarResources"/><fmt:message key="admin.admin.mcedt"/></a>

--- a/src/main/webapp/administration/leftNav.jspf
+++ b/src/main/webapp/administration/leftNav.jspf
@@ -206,7 +206,7 @@ String curProvider_no = (String)session.getAttribute("user");
 					</li>
 					</oscar:oscarPropertiesCheck>
 					<li><a href='javascript:void(0);'
-						class="xlink" rel="${ctx}/billing/CA/ON/billingRA.jsp"><fmt:setBundle basename="oscarResources"/><fmt:message key="admin.admin.btnBillingReconciliation"/></a></li>
+						class="xlink" rel="${ctx}<%= oscarVariables.getProperty("RA_FORWORD", "/billing/CA/ON/genRA.jsp") %>"><fmt:setBundle basename="oscarResources"/><fmt:message key="admin.admin.btnBillingReconciliation"/></a></li>
 					<!--  li><a href='javascript:void(0);' onclick ='popupPage(600,1000,"${ctx}/billing/CA/ON/billingOBECEA.jsp");return false;'><fmt:setBundle basename="oscarResources"/><fmt:message key="admin.admin.btnEDTBillingReportGenerator"/></a></li-->
 					<li><a href='javascript:void(0);'
 						class="xlink" rel="${ctx}/billing/CA/ON/billStatus.jsp"><fmt:setBundle basename="oscarResources"/><fmt:message key="admin.admin.invoiceRpts"/></a></li>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes broken MOH/Teleplan billing file uploads and improves medication export accuracy; also adds Playwright MCP to the devcontainer. Includes a small admin nav fix and extensive Javadoc updates in integrator modules.

- **Bug Fixes**
  - Restore billing uploads: refine Struts exclude to only the two upload servlets; switch DocumentUploadServlet to ServletFileUpload with UTF-8, 50 MB limits, 1 MB memory threshold, and a validated temp directory.
  - CDS exports: preserve fractional doses (e.g., 125/5) via new leadingNumWithFraction; update 4 export paths to use it.
  - Admin: Billing Reconciliation link now respects RA_FORWORD to open the report list.

- **Dependencies**
  - Devcontainer: add Playwright and playwright MCP server; install Chromium/Firefox; default to headless Firefox.

<sup>Written for commit eb5e9e02360b0908ac81c47021eb53d7112e12df. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

