### PR TITLE
Resolve duplicate letterheadFax ID in consultation fax account dropdown

### DIFF
--- a/src/main/webapp/oscarEncounter/oscarConsultationRequest/ConsultationFormRequest.jsp
+++ b/src/main/webapp/oscarEncounter/oscarConsultationRequest/ConsultationFormRequest.jsp
@@ -2665,7 +2665,7 @@ if (userAgent != null) {
 								<%
                                     for (FaxConfig faxConfig : faxConfigs) {
                                 %>
-										<option value="<%=Encode.forHtmlAttribute(String.valueOf(faxConfig.getId()))%>" <%=faxConfig.getFaxNumber().equalsIgnoreCase(consultUtil.letterheadFax) ? "selected" : ""%>><%=Encode.forHtmlContent(faxConfig.getAccountName())%></option>
+										<option value="<%=Encode.forHtmlAttribute(faxConfig.getFaxNumber())%>" <%=faxConfig.getFaxNumber().equalsIgnoreCase(consultUtil.letterheadFax) ? "selected" : ""%>><%=Encode.forHtmlContent(faxConfig.getAccountName())%></option>
 								<%
                                     }
                                 %>


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                      
  Fixes duplicate HTML ID issue in consultation form fax account dropdown that was preventing proper fax functionality.                                                                                                                                           
                                                                                                                                                                                                                                                                  
  ## Problem                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      
  This caused:                                                                                                                                                                                                                                                    
  - JavaScript `getElementById("faxAccount")` calls to fail (lines 1512, 1537)                                                                                                                                                                                    
  - Fax account selection not persisting to CoverPage.jsp                                                                                                                                                                                                         
  - HTML validation errors  

 ## Changes Made                                                                                                                                                                                                                                                 
  - Changed select dropdown `id="letterheadFax"` → `id="faxAccount"`                                                                                                                                                                                           
  - Changed select `name="letterheadFax"` → `name="faxAccount"`                                                                                                                                                                                                
  - Changed option value from `faxConfig.getFaxNumber()` → `faxConfig.getId()`                                                                                                                                                                                 
  - Applied `Encode.forHtmlAttribute()` to option values (XSS protection)                                                                                                                                                                                      
  - Removed unnecessary `<span id="letterheadFaxSpan">` wrapper

## Summary by Sourcery

Fix fax account selection in the consultation request form by correcting the dropdown field identifiers and option values.

Bug Fixes:
- Ensure the consultation fax account dropdown uses the correct ID and name so JavaScript selection and persistence work properly.
- Use the fax configuration ID as the option value and HTML-encode it to prevent XSS in the fax account dropdown.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the consultation fax account dropdown by renaming the field and removing the duplicate HTML ID. JavaScript lookups now work correctly.

- **Bug Fixes**
  - Rename select name/id to faxAccount (from letterheadFax) to match JS.
  - Keep fax numbers as option values.
  - Remove unused span wrapper.

<sup>Written for commit d57167fc3815ffaff31889da2de34923acb802c5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced the fax account selection interface in consultation request forms for improved clarity and usability. The fax selection field now displays all available accounts with their corresponding fax numbers, making it easier for users to identify and select the correct fax account when submitting consultation requests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->