### PR TITLE
Fix reversed prevention ordering

### DIFF
--- a/src/main/java/ca/openosp/openo/commn/dao/PreventionDaoImpl.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/PreventionDaoImpl.java
@@ -184,7 +184,7 @@ public class PreventionDaoImpl extends AbstractDaoImpl<Prevention> implements Pr
 
     @Override
     public List<Prevention> findByTypeAndDemoNo(String preventionType, Integer demoNo) {
-        String sqlCommand = "select x from " + modelClass.getSimpleName() + " x where preventionType=?1 and demographicId=?2 and deleted='0' order by preventionDate";
+        String sqlCommand = "select x from " + modelClass.getSimpleName() + " x where preventionType=?1 and demographicId=?2 and deleted='0' order by preventionDate asc";
 
         Query query = entityManager.createQuery(sqlCommand);
         query.setParameter(1, preventionType);


### PR DESCRIPTION
## In this PR, I have fixed:
- Ordering for prevention (was revered as descending), and is now set back to ascending

## I have tested this by:
- Opening a patients eChart, inspecting the "Preventions" tab ensuring that the values are the newest date (descending), inspecting the "Preventions" page ensuring that the entries are oldest to newest (ascending)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed prevention search ordering to sort ascending by date, restoring the Preventions page to show entries from oldest to newest while keeping the eChart tab newest first.

<sup>Written for commit fdda1beb3ee53f74ef2149576d1c6193a2abfb9f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Bug Fixes:
- Correct prevention search ordering so demographic-specific prevention lists are sorted from oldest to newest by prevention date.