### PR TITLE
Copilot/replace taglibs standard

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -524,7 +524,7 @@
             <version>3.12.0</version>
         </dependency>
 
-        <!-- Jakarta JSTL implementation (javax namespace compatible) -->
+        <!-- Glassfish JSTL 1.2.5 implementation (javax namespace for Servlet 4.0 compatibility) -->
         <dependency>
             <groupId>org.glassfish.web</groupId>
             <artifactId>javax.servlet.jsp.jstl</artifactId>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Replaced taglibs:standard with Glassfish JSTL (javax namespace) and removed the standalone javax.servlet:jstl to prevent conflicts and ensure Servlet 4.0 compatibility.

- **Dependencies**
  - Added org.glassfish.web:javax.servlet.jsp.jstl:1.2.5
  - Removed javax.servlet:jstl:1.2
  - Removed taglibs:standard:1.1.2

<sup>Written for commit 786f2577ba185f39dc395cf291d79d15e5f72569. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated server-side template library dependencies to improve application stability, reduce potential conflicts, and enhance compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->