### PR TITLE
fix: adjust permissions to allow gh cli actions sandboxed by token

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -54,6 +54,6 @@ jobs:
           # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
           # prompt: 'Update the pull request description to include a summary of changes.'
 
-          # Allow gh CLI commands for PR/issue management
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          claude_args: '--allowed-tools "Bash(gh pr create *)" --allowed-tools "Bash(gh pr view *)" --allowed-tools "Bash(gh pr list *)" --allowed-tools "Bash(gh pr diff *)" --allowed-tools "Bash(gh pr checks *)" --allowed-tools "Bash(gh issue view *)" --allowed-tools "Bash(gh issue list *)" --allowed-tools "Bash(gh issue comment *)" --allowed-tools "Bash(gh run view *)" --allowed-tools "Bash(gh run list *)"'
+          # Allow gh CLI commands for PR/issue management (uses :* prefix matching syntax)
+          # See https://code.claude.com/docs/en/settings#permission-rule-syntax
+          claude_args: '--allowedTools "Bash(gh pr create:*)" "Bash(gh pr view:*)" "Bash(gh pr list:*)" "Bash(gh pr diff:*)" "Bash(gh pr checks:*)" "Bash(gh pr comment:*)" "Bash(gh issue view:*)" "Bash(gh issue list:*)" "Bash(gh issue comment:*)" "Bash(gh issue create:*)" "Bash(gh run view:*)" "Bash(gh run list:*)" "Bash(gh run watch:*)" "Bash(gh repo view:*)" "Bash(git status:*)" "Bash(git branch:*)" "Bash(git checkout:*)" "Bash(git add:*)" "Bash(git commit:*)" "Bash(git push:*)" "Bash(git pull:*)" "Bash(git fetch:*)" "Bash(git log:*)" "Bash(git diff:*)" "Bash(git show:*)"'


### PR DESCRIPTION
## Summary by Sourcery

Update Claude GitHub Action workflow permissions to use the new allowed tools syntax and expand permitted gh and git commands for PR and repo management.

Enhancements:
- Broaden the set of permitted gh and git commands available to the Claude action for pull request, issue, run, repo, and basic git operations.

CI:
- Adjust Claude workflow configuration to use :* prefix matching syntax for allowed tools and align with current permission rule format.