### PR TITLE
feat: update styling for billing report and messenger search pages

### DIFF
--- a/src/main/webapp/billing/CA/ON/billingONNewReport.jsp
+++ b/src/main/webapp/billing/CA/ON/billingONNewReport.jsp
@@ -357,6 +357,92 @@
     <link href="${pageContext.request.contextPath}/library/DataTables-1.10.12/media/css/jquery.dataTables.min.css"
           rel="stylesheet">
 
+    <style>
+        body {
+            font-family: Verdana, helvetica, sans-serif;
+            font-size: 14px;
+            background-color: #fff;
+            margin: 0;
+            padding: 0;
+        }
+        .reportHeader {
+            background-color: #428bca;
+            color: #d0d0d0;
+            padding: 10px 15px;
+            font-weight: normal;
+            font-size: 18px;
+            font-family: Verdana, helvetica, sans-serif;
+            margin-bottom: 15px;
+        }
+        .reportHeader td {
+            color: #d0d0d0;
+        }
+        .reportHeader a {
+            color: #d0d0d0;
+        }
+        .reportTable {
+            margin: 0 15px;
+        }
+        .reportTable tr:hover {
+            background-color: #FACC2E;
+        }
+        .reportTable td {
+            padding: 2px 2px;
+            vertical-align: middle;
+        }
+        .reportTable a {
+            color: #0066CC;
+            text-decoration: none;
+        }
+        .reportTable a:hover {
+            text-decoration: underline;
+        }
+        .reportTable input[type="text"],
+        .reportTable select {
+            padding: 1px 3px;
+            font-size: 13px;
+            margin: 0 2px;
+        }
+        .reportTable input[type="button"],
+        .reportTable input[type="submit"] {
+            font-size: 13px;
+            margin: 0 2px;
+        }
+        .reportTable .btn-primary,
+        input[type="submit"].btn-primary {
+            padding: 6px 12px;
+            background-color: #428bca;
+            border-color: #357ebd;
+            color: #d0d0d0;
+            border-radius: 0;
+        }
+        .reportTable .btn-default,
+        .reportTable .btn {
+            border-radius: 0;
+        }
+        .reportTable input[type="text"] {
+            width: 90px !important;
+            box-sizing: border-box;
+        }
+        .reportTable select {
+            width: auto;
+            max-width: 140px;
+        }
+        .sectionHeader {
+            background-color: #CCCCFF;
+            font-weight: bold;
+            padding: 8px;
+            margin: 15px 0 5px 0;
+        }
+        .well {
+            background-color: #fff;
+            border: none;
+        }
+        .btn-primary {
+            color: #d0d0d0;
+        }
+    </style>
+
     <script src="${pageContext.request.contextPath}/share/javascript/Oscar.js"></script>
     <script src="${pageContext.request.contextPath}/js/bootstrap.min.2.js"></script>
     <script src="${pageContext.request.contextPath}/library/jquery/jquery-3.6.4.min.js"></script>
@@ -403,28 +489,25 @@
 
 <body>
 
-
-<table style="width:100%">
-    <tr>
-        <td style="width:1%"></td>
-        <td style="width:80%; text-align:left;">
-            <H4><a style="color:black;"
-                   href="billingReportCenter.jsp">OSCARbilling</a></H4>
-        </td>
-        <td style="text-align:right;">
-            <i class=" icon-question-sign"></i>
-            <a href="javascript:void(0)"
-               onClick="popupPage(600,750,'<%=(OscarProperties.getInstance()).getProperty("HELP_SEARCH_URL")%>'+'OscarBilling+Billing')"><fmt:setBundle basename="oscarResources"/><fmt:message key="app.top1"/></a>
-            <i class=" icon-info-sign" style="margin-left:10px;"></i>
-            <a href="javascript:void(0)"
-               onClick="window.open('<%=request.getContextPath()%>/oscarEncounter/About.jsp','About OSCAR','scrollbars=1,resizable=1,width=800,height=600,left=0,top=0')"><fmt:setBundle basename="oscarResources"/><fmt:message key="global.about"/></a>
-        </td>
-        <td style="width:1%"></td>
-    </tr>
-</table>
+<div class="reportHeader">
+    <table width="100%" border="0" cellspacing="0" cellpadding="0">
+        <tr>
+            <td align="left">
+                <a href="billingReportCenter.jsp">ONTARIO BILLING REPORT</a>
+            </td>
+            <td align="right">
+                <a href="javascript:void(0)"
+                   onClick="popupPage(600,750,'<%=(OscarProperties.getInstance()).getProperty("HELP_SEARCH_URL")%>'+'OscarBilling+Billing')"><fmt:setBundle basename="oscarResources"/><fmt:message key="app.top1"/></a>
+                &nbsp;|&nbsp;
+                <a href="javascript:void(0)"
+                   onClick="window.open('<%=request.getContextPath()%>/oscarEncounter/About.jsp','About OSCAR','scrollbars=1,resizable=1,width=800,height=600,left=0,top=0')"><fmt:setBundle basename="oscarResources"/><fmt:message key="global.about"/></a>
+            </td>
+        </tr>
+    </table>
+</div>
 <div class="well">
     <form name="serviceform" method="post" action="billingONReport.jsp">
