### PR TITLE
feat: add GITHUB_TOKEN sandboxed permissions for gh cli for claude

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -91,6 +91,7 @@
       "Bash(gh run view *)",
       "Bash(gh run list *)",
       "Bash(gh run watch *)",
+      "Bash(gh issue create *)",
       "Bash(git status *)",
       "Bash(git branch *)",
       "Bash(git checkout *)",
@@ -214,7 +215,6 @@
     "ask": [
       "Bash(gh pr close *)",
       "Bash(gh issue close *)",
-      "Bash(gh issue create *)",
       "Bash(gh issue edit *)",
       "Bash(gh label *)",
       "Bash(gh run rerun *)",

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -45,6 +45,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Pass the repository GITHUB_TOKEN into the claude-code GitHub Action as an explicit input for GitHub CLI operations.

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added GITHUB_TOKEN to the Claude workflow to enable safe gh CLI usage. Claude can now create GitHub issues without manual prompts, using repo-scoped permissions.

- **New Features**
  - Pass github_token to anthropics/claude-code-action in the workflow.
  - Move "Bash(gh issue create *)" to the allowed commands in .claude/settings.json (removed from ask).

<sup>Written for commit b5e93859f9db7d4743e4384da430cc0db8ec7808. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal configuration settings for developer tools.
  * Enhanced GitHub workflow authentication to improve integration and reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->