### PR TITLE
Fix: reverse flowsheets prevention order, now descending instead of ascending to match other parts of the flowsheet, like measurements

### DIFF
--- a/src/main/webapp/oscarEncounter/oscarMeasurements/TemplateFlowSheetPage.jspf
+++ b/src/main/webapp/oscarEncounter/oscarMeasurements/TemplateFlowSheetPage.jspf
@@ -840,6 +840,9 @@ div.recommendations ul{
     String prevType = (String) h2.get("prevention_type");
     long startPrevType = System.currentTimeMillis();
     ArrayList<Map<String,Object>> alist = PreventionData.getPreventionData(loggedInInfo, prevType, Integer.parseInt(demographic_no));
+    // Reverse to display newest first (matching measurements/drugs display order)
+    // The query returns ASC order for Prevention page compatibility
+    Collections.reverse(alist);
 
 %>
 

--- a/src/main/webapp/oscarEncounter/oscarMeasurements/TemplateFlowSheetPrint.jsp
+++ b/src/main/webapp/oscarEncounter/oscarMeasurements/TemplateFlowSheetPrint.jsp
@@ -739,6 +739,9 @@ maybe use jquery/ajax to post this data instead of submitting a form to send ALL
                     String prevType = (String) h2.get("prevention_type");
                     long startPrevType = System.currentTimeMillis();
                     ArrayList<Map<String, Object>> alist = PreventionData.getPreventionData(LoggedInInfo.getLoggedInInfoFromSession(request), prevType, Integer.valueOf(demographic_no));
+                    // Reverse to display newest first (matching measurements/drugs display order)
+                    // The query returns ASC order for Prevention page compatibility
+                    Collections.reverse(alist);
                 %>
 
                 <div class="preventionSection" style="<%=hidden%>">


### PR DESCRIPTION
## In this PR, I have fixed:
- preventions flowsheet order (since the order of preventions is back to ascending, we need custom logic to reverse the order that that preventions show as descending ONLY in the flowsheet pages)

## I have tested this by:
- Inspecting the flowsheet, and flowsheet print functionalities, ensuring that the flowsheets are now in descending order (for both measurements and preventions), inspecting the eChart/Preventions page, ensuring that the preventions are the opposite of the flowsheets (ascending order, eChart shows latest prevention not oldest

## Summary by Sourcery

Bug Fixes:
- Correct prevention ordering in flowsheet print views so that preventions display in descending order to match measurements and drugs while keeping Prevention page compatibility.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reversed prevention entries in flowsheets to show newest first, matching measurements and drugs. Applied the change to both the flowsheet page and print view; the Prevention page keeps ascending order.

<sup>Written for commit 12148fc1b538d4e405f80eeb556260e84d7e77b8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