-        <table style="width:100%;">
+        <table style="width:100%;" class="reportTable">
 
             <tr class="form-inline">
                 <td>
@@ -545,7 +628,8 @@ end broken -->
                     </label>
                 </td>
                 <td style="text-align:right"><input type="submit" name="Submit" class="btn btn-primary"
-                                                    value="Create Report"></td>
+                                                    style="color: #d0d0d0; background-color: #428bca; background-image: none;"
+                                                    value="CREATE REPORT"></td>
             </tr>
             <tr>
                 <td colspan="2"><a href=#
@@ -587,12 +671,11 @@ end broken -->
 
 </div> <!-- well end -->
 
-<table style="width:100%">
+<table style="width:100%;" class="reportTable">
     <tr>
-        <td><a href=# onClick="javascript:history.go(-1);return false;" class="btn btn-link">
-            <fmt:setBundle basename="oscarResources"/><fmt:message key="global.btnCancel"/></a></td>
-        <td style="text-align:right;"><a href="" onClick="self.close();" class="btn btn-link">
-            <fmt:setBundle basename="oscarResources"/><fmt:message key="global.btnExit"/></a></td>
+        <td colspan='3' align="left"><input type="button" name="Button" class="btn btn-default"
+                                            value="Cancel"
+                                            onClick="window.close()"></td>
     </tr>
 </table>
 <script>

--- a/src/main/webapp/messenger/msgSearchDemo.jsp
+++ b/src/main/webapp/messenger/msgSearchDemo.jsp
@@ -93,14 +93,54 @@
 %>
 <html>
 <head>
+    <base href="<%= request.getScheme() + "://" + request.getServerName() + ":" + request.getServerPort() + request.getContextPath() + "/" %>">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <script type="text/javascript" src="<%= request.getContextPath() %>/js/global.js"></script>
+    <link rel="stylesheet" type="text/css" href="css/encounterStyles.css">
     <title>Demographic Search</title>
+    <style type="text/css">
+        td.messengerButtonsA {
+            background-color: #003399;
+        }
+
+        td.messengerButtonsD {
+            background-color: #555599;
+        }
+
+        a.messengerButtons {
+            color: #ffffff;
+            font-size: 9pt;
+            text-decoration: none;
+        }
+
+        table.messButtonsA {
+            border-top: 2px solid #cfcfcf;
+            border-left: 2px solid #cfcfcf;
+            border-bottom: 2px solid #333333;
+            border-right: 2px solid #333333;
+        }
+
+        table.messButtonsD {
+            border-top: 2px solid #333333;
+            border-left: 2px solid #333333;
+            border-bottom: 2px solid #cfcfcf;
+            border-right: 2px solid #cfcfcf;
+        }
+
+        .searchInput {
+            padding: 4px 8px;
+            font-size: 12px;
+            border: 1px solid #ccc;
+        }
+
+        input[type="submit"], input[type="button"] {
+            padding: 4px 12px;
+            font-size: 12px;
+        }
+    </style>
 </head>
