### PR TITLE
Fix issue where billings created from a past encounter/appointment had the wrong service date prefilled

### DIFF
--- a/src/main/webapp/casemgmt/forward.jsp
+++ b/src/main/webapp/casemgmt/forward.jsp
@@ -57,7 +57,8 @@
         "&start_time=" + (request.getParameter("start_time") != null ? URLEncoder.encode(request.getParameter("start_time"), StandardCharsets.UTF_8) : "") +
         "&apptProvider=" + (request.getParameter("apptProvider") != null ? URLEncoder.encode(request.getParameter("apptProvider"), StandardCharsets.UTF_8) : "") +
         "&providerview=" + (request.getParameter("providerview") != null ? URLEncoder.encode(request.getParameter("providerview"), StandardCharsets.UTF_8) : "") +
-        "&OscarMsgTypeLink=" + request.getParameter("OscarMsgTypeLink") + "&msgType=" + request.getParameter("msgType");
+        "&OscarMsgTypeLink=" + (request.getParameter("OscarMsgTypeLink") != null ? URLEncoder.encode(request.getParameter("OscarMsgTypeLink"), StandardCharsets.UTF_8) : "") +
+        "&msgType=" + (request.getParameter("msgType") != null ? URLEncoder.encode(request.getParameter("msgType"), StandardCharsets.UTF_8) : "");
     } else {
         redirectURL = request.getContextPath() + "/CaseManagementView.do";
     }


### PR DESCRIPTION
## In this PR, I have:
- Added required appointment params with the foward.jsp page (used to forward towards the echart)

## I have tested this by:
- Testing the eChart functionality (no appointment, appointment today, appointment previously, check the billing state in all)

## Summary by Sourcery

Bug Fixes:
- Include appointment date, start time, provider, and provider view parameters in the eChart redirect to restore appointment tracking and related UI behavior.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add appointmentDate, start_time, apptProvider, and providerview to the eChart redirect in forward.jsp to preserve appointment context, and URL-encode OscarMsgTypeLink and msgType. This enables appointment tracking and fixes the missing calendar icon when viewing notes in billing.

<sup>Written for commit c7de4bcc7f7137e806f81971456d4f9c223a5e67. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Bug Fixes:
- Ensure eChart redirects include appointment date, start time, and provider context to fix missing appointment tracking and related UI issues.