### PR TITLE
feat: add the command line permissions, sandboxed by token, for claude workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -54,7 +54,6 @@ jobs:
           # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
           # prompt: 'Update the pull request description to include a summary of changes.'
 
-          # Optional: Add claude_args to customize behavior and configuration
+          # Allow gh CLI commands for PR/issue management
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr:*)'
+          claude_args: '--allowed-tools "Bash(gh pr create *)" --allowed-tools "Bash(gh pr view *)" --allowed-tools "Bash(gh pr list *)" --allowed-tools "Bash(gh pr diff *)" --allowed-tools "Bash(gh pr checks *)" --allowed-tools "Bash(gh issue view *)" --allowed-tools "Bash(gh issue list *)" --allowed-tools "Bash(gh issue comment *)" --allowed-tools "Bash(gh run view *)" --allowed-tools "Bash(gh run list *)"'


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Restrict Claude Action to a sandboxed set of gh CLI commands for viewing, listing, creating PRs, managing issues, and inspecting workflow runs.

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enable GitHub CLI permissions in the Claude workflow, limited to specific subcommands and sandboxed by the workflow token. This lets the action manage PRs/issues and inspect runs without broad access.

- **New Features**
  - gh pr: create, view, list, diff, checks
  - gh issue: view, list, comment
  - gh run: view, list

<sup>Written for commit 9f689893418af560b0dee458cb71ed212a757657. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal GitHub workflow configuration to support improved development and release processes.

---

**Note:** This release contains primarily internal infrastructure updates with no direct user-facing changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->