-<body
-        onload="<% if ( firstSearch) { %> document.forms[0].submit() <% } %>">
+<body class="BodyStyle" onload="<% if ( firstSearch) { %> document.forms[0].submit() <% } %>">
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
-
-
 
 <script language="JavaScript">
     /**
@@ -137,38 +177,48 @@
         opener.document.forms[0].demographic_no.value = demographic_no;
         opener.document.forms[0].selectedDemo.value = keyword;
         opener.document.forms[0].keyword.value = "";
-        
+
         // Focus back to keyword field in parent window
         opener.document.forms[0].keyword.focus();
     }
 
 </script>
 
-<table BORDER="0" CELLPADDING="0" CELLSPACING="2" WIDTH="100%"
-       bgcolor="#CCCCFF">
-    <form method="post" name="titlesearch"
-          action="<%= request.getContextPath() %>/demographic/demographiccontrol.jsp"
-          onsubmit="return checkTypeIn()">
-        <tr>
-            <td colspan="6" class="RowTop"><b><fmt:setBundle basename="oscarResources"/><fmt:message key="demographic.zdemographicfulltitlesearch.msgSearch"/></b></td>
-        </tr>
-        <%
-            String keyword = request.getParameter("keyword");
+<table class="MainTable" id="scrollNumber1" name="encounterTable">
+    <tr class="MainTableTopRow">
+        <td class="MainTableTopRowLeftColumn">
+            <h2><fmt:setBundle basename="oscarResources"/><fmt:message key="demographic.zdemographicfulltitlesearch.msgSearch"/></h2>
+        </td>
+        <td class="MainTableTopRowRightColumn">
+            <table class="TopStatusBar" style="width:100%">
+                <tr>
+                    <td>
+                        <div class="DivContentTitle"><fmt:setBundle basename="oscarResources"/><fmt:message key="demographic.zdemographicfulltitlesearch.msgSearch"/></div>
+                    </td>
+                    <td style="text-align:right">
+                        <a href="<%= request.getContextPath() %>/oscarEncounter/About.jsp" target="_new"><fmt:setBundle basename="oscarResources"/><fmt:message key="global.about"/></a>
+                    </td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+    <tr>
+        <td class="MainTableLeftColumn">&nbsp;</td>
+        <td class="MainTableRightColumn">
+            <form method="post" name="titlesearch"
+                  action="<%= request.getContextPath() %>/demographic/demographiccontrol.jsp"
+                  onsubmit="return checkTypeIn()">
+                <table border="0" cellpadding="5" cellspacing="3" width="95%">
+                    <%
+                        String keyword = request.getParameter("keyword");
 
-            if (keyword == null) {
-                keyword = "";
-            }
-        %>
-        <tr>
-            <td>
-                <table bgcolor="white" width="100%">
+                        if (keyword == null) {
+                            keyword = "";
+                        }
+                    %>
                     <tr>
-                        <td width="10%" nowrap></td>
-                        <td nowrap></td>
-                        <td nowrap></td>
-                        <td valign="middle" rowspan="2" ALIGN="left"><input type="text"
-                                                                            NAME="keyword" VALUE="<%=keyword%>"
-                                                                            SIZE="17" MAXLENGTH="100">
+                        <td>
+                            <input type="text" NAME="keyword" VALUE="<%=keyword%>" SIZE="25" MAXLENGTH="100" class="searchInput">
                             <%
                                 String searchMode = request.getParameter("search_mode");
                                 if (searchMode == null || searchMode.isEmpty()) {
@@ -177,34 +227,67 @@
                             %>
                             <input type="hidden" name="outofdomain" value="">
                             <input type="hidden" name="search_mode" value="<%=searchMode%>">
-                            <INPUT TYPE="hidden" NAME="orderby" VALUE="last_name, first_name">
-                            <INPUT TYPE="hidden" NAME="dboperation" VALUE="search_titlename">
-                            <INPUT TYPE="hidden" NAME="limit1" VALUE="0"> <INPUT
-                                    TYPE="hidden" NAME="limit2" VALUE="10"> <INPUT
-                                    TYPE="hidden" NAME="displaymode" VALUE="Search"> <INPUT
-                                    TYPE="hidden" NAME="ptstatus" VALUE="active"> <INPUT
-                                    TYPE="hidden" NAME="fromMessenger" VALUE="true"> <INPUT
-                                    TYPE="SUBMIT"
-                                    VALUE="<fmt:setBundle basename="oscarResources"/><fmt:message key="demographic.zdemographicfulltitlesearch.msgSearch"/>"
-                                    SIZE="17"
-                                    TITLE="<fmt:setBundle basename="oscarResources"/><fmt:message key="demographic.zdemographicfulltitlesearch.tooltips.searchActive"/>">
-                            &nbsp;&nbsp;&nbsp; <INPUT TYPE="button" onclick="searchInactive();"
-                                                      TITLE="<fmt:setBundle basename="oscarResources"/><fmt:message key="demographic.zdemographicfulltitlesearch.tooltips.searchInactive"/>"
-                                                      VALUE="<fmt:setBundle basename="oscarResources"/><fmt:message key="demographic.search.Inactive"/>">
-                            <INPUT TYPE="button" onclick="searchAll();"
-                                   TITLE="<fmt:setBundle basename="oscarResources"/><fmt:message key="demographic.zdemographicfulltitlesearch.tooltips.searchAll"/>"
-                                   VALUE="<fmt:setBundle basename="oscarResources"/><fmt:message key="demographic.search.All"/>"></td>
-                    </tr>
-                    <tr bgcolor="white">
-                        <td nowrap></td>
-                        <td nowrap></td>
-                        <td nowrap></td>
+                            <input type="hidden" name="orderby" value="last_name, first_name">
+                            <input type="hidden" name="dboperation" value="search_titlename">
+                            <input type="hidden" name="limit1" value="0">
+                            <input type="hidden" name="limit2" value="10">
+                            <input type="hidden" name="displaymode" value="Search">
+                            <input type="hidden" name="ptstatus" value="active">
+                            <input type="hidden" name="fromMessenger" value="true">
+                        </td>
+                        <td>
+                            <table cellspacing="3">
+                                <tr>
+                                    <td>
+                                        <table class="messButtonsA" cellspacing="0" cellpadding="3">
+                                            <tr>
+                                                <td class="messengerButtonsA">
+                                                    <a href="javascript:document.titlesearch.submit();" class="messengerButtons"
+                                                       title="<fmt:setBundle basename="oscarResources"/><fmt:message key="demographic.zdemographicfulltitlesearch.tooltips.searchActive"/>">
+                                                        <fmt:setBundle basename="oscarResources"/><fmt:message key="demographic.zdemographicfulltitlesearch.msgSearch"/>
+                                                    </a>
+                                                </td>
+                                            </tr>
+                                        </table>
+                                    </td>
+                                    <td>
+                                        <table class="messButtonsA" cellspacing="0" cellpadding="3">
+                                            <tr>
+                                                <td class="messengerButtonsA">
+                                                    <a href="javascript:searchInactive();" class="messengerButtons"
+                                                       title="<fmt:setBundle basename="oscarResources"/><fmt:message key="demographic.zdemographicfulltitlesearch.tooltips.searchInactive"/>">
+                                                        <fmt:setBundle basename="oscarResources"/><fmt:message key="demographic.search.Inactive"/>
+                                                    </a>
+                                                </td>
+                                            </tr>
+                                        </table>
+                                    </td>
+                                    <td>
+                                        <table class="messButtonsA" cellspacing="0" cellpadding="3">
+                                            <tr>
+                                                <td class="messengerButtonsA">
+                                                    <a href="javascript:searchAll();" class="messengerButtons"
+                                                       title="<fmt:setBundle basename="oscarResources"/><fmt:message key="demographic.zdemographicfulltitlesearch.tooltips.searchAll"/>">
+                                                        <fmt:setBundle basename="oscarResources"/><fmt:message key="demographic.search.All"/>
+                                                    </a>
+                                                </td>
+                                            </tr>
+                                        </table>
+                                    </td>
+                                </tr>
+                            </table>
+                        </td>
                     </tr>
                 </table>
-            </td>
-        </tr>
-    </form>
+            </form>
+        </td>
+    </tr>
+    <tr>
+        <td class="MainTableBottomRowLeftColumn"></td>
+        <td class="MainTableBottomRowRightColumn"></td>
+    </tr>
 </table>
+
 <script>
     // Auto-close window and write selection back to parent if demographic was selected
     if ("<%=demographic_no%>" != "null") {

--- a/src/main/webapp/share/css/searchBox.css
+++ b/src/main/webapp/share/css/searchBox.css
@@ -39,3 +39,15 @@ form {
     margin: auto 15px;
 }
 
+.searchBox .btn-primary {
+    color: #d0d0d0;
+}
+
+.searchBox input[type="search"]::placeholder {
+    color: #d0d0d0;
+}
+
+.container > h2 {
+    font-size: 18px;
+}
+


### PR DESCRIPTION
Updated a few items.  

Made theme for caseload, search, report, billing similar and cleaned them up.

Adjusted small items as there was cutoff of second bars on scheduling page etc.

Made it so you can single click an email, number, DOB and copy to clipboard.  



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated styling for the Ontario Billing Report and Messenger Search pages to match our caseload/search/report theme. Adds a blue header, consistent buttons, and cleaner table layouts for a more readable, consistent UI.

- **Refactors**
  - billingONNewReport.jsp: Added blue header bar, standardized table and hover styles, normalized input/button sizes, and updated primary button colors and labels.
  - msgSearchDemo.jsp: Aligned with messenger UI (encounterStyles, TopStatusBar), added base/viewport tags, simplified form layout, and styled search input and action buttons.
  - searchBox.css: Tweaked .btn-primary text color, placeholder color for search inputs, and reduced heading size for better visual balance.

<sup>Written for commit f9c7fe00dc739cd5a3bbefce609a09b708549281. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced Ontario billing report interface with styled header and updated controls.
  * Redesigned messenger search interface with improved layout and action buttons.

* **Style**
  * Updated button styling and labeling ("CREATE REPORT", "Cancel") across interfaces.
  * Improved visual consistency with new CSS styling for headers, inputs, and tables.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->