### PR TITLE
docs: add comprehensive JavaDoc to BirthAttendantsImpl

### DIFF
--- a/src/main/java/ca/openosp/openo/ar2005/impl/BirthAttendantsImpl.java
+++ b/src/main/java/ca/openosp/openo/ar2005/impl/BirthAttendantsImpl.java
@@ -9,6 +9,29 @@ import javax.xml.namespace.QName;
 import ca.openosp.openo.ar2005.BirthAttendants;
 import org.apache.xmlbeans.impl.values.XmlComplexContentImpl;
 
+/**
+ * XML Beans implementation for the BirthAttendants element in the British Columbia Antenatal Record (BCAR) AR2005 form.
+ *
+ * <p>This class provides XML serialization and deserialization capabilities for tracking the healthcare professionals
+ * who attended a birth. The BCAR AR2005 form is used throughout British Columbia for standardized prenatal care
+ * documentation and captures essential information about pregnancy, delivery, and postnatal care.</p>
+ *
+ * <p>Birth attendants tracked by this implementation include:</p>
+ * <ul>
+ *   <li>OBS (Obstetrician) - Medical doctor specializing in pregnancy and childbirth</li>
+ *   <li>FP (Family Physician) - General practitioner providing maternity care</li>
+ *   <li>Midwife - Licensed midwife providing maternity care</li>
+ *   <li>Other - Free-text field for other healthcare providers</li>
+ * </ul>
+ *
+ * <p>This implementation extends Apache XMLBeans' XmlComplexContentImpl to provide type-safe access to the
+ * XML structure defined in the AR2005 schema. All accessor methods are thread-safe through monitor synchronization
+ * and interact with the underlying XML store through the XMLBeans framework.</p>
+ *
+ * @see ca.openosp.openo.ar2005.BirthAttendants
+ * @see org.apache.xmlbeans.impl.values.XmlComplexContentImpl
+ * @since 2026-01-23
+ */
 public class BirthAttendantsImpl extends XmlComplexContentImpl implements BirthAttendants
 {
     private static final long serialVersionUID = 1L;
@@ -16,11 +39,29 @@ public class BirthAttendantsImpl extends XmlComplexContentImpl implements BirthA
     private static final QName FP$2;
     private static final QName MIDWIFE$4;
     private static final QName OTHER$6;
-    
+
+    /**
+     * Constructs a new BirthAttendantsImpl instance with the specified schema type.
+     *
+     * <p>This constructor is typically called by the Apache XMLBeans framework during XML parsing
+     * and deserialization. It initializes the underlying XML store with the appropriate schema type
+     * definition for the BirthAttendants element.</p>
+     *
+     * @param sType SchemaType the schema type definition for this XML element, must not be null
+     */
     public BirthAttendantsImpl(final SchemaType sType) {
         super(sType);
     }
-    
+
+    /**
+     * Retrieves whether an obstetrician was present as a birth attendant.
+     *
+     * <p>Obstetricians are medical doctors who specialize in pregnancy, childbirth, and the postpartum period.
+     * This method returns the primitive boolean value indicating presence or absence of an obstetrician
+     * at the birth.</p>
+     *
+     * @return boolean true if an obstetrician attended the birth, false otherwise
+     */
     public boolean getOBS() {
         synchronized (this.monitor()) {
             this.check_orphaned();
@@ -29,7 +70,16 @@ public class BirthAttendantsImpl extends XmlComplexContentImpl implements BirthA
             return target != null && target.getBooleanValue();
         }
     }
-    
+
+    /**
+     * Retrieves the XML representation of the OBS (obstetrician) birth attendant indicator.
+     *
+     * <p>This method returns the underlying XmlBoolean object rather than the primitive boolean value,
+     * allowing access to XML-specific features such as nil values, validation state, and schema type information.
+     * Used primarily for XML processing and serialization tasks.</p>
+     *
+     * @return XmlBoolean the XML boolean object representing obstetrician attendance, or null if not set
+     */
     public XmlBoolean xgetOBS() {
         synchronized (this.monitor()) {
             this.check_orphaned();
@@ -38,7 +88,15 @@ public class BirthAttendantsImpl extends XmlComplexContentImpl implements BirthA
             return target;
         }
     }
-    
+
+    /**
+     * Sets whether an obstetrician was present as a birth attendant.
+     *
+     * <p>This method updates the primitive boolean value in the underlying XML store. If the XML element
+     * does not exist, it will be created automatically. This is thread-safe through monitor synchronization.</p>
+     *
+     * @param obs boolean true to indicate an obstetrician attended the birth, false otherwise
+     */
     public void setOBS(final boolean obs) {
         synchronized (this.monitor()) {
             this.check_orphaned();
@@ -50,7 +108,16 @@ public class BirthAttendantsImpl extends XmlComplexContentImpl implements BirthA
             target.setBooleanValue(obs);
         }
     }
-    
+
+    /**
+     * Sets the XML representation of the OBS (obstetrician) birth attendant indicator.
+     *
+     * <p>This method allows setting the value using an XmlBoolean object rather than a primitive boolean,
+     * preserving XML-specific attributes such as nil state and validation metadata. The provided XmlBoolean
+     * is copied into the underlying XML store. If the element does not exist, it will be created.</p>
+     *
+     * @param obs XmlBoolean the XML boolean object to set, must not be null
+     */
     public void xsetOBS(final XmlBoolean obs) {
         synchronized (this.monitor()) {
             this.check_orphaned();
@@ -62,7 +129,16 @@ public class BirthAttendantsImpl extends XmlComplexContentImpl implements BirthA
             target.set((XmlObject)obs);
         }
     }
-    
+
+    /**
+     * Retrieves whether a family physician was present as a birth attendant.
+     *
+     * <p>Family physicians (FPs) are general practitioners who provide comprehensive maternity care including
+     * prenatal visits, delivery, and postnatal care. This method returns the primitive boolean value
+     * indicating presence or absence of a family physician at the birth.</p>
+     *
+     * @return boolean true if a family physician attended the birth, false otherwise
+     */
     public boolean getFP() {
         synchronized (this.monitor()) {
             this.check_orphaned();
@@ -71,7 +147,16 @@ public class BirthAttendantsImpl extends XmlComplexContentImpl implements BirthA
             return target != null && target.getBooleanValue();
         }
     }
-    
+
+    /**
+     * Retrieves the XML representation of the FP (family physician) birth attendant indicator.
+     *
+     * <p>This method returns the underlying XmlBoolean object rather than the primitive boolean value,
+     * allowing access to XML-specific features such as nil values, validation state, and schema type information.
+     * Used primarily for XML processing and serialization tasks.</p>
+     *
+     * @return XmlBoolean the XML boolean object representing family physician attendance, or null if not set
+     */
     public XmlBoolean xgetFP() {
         synchronized (this.monitor()) {
             this.check_orphaned();
@@ -80,7 +165,15 @@ public class BirthAttendantsImpl extends XmlComplexContentImpl implements BirthA
             return target;
         }
     }
-    
+
+    /**
+     * Sets whether a family physician was present as a birth attendant.
+     *
+     * <p>This method updates the primitive boolean value in the underlying XML store. If the XML element
+     * does not exist, it will be created automatically. This is thread-safe through monitor synchronization.</p>
+     *
+     * @param fp boolean true to indicate a family physician attended the birth, false otherwise
+     */
     public void setFP(final boolean fp) {
         synchronized (this.monitor()) {
             this.check_orphaned();
@@ -92,7 +185,16 @@ public class BirthAttendantsImpl extends XmlComplexContentImpl implements BirthA
             target.setBooleanValue(fp);
         }
     }
-    
+
+    /**
+     * Sets the XML representation of the FP (family physician) birth attendant indicator.
+     *
+     * <p>This method allows setting the value using an XmlBoolean object rather than a primitive boolean,
+     * preserving XML-specific attributes such as nil state and validation metadata. The provided XmlBoolean
+     * is copied into the underlying XML store. If the element does not exist, it will be created.</p>
+     *
+     * @param fp XmlBoolean the XML boolean object to set, must not be null
+     */
     public void xsetFP(final XmlBoolean fp) {
         synchronized (this.monitor()) {
             this.check_orphaned();
@@ -104,7 +206,17 @@ public class BirthAttendantsImpl extends XmlComplexContentImpl implements BirthA
             target.set((XmlObject)fp);
         }
     }
-    
+
+    /**
+     * Retrieves whether a midwife was present as a birth attendant.
+     *
+     * <p>Midwives are healthcare professionals who specialize in pregnancy, childbirth, postpartum care,
+     * and newborn care. In British Columbia, registered midwives are licensed primary care providers for
+     * women during pregnancy and birth. This method returns the primitive boolean value indicating
+     * presence or absence of a midwife at the birth.</p>
+     *
+     * @return boolean true if a midwife attended the birth, false otherwise
+     */
     public boolean getMidwife() {
         synchronized (this.monitor()) {
             this.check_orphaned();
@@ -113,7 +225,16 @@ public class BirthAttendantsImpl extends XmlComplexContentImpl implements BirthA
             return target != null && target.getBooleanValue();
         }
     }
-    
+
+    /**
+     * Retrieves the XML representation of the midwife birth attendant indicator.
+     *
+     * <p>This method returns the underlying XmlBoolean object rather than the primitive boolean value,
+     * allowing access to XML-specific features such as nil values, validation state, and schema type information.
+     * Used primarily for XML processing and serialization tasks.</p>
+     *
+     * @return XmlBoolean the XML boolean object representing midwife attendance, or null if not set
+     */
     public XmlBoolean xgetMidwife() {
         synchronized (this.monitor()) {
             this.check_orphaned();
@@ -122,7 +243,15 @@ public class BirthAttendantsImpl extends XmlComplexContentImpl implements BirthA
             return target;
         }
     }
-    
+
+    /**
+     * Sets whether a midwife was present as a birth attendant.
+     *
+     * <p>This method updates the primitive boolean value in the underlying XML store. If the XML element
+     * does not exist, it will be created automatically. This is thread-safe through monitor synchronization.</p>
+     *
+     * @param midwife boolean true to indicate a midwife attended the birth, false otherwise
+     */
     public void setMidwife(final boolean midwife) {
         synchronized (this.monitor()) {
             this.check_orphaned();
@@ -134,7 +263,16 @@ public class BirthAttendantsImpl extends XmlComplexContentImpl implements BirthA
             target.setBooleanValue(midwife);
         }
     }
-    
+
+    /**
+     * Sets the XML representation of the midwife birth attendant indicator.
+     *
+     * <p>This method allows setting the value using an XmlBoolean object rather than a primitive boolean,
+     * preserving XML-specific attributes such as nil state and validation metadata. The provided XmlBoolean
+     * is copied into the underlying XML store. If the element does not exist, it will be created.</p>
+     *
+     * @param midwife XmlBoolean the XML boolean object to set, must not be null
+     */
     public void xsetMidwife(final XmlBoolean midwife) {
         synchronized (this.monitor()) {
             this.check_orphaned();
@@ -146,7 +284,16 @@ public class BirthAttendantsImpl extends XmlComplexContentImpl implements BirthA
             target.set((XmlObject)midwife);
         }
     }
-    
+
+    /**
+     * Retrieves the free-text description of other birth attendants not covered by standard categories.
+     *
+     * <p>This field allows documentation of healthcare providers or support persons who attended the birth
+     * but do not fall into the standard categories of obstetrician, family physician, or midwife. Examples
+     * might include doulas, nurse practitioners, resident physicians, or traditional birth attendants.</p>
+     *
+     * @return String the description of other birth attendants, or null if not specified
+     */
     public String getOther() {
         synchronized (this.monitor()) {
             this.check_orphaned();
@@ -158,7 +305,16 @@ public class BirthAttendantsImpl extends XmlComplexContentImpl implements BirthA
             return target.getStringValue();
         }
     }
-    
+
+    /**
+     * Retrieves the XML representation of the other birth attendants description.
+     *
+     * <p>This method returns the underlying XmlString object rather than the primitive String value,
+     * allowing access to XML-specific features such as nil values, validation state, and schema type information.
+     * Used primarily for XML processing and serialization tasks.</p>
+     *
+     * @return XmlString the XML string object representing other birth attendants, or null if not set
+     */
     public XmlString xgetOther() {
         synchronized (this.monitor()) {
             this.check_orphaned();
@@ -167,7 +323,15 @@ public class BirthAttendantsImpl extends XmlComplexContentImpl implements BirthA
             return target;
         }
     }
-    
+
+    /**
+     * Sets the free-text description of other birth attendants not covered by standard categories.
+     *
+     * <p>This method updates the string value in the underlying XML store. If the XML element does not exist,
+     * it will be created automatically. This is thread-safe through monitor synchronization.</p>
+     *
+     * @param other String the description of other birth attendants, may be null
+     */
     public void setOther(final String other) {
         synchronized (this.monitor()) {
             this.check_orphaned();
@@ -179,7 +343,16 @@ public class BirthAttendantsImpl extends XmlComplexContentImpl implements BirthA
             target.setStringValue(other);
         }
     }
-    
+
+    /**
+     * Sets the XML representation of the other birth attendants description.
+     *
+     * <p>This method allows setting the value using an XmlString object rather than a primitive String,
+     * preserving XML-specific attributes such as nil state and validation metadata. The provided XmlString
+     * is copied into the underlying XML store. If the element does not exist, it will be created.</p>
+     *
+     * @param other XmlString the XML string object to set, must not be null
+     */
     public void xsetOther(final XmlString other) {
         synchronized (this.monitor()) {
             this.check_orphaned();


### PR DESCRIPTION
Add complete JavaDoc documentation to BirthAttendantsImpl.java following CLAUDE.md documentation standards.

### Changes
- Add class-level documentation explaining BCAR AR2005 healthcare context
- Document all 13 public methods with @param, @return descriptions
- Add @since tag with date from git history (2026-01-23)
- Add @see tags for related classes
- Include healthcare domain context for birth attendants (OBS, FP, Midwife)
- Document XMLBeans-specific methods (xget/xset variants)

No functional code changes - documentation only.

Fixes #1534
Part of Epic #1405

Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Add comprehensive JavaDoc documentation to the BirthAttendantsImpl XMLBeans implementation for the BCAR AR2005 birth attendants element.

Documentation:
- Document BirthAttendantsImpl with class-level JavaDoc describing its BC healthcare and XMLBeans context, including supported birth attendant roles and threading semantics.
- Add detailed JavaDoc to all public constructor and accessor methods, covering parameters, return values, and XML-specific usage patterns.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added comprehensive JavaDoc to BirthAttendantsImpl to clarify BCAR AR2005 birth attendant context (OBS, FP, Midwife, Other) and document all accessors, including XMLBeans xget/xset methods, @see, and @since. Documentation only; no functional changes. Fixes #1534 (Epic #1405).

<sup>Written for commit 5f8a91707f019f01e49a8cc217709cf76af5bfa5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced internal code documentation with comprehensive Javadoc comments for improved developer reference.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->