### PR TITLE
Fix: removed show call to HTML element that is never set

### DIFF
--- a/src/main/webapp/oscarRx/SearchDrug3.jsp
+++ b/src/main/webapp/oscarRx/SearchDrug3.jsp
@@ -595,7 +595,6 @@ function checkFav(){
 function renderRxStage() {
 	$('rxText').show();
 	$('prescriptionStageSet').show();
-	$('savePrescriptionButtonSet').show();
 }
 
      //not used , represcribe a drug


### PR DESCRIPTION
Looking at the git history:
 
  │   Commit   │     Date     │                                 Description                                 │
  │ 8b9f0babd0 │ Aug 25, 2025 │ Added renderRxStage() function with the savePrescriptionButtonSet reference │

  The renderRxStage() function was newly added in that commit, and the reference to savePrescriptionButtonSet was included from the start - but no corresponding HTML element was ever created.

## Summary by Sourcery

Bug Fixes:
- Stop attempting to show a prescription save button element that is never initialized in the Rx search page.

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed a show() call on savePrescriptionButtonSet in renderRxStage, which targets an element that is never set. This prevents a null console error when rendering the prescription stage.

<sup>Written for commit 4c3db3e334b84237e1efe6d1967b9f9878b53624. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Bug Fixes:
- Prevent a null reference error by no longer showing a prescription save button element that is never set when rendering the prescription stage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the save button from displaying during a specific stage in the prescription workflow to prevent user confusion and ensure correct interface behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->