### PR TITLE
Fix: missing ":" seperator for Tel in Rx printout

### DIFF
--- a/src/main/webapp/oscarRx/Preview.jsp
+++ b/src/main/webapp/oscarRx/Preview.jsp
@@ -180,7 +180,7 @@
                     <input type="hidden" name="patientCityPostal"
                            value="<%= StringEscapeUtils.escapeHtml4(patient.getCity())+ ", " + StringEscapeUtils.escapeHtml4(patient.getProvince()) + " " + StringEscapeUtils.escapeHtml4(patient.getPostal())%>"/>
                     <input type="hidden" name="patientPhone"
-                           value="<fmt:setBundle basename="oscarResources"/><fmt:message key="RxPreview.msgTel"/><%=StringEscapeUtils.escapeHtml4(patient.getPhone()) %>"/>
+                           value="<fmt:setBundle basename="oscarResources"/><fmt:message key="RxPreview.msgTel"/>: <%=StringEscapeUtils.escapeHtml4(patient.getPhone()) %>"/>
 
                     <input type="hidden" name="rxDate"
                            value="<%= StringEscapeUtils.escapeHtml4(RxUtil.DateToString(rxDate, "MMMM d, yyyy")) %>"/>

--- a/src/main/webapp/oscarRx/Preview2.jsp
+++ b/src/main/webapp/oscarRx/Preview2.jsp
@@ -421,7 +421,7 @@
                                        value="<%=StringEscapeUtils.escapeHtml4(ptChartNo)%>"/>
                                 <input type="hidden" name="bandNumber" value="${ bandNumber }"/>
                                 <input type="hidden" name="patientPhone"
-                                       value="<fmt:setBundle basename="oscarResources"/><fmt:message key="RxPreview.msgTel"/><%=StringEscapeUtils.escapeHtml4(patientPhone) %>"/>
+                                       value="<fmt:setBundle basename="oscarResources"/><fmt:message key="RxPreview.msgTel"/>: <%=StringEscapeUtils.escapeHtml4(patientPhone) %>"/>
                                 <input type="hidden" name="rxDate"
                                        value="<%= StringEscapeUtils.escapeHtml4(RxUtil.DateToString(rxDate, "MMMM d, yyyy")) %>"/>
                                 <input type="hidden" name="sigDoctorName"


### PR DESCRIPTION
## In this PR, I have fixed:
- The missing ":" seperator for Tel, like other sections of the JSP file(s)

## I have tested this by:
- Previewing the print page, and previewing the fax result from the print to ensure that the ":" seperator is shown correctly infront of "Tel"

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the missing ":" after the Tel label in Rx print pages so phone numbers render as "Tel: <number>" in previews and fax outputs. Updates the hidden patientPhone field in Preview.jsp and Preview2.jsp to include the separator.

- **Bug Fixes**
  - Add ": " after Tel in patientPhone values in Preview.jsp and Preview2.jsp to match other labels and correct print/fax formatting.

<sup>Written for commit 127bbd3e68f5c696c9abdcaaa2f8549a66ae582e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

