### PR TITLE
Resolve Missing changes from OpenOSP main before dogfish merge (PR 61: Tweak - Show MRP in document view)

### DIFF
--- a/src/main/webapp/documentManager/showDocument.jsp
+++ b/src/main/webapp/documentManager/showDocument.jsp
@@ -118,7 +118,7 @@
         Demographic demographic = demographicDao.getDemographic(demographicID);  
 				demoName = demographic.getLastName()+","+demographic.getFirstName();
         mrpProviderName = demographic.getProviderNo() == null || demographic.getProviderNo().isEmpty() ? "Unknown" : providerDao.getProviderNameLastFirst(demographic.getProviderNo());
-        mrpProviderName = " (MRP: " + Encode.forHtmlContent(mrpProviderName) + ")";
+        mrpProviderName = " (MRP: " + mrpProviderName + ")";
     } else {
       demoName = EDocUtil.getProviderName(providerNo);
     }
@@ -267,7 +267,7 @@
                 loc = loc + id;
                 loc = loc + "&queueID=";
                 loc = loc + "<%=inQueue%>";
-                loc = loc + "&demoName=" + demoName;
+                loc = loc + "&demoName=" + encodeURIComponent(demoName);
                 popupStart(1400, 1400, loc, "Splitter");
             }
 
@@ -531,7 +531,7 @@
                                            id="demofind<%=docId%>"/>
                                     <input type="hidden" name="demofindName" value="${e:forHtmlAttribute(demoName)}"
                                            id="demofindName<%=docId%>"/>
-                                    <e:forHtmlContent value='${demoName}' /><c:out value="${mrpProviderName}" default=" (MRP: Unknown)" /><%} else {%>
+                                    <e:forHtmlContent value='${demoName}' /><e:forHtmlContent value='${mrpProviderName}' /><%} else {%>
                                     <input id="saved<%=docId%>" type="hidden" name="saved" value="false"/>
                                     <input type="hidden" name="demog" value="<%=demographicID%>"
                                            id="demofind<%=docId%>"/>


### PR DESCRIPTION
Link to the original PR: https://github.com/open-osp/Open-O/pull/61

## Summary by Sourcery

Restore missing changes to show a patient’s MRP in the document view while hardening patient name handling against XSS in the document manager UI.

New Features:
- Display the patient’s MRP provider name alongside the patient name in the document view, with a default placeholder when unknown.

Bug Fixes:
- Sanitize patient name usage in document view markup, attributes, and JavaScript handlers using the OWASP Java Encoder taglib to prevent XSS vulnerabilities.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores missing changes to show the patient’s MRP in the document view and hardens patient name and MRP handling to prevent XSS.

- **New Features**
  - Show MRP provider next to the patient name, with a default of "(MRP: Unknown)".

- **Bug Fixes**
  - Use OWASP Java Encoder consistently; encode demoName and MRP at render time for HTML content, attributes, and JavaScript; encode URL params with encodeURIComponent; remove double encoding of MRP.

<sup>Written for commit 89041275caa5d6e4b0b712a99490878fea45fefd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of dynamic text across the document view for more consistent and safe rendering in legends, form fields, and display fragments.
  * Fixed URL construction for the Split action so names are properly encoded, avoiding broken links.
  * Adjusted provider/name display logic for clearer rendering in MRPP and related sections.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->