### PR TITLE
Fix: Return DOB in epoch format for Ocean eReferral import 

### DIFF
--- a/src/main/java/ca/openosp/openo/webserv/rest/to/model/DemographicSearchResult.java
+++ b/src/main/java/ca/openosp/openo/webserv/rest/to/model/DemographicSearchResult.java
@@ -29,6 +29,8 @@ import java.util.Date;
 
 import org.apache.tools.ant.util.DateUtils;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+
 public class DemographicSearchResult {
 
     private SimpleDateFormat sdf = new SimpleDateFormat(DateUtils.ISO8601_DATE_PATTERN);
@@ -38,7 +40,10 @@ public class DemographicSearchResult {
     private String firstName;
     private String chartNo;
     private String sex;
+
+    @JsonFormat(shape = JsonFormat.Shape.NUMBER)
     private Date dob;
+
     private String providerNo;
     private String providerName;
     private String rosterStatus;


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                            
  Fixes the demographic search endpoint to return DOB in epoch timestamp format instead of yyyy-mm-dd string format, resolving Ocean eReferral import issues and restoring Struts 1 legacy behavior.                                                    
                                                                                                                                                                                                                                                        
  ## Problem                                                                                                                                                                                                                                            
  When importing a sent eReferral from Ocean back into the EMR (Action → Import into EMR), a warning message was incorrectly displayed: "Ocean has not received a confirmation...".                                                                     
                                                                                                                                                                                                                                                        
  Root cause: The demographic search REST endpoint was returning DOB in yyyy-mm-dd string format when Ocean expected epoch timestamp (number) format.                                                                                                   
                                                                                                                                                                                                                                                        
  ## Background                                                                                                                                                                                                                                         
  During the Struts 1 to Struts 2 migration (`*2Action` pattern), the original behavior was to send DOB in epoch format. The REST endpoint must maintain this legacy behavior for backward compatibility with Ocean's integration expectations.         
                                                                                                                                                                                                                                                        
  ## Solution                                                                                                                                                                                                                                           
  Added `@JsonFormat(shape = JsonFormat.Shape.NUMBER)` annotation to the `dob` field in `DemographicSearchResult` to ensure DOB is serialized as an epoch timestamp in JSON responses, matching the original Struts 1 behavior.

## Summary by Sourcery

Bug Fixes:
- Correct DOB serialization in DemographicSearchResult so it is returned as a numeric epoch timestamp instead of a date string in REST responses.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return DOB as an epoch timestamp in the demographic search endpoint to fix Ocean eReferral import warnings and restore legacy behavior.

- **Bug Fixes**
  - Serialize dob as epoch by adding @JsonFormat(shape = JsonFormat.Shape.NUMBER) in DemographicSearchResult.
  - Matches the original Struts 1 response format expected by Ocean.

<sup>Written for commit e58b250384648ca7ca913f2394d8b632366d68ed. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

