### PR TITLE
docs: Document: GenericHistoryTypeImpl

### DIFF
--- a/src/main/java/ca/openosp/openo/ar2005/impl/GenericHistoryTypeImpl.java
+++ b/src/main/java/ca/openosp/openo/ar2005/impl/GenericHistoryTypeImpl.java
@@ -7,6 +7,25 @@ import javax.xml.namespace.QName;
 import ca.openosp.openo.ar2005.GenericHistoryType;
 import org.apache.xmlbeans.impl.values.XmlComplexContentImpl;
 
+/**
+ * Implementation class for GenericHistoryType XML schema type used in the AR2005 (Antenatal Record 2005) healthcare forms.
+ *
+ * This class provides XMLBeans-based implementation for managing genetic and developmental history information
+ * in antenatal care records. It handles five key health risk indicators commonly tracked during pregnancy:
+ * at-risk status, developmental delays, congenital anomalies, chromosomal disorders, and genetic disorders.
+ *
+ * The implementation extends XmlComplexContentImpl to provide XML serialization/deserialization capabilities
+ * and follows the AR2005 XML schema namespace (http://www.oscarmcmaster.org/AR2005). Each health indicator
+ * is represented as a YesNoNullType element, allowing for tri-state values (yes, no, or null/unknown).
+ *
+ * This class is part of the British Columbia Antenatal Record (BCAR) forms integration used for
+ * comprehensive pregnancy care documentation in OpenO EMR.
+ *
+ * @see ca.openosp.openo.ar2005.GenericHistoryType
+ * @see ca.openosp.openo.ar2005.YesNoNullType
+ * @see org.apache.xmlbeans.impl.values.XmlComplexContentImpl
+ * @since 2026-01-23
+ */
 public class GenericHistoryTypeImpl extends XmlComplexContentImpl implements GenericHistoryType
 {
     private static final long serialVersionUID = 1L;
@@ -15,11 +34,27 @@ public class GenericHistoryTypeImpl extends XmlComplexContentImpl implements Gen
     private static final QName CONGENITALANOMOLIES$4;
     private static final QName CHROMOSOMALDISORDERS$6;
     private static final QName GENETICDISORDERS$8;
-    
+
+    /**
+     * Constructs a new GenericHistoryTypeImpl instance with the specified XMLBeans schema type.
+     *
+     * This constructor initializes the XML complex content implementation with the provided schema type,
+     * enabling proper XML serialization and validation according to the AR2005 schema definition.
+     *
+     * @param sType SchemaType the XMLBeans schema type definition for GenericHistoryType
+     */
     public GenericHistoryTypeImpl(final SchemaType sType) {
         super(sType);
     }
-    
+
+    /**
+     * Retrieves the at-risk status indicator for the patient's antenatal history.
+     *
+     * This method returns the at-risk flag which indicates whether the patient has been identified
+     * as having elevated pregnancy risk factors requiring additional monitoring or interventions.
+     *
+     * @return YesNoNullType the at-risk status (yes, no, or null if not specified)
+     */
     public YesNoNullType getAtRisk() {
         synchronized (this.monitor()) {
             this.check_orphaned();
@@ -31,7 +66,15 @@ public class GenericHistoryTypeImpl extends XmlComplexContentImpl implements Gen
             return target;
         }
     }
-    
+
+    /**
+     * Sets the at-risk status indicator for the patient's antenatal history.
+     *
+     * This method updates the at-risk flag to indicate whether the patient has been identified
+     * as having elevated pregnancy risk factors. The value persists in the XML store.
+     *
+     * @param atRisk YesNoNullType the at-risk status to set (yes, no, or null)
+     */
     public void setAtRisk(final YesNoNullType atRisk) {
         synchronized (this.monitor()) {
             this.check_orphaned();
@@ -43,7 +86,15 @@ public class GenericHistoryTypeImpl extends XmlComplexContentImpl implements Gen
             target.set((XmlObject)atRisk);
         }
     }
-    
+
+    /**
+     * Creates and adds a new at-risk status element to the XML store.
+     *
+     * This method creates a new YesNoNullType element for the at-risk indicator and adds it
+     * to the internal XML store. The newly created element is returned for immediate configuration.
+     *
+     * @return YesNoNullType the newly created at-risk status element
+     */
     public YesNoNullType addNewAtRisk() {
         synchronized (this.monitor()) {
             this.check_orphaned();
@@ -52,7 +103,15 @@ public class GenericHistoryTypeImpl extends XmlComplexContentImpl implements Gen
             return target;
         }
     }
-    
+
+    /**
+     * Retrieves the developmental delay indicator for the patient's antenatal history.
+     *
+     * This method returns the developmental delay flag which indicates whether there is a history
+     * or risk of developmental delays that may affect pregnancy care or neonatal outcomes.
+     *
+     * @return YesNoNullType the developmental delay status (yes, no, or null if not specified)
+     */
     public YesNoNullType getDevelopmentalDelay() {
         synchronized (this.monitor()) {
             this.check_orphaned();
@@ -64,7 +123,15 @@ public class GenericHistoryTypeImpl extends XmlComplexContentImpl implements Gen
             return target;
         }
     }
-    
+
+    /**
+     * Sets the developmental delay indicator for the patient's antenatal history.
+     *
+     * This method updates the developmental delay flag to document any history or risk
+     * of developmental delays. The value persists in the XML store.
+     *
+     * @param developmentalDelay YesNoNullType the developmental delay status to set (yes, no, or null)
+     */
     public void setDevelopmentalDelay(final YesNoNullType developmentalDelay) {
         synchronized (this.monitor()) {
             this.check_orphaned();
@@ -76,7 +143,15 @@ public class GenericHistoryTypeImpl extends XmlComplexContentImpl implements Gen
             target.set((XmlObject)developmentalDelay);
         }
     }
-    
+
+    /**
+     * Creates and adds a new developmental delay element to the XML store.
+     *
+     * This method creates a new YesNoNullType element for the developmental delay indicator
+     * and adds it to the internal XML store. The newly created element is returned for immediate configuration.
+     *
+     * @return YesNoNullType the newly created developmental delay element
+     */
     public YesNoNullType addNewDevelopmentalDelay() {
         synchronized (this.monitor()) {
             this.check_orphaned();
@@ -85,7 +160,15 @@ public class GenericHistoryTypeImpl extends XmlComplexContentImpl implements Gen
             return target;
         }
     }
-    
+
+    /**
+     * Retrieves the congenital anomalies indicator for the patient's antenatal history.
+     *
+     * This method returns the congenital anomalies flag which indicates whether there is a history
+     * or risk of birth defects or structural abnormalities present from birth.
+     *
+     * @return YesNoNullType the congenital anomalies status (yes, no, or null if not specified)
+     */
     public YesNoNullType getCongenitalAnomolies() {
         synchronized (this.monitor()) {
             this.check_orphaned();
@@ -97,7 +180,15 @@ public class GenericHistoryTypeImpl extends XmlComplexContentImpl implements Gen
             return target;
         }
     }
-    
+
+    /**
+     * Sets the congenital anomalies indicator for the patient's antenatal history.
+     *
+     * This method updates the congenital anomalies flag to document any history or risk
+     * of birth defects or structural abnormalities. The value persists in the XML store.
+     *
+     * @param congenitalAnomolies YesNoNullType the congenital anomalies status to set (yes, no, or null)
+     */
     public void setCongenitalAnomolies(final YesNoNullType congenitalAnomolies) {
         synchronized (this.monitor()) {
             this.check_orphaned();
@@ -109,7 +200,15 @@ public class GenericHistoryTypeImpl extends XmlComplexContentImpl implements Gen
             target.set((XmlObject)congenitalAnomolies);
         }
     }
-    
+
+    /**
+     * Creates and adds a new congenital anomalies element to the XML store.
+     *
+     * This method creates a new YesNoNullType element for the congenital anomalies indicator
+     * and adds it to the internal XML store. The newly created element is returned for immediate configuration.
+     *
+     * @return YesNoNullType the newly created congenital anomalies element
+     */
     public YesNoNullType addNewCongenitalAnomolies() {
         synchronized (this.monitor()) {
             this.check_orphaned();
@@ -118,7 +217,15 @@ public class GenericHistoryTypeImpl extends XmlComplexContentImpl implements Gen
             return target;
         }
     }
-    
+
+    /**
+     * Retrieves the chromosomal disorders indicator for the patient's antenatal history.
+     *
+     * This method returns the chromosomal disorders flag which indicates whether there is a history
+     * or risk of chromosomal abnormalities such as Down syndrome, Turner syndrome, or other karyotype abnormalities.
+     *
+     * @return YesNoNullType the chromosomal disorders status (yes, no, or null if not specified)
+     */
     public YesNoNullType getChromosomalDisorders() {
         synchronized (this.monitor()) {
             this.check_orphaned();
@@ -130,7 +237,15 @@ public class GenericHistoryTypeImpl extends XmlComplexContentImpl implements Gen
             return target;
         }
     }
-    
+
+    /**
+     * Sets the chromosomal disorders indicator for the patient's antenatal history.
+     *
+     * This method updates the chromosomal disorders flag to document any history or risk
+     * of chromosomal abnormalities. The value persists in the XML store.
+     *
+     * @param chromosomalDisorders YesNoNullType the chromosomal disorders status to set (yes, no, or null)
+     */
     public void setChromosomalDisorders(final YesNoNullType chromosomalDisorders) {
         synchronized (this.monitor()) {
             this.check_orphaned();
@@ -142,7 +257,15 @@ public class GenericHistoryTypeImpl extends XmlComplexContentImpl implements Gen
             target.set((XmlObject)chromosomalDisorders);
         }
     }
-    
+
+    /**
+     * Creates and adds a new chromosomal disorders element to the XML store.
+     *
+     * This method creates a new YesNoNullType element for the chromosomal disorders indicator
+     * and adds it to the internal XML store. The newly created element is returned for immediate configuration.
+     *
+     * @return YesNoNullType the newly created chromosomal disorders element
+     */
     public YesNoNullType addNewChromosomalDisorders() {
         synchronized (this.monitor()) {
             this.check_orphaned();
@@ -151,7 +274,15 @@ public class GenericHistoryTypeImpl extends XmlComplexContentImpl implements Gen
             return target;
         }
     }
-    
+
+    /**
+     * Retrieves the genetic disorders indicator for the patient's antenatal history.
+     *
+     * This method returns the genetic disorders flag which indicates whether there is a family history
+     * or risk of inherited genetic conditions that may affect pregnancy or fetal development.
+     *
+     * @return YesNoNullType the genetic disorders status (yes, no, or null if not specified)
+     */
     public YesNoNullType getGeneticDisorders() {
         synchronized (this.monitor()) {
             this.check_orphaned();
@@ -163,7 +294,15 @@ public class GenericHistoryTypeImpl extends XmlComplexContentImpl implements Gen
             return target;
         }
     }
-    
+
+    /**
+     * Sets the genetic disorders indicator for the patient's antenatal history.
+     *
+     * This method updates the genetic disorders flag to document any family history or risk
+     * of inherited genetic conditions. The value persists in the XML store.
+     *
+     * @param geneticDisorders YesNoNullType the genetic disorders status to set (yes, no, or null)
+     */
     public void setGeneticDisorders(final YesNoNullType geneticDisorders) {
         synchronized (this.monitor()) {
             this.check_orphaned();
@@ -175,7 +314,15 @@ public class GenericHistoryTypeImpl extends XmlComplexContentImpl implements Gen
             target.set((XmlObject)geneticDisorders);
         }
     }
-    
+
+    /**
+     * Creates and adds a new genetic disorders element to the XML store.
+     *
+     * This method creates a new YesNoNullType element for the genetic disorders indicator
+     * and adds it to the internal XML store. The newly created element is returned for immediate configuration.
+     *
+     * @return YesNoNullType the newly created genetic disorders element
+     */
     public YesNoNullType addNewGeneticDisorders() {
         synchronized (this.monitor()) {
             this.check_orphaned();


### PR DESCRIPTION
## Summary
Documentation update for issue #1539

Fixes #1539

---
Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added comprehensive JavaDoc to GenericHistoryTypeImpl to explain the AR2005 antenatal record schema and the five YesNoNull indicators (at risk, developmental delay, congenital anomalies, chromosomal disorders, genetic disorders). Addresses #1539 by adding class-level context, @see and @since tags, and method docs with @param/@return for all get/set/add methods.

<sup>Written for commit 9dd50bf6552b0ec54e5c2beaec0058ca191ef4fe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

