### PR TITLE
Security: upgrade needed/exclude unused apache cxf vulnerable transitive dependencies 

### DIFF
--- a/dependencies-lock-modern.json
+++ b/dependencies-lock-modern.json
@@ -1828,14 +1828,6 @@
     "integrity" : "sha512:ppHjzG0MGRAtR5Un6onFsdX0aTcEBFq+hMRPg7CfpNyfvGW/zZXrPTkpzBI/VgETm5dOLnlfW3P2B0PwiaAnFQ=="
   }, {
     "groupId" : "org.apache.cxf",
-    "artifactId" : "cxf-rt-frontend-js",
-    "version" : "3.5.11",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:UFGYhfJUZ4KncYS0YU4ZFU/cwBdVMjP7DtFMkaMbBfLPN54an1AP09dGJ+8q0D+gN4rYRYr6qm9F11LbCBVwSA=="
-  }, {
-    "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-frontend-simple",
     "version" : "3.5.11",
     "scope" : "compile",
@@ -3178,14 +3170,6 @@
     "type" : "jar",
     "optional" : false,
     "integrity" : "sha512:B6gVYC1OcTt862fwXNN5R2unbOdQFnjP20asjNMBaZ01e6x5rhtNgbh3E5Tt34qOPOuhZfcfQ+rm4a8/hRQVZA=="
-  }, {
-    "groupId" : "org.mozilla",
-    "artifactId" : "rhino",
-    "version" : "1.7.15",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:VhnE9S8YY8XXLNkRXC6cz/VcfnqPTxOV9zSGEg2UqzkAY0+ynVQ1alsPwiFFcGFdXwbhUiYN+XG7AcW8TeS7lQ=="
   }, {
     "groupId" : "org.objenesis",
     "artifactId" : "objenesis",

--- a/dependencies-lock.json
+++ b/dependencies-lock.json
@@ -1828,14 +1828,6 @@
     "integrity" : "sha512:ppHjzG0MGRAtR5Un6onFsdX0aTcEBFq+hMRPg7CfpNyfvGW/zZXrPTkpzBI/VgETm5dOLnlfW3P2B0PwiaAnFQ=="
   }, {
     "groupId" : "org.apache.cxf",
-    "artifactId" : "cxf-rt-frontend-js",
-    "version" : "3.5.11",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:UFGYhfJUZ4KncYS0YU4ZFU/cwBdVMjP7DtFMkaMbBfLPN54an1AP09dGJ+8q0D+gN4rYRYr6qm9F11LbCBVwSA=="
-  }, {
-    "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-frontend-simple",
     "version" : "3.5.11",
     "scope" : "compile",
@@ -3114,14 +3106,6 @@
     "type" : "jar",
     "optional" : false,
     "integrity" : "sha512:fYNi4VyUGo/MBw9AsUwAEf6UW+hVta8qNRKS3UadOg56kk4m6+lmBQ3RMEFdBGXeGx73cUFcGvSCLQnA9SKcGw=="
-  }, {
-    "groupId" : "org.mozilla",
-    "artifactId" : "rhino",
-    "version" : "1.7.15",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:VhnE9S8YY8XXLNkRXC6cz/VcfnqPTxOV9zSGEg2UqzkAY0+ynVQ1alsPwiFFcGFdXwbhUiYN+XG7AcW8TeS7lQ=="
   }, {
     "groupId" : "org.objenesis",
     "artifactId" : "objenesis",

--- a/pom.xml
+++ b/pom.xml
@@ -1101,6 +1101,11 @@
                     <groupId>org.apache.cxf</groupId>
                     <artifactId>cxf-rt-transports-jms</artifactId>
                 </exclusion>
+                <!-- Not used, excluded to fix CVE (DoS via Rhino toFixed) -->
+                <exclusion>
+                    <groupId>org.apache.cxf</groupId>
+                    <artifactId>cxf-rt-frontend-js</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
## In this PR, I have:
- Updated mime4j core to a stable secure version (transitive dependency)
- Excluded unused apache cxf, transports-jms dependency (transitive as well)
- Excluded unused apache cxf, rhino dependency (transitive as well)
     - These are done to resolve dependabot security alerts

## I have tested this by:
- Smoke testing the application

## Summary by Sourcery

Address security vulnerabilities by updating dependencies and excluding an unused vulnerable component.

Bug Fixes:
- Mitigate MIME header injection by forcing a secure apache-mime4j-core version for transitive usage via axis2-transport-http.
- Eliminate potential RCE via untrusted JMS configuration by excluding the unused cxf-rt-transports-jms transitive dependency.

Build:
- Update Maven dependency management to pin a secure apache-mime4j-core version and exclude the vulnerable cxf-rt-transports-jms artifact from CXF.

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Upgraded apache-mime4j-core to 0.8.10 and excluded the unused CXF JMS transport to resolve security vulnerabilities and reduce attack surface.

- **Dependencies**
  - Forced org.apache.james:apache-mime4j-core to 0.8.10 to patch a header injection CVE.
  - Excluded org.apache.cxf:cxf-rt-transports-jms (not used) due to an RCE risk from untrusted JMS config.

<sup>Written for commit da6da0bf59aa2554773f59a3132c4f9a9c443080. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Address security vulnerabilities in transitive dependencies by pinning a secure MIME4J version and excluding unused vulnerable Apache CXF components.

Bug Fixes:
- Mitigate MIME header injection risk by forcing a secure apache-mime4j-core version used transitively via Axis2 HTTP transport.
- Reduce risk of RCE and DoS by excluding unused CXF JMS transport and JS frontend (Rhino-based) transitive dependencies.

Build:
- Update Maven dependency management to explicitly add apache-mime4j-core and exclude vulnerable CXF JMS and JS frontend artifacts from the CXF dependency tree.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Apache MIME4J library to a more secure version (0.8.6 → 0.8.10).
  * Removed unused transitive dependencies to streamline the dependency graph and improve application security posture.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->