### PR TITLE
chore: auto set type project and status for new issue tickets

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -25,78 +25,156 @@ jobs:
 
             async function run() {
               try {
-                // Add issue to project
-                let addResult;
-                try {
-                  addResult = await github.graphql(`
-                    mutation($projectId: ID!, $contentId: ID!) {
-                      addProjectV2ItemById(input: {projectId: $projectId, contentId: $contentId}) {
-                        item { id }
+                const issueNodeId = context.payload.issue.node_id;
+                const issueNumber = context.payload.issue.number;
+
+                // Check if issue already exists in the project
+                console.log(`Checking if issue #${issueNumber} already exists in project...`);
+                const existingItems = await github.graphql(`
+                  query($issueId: ID!) {
+                    node(id: $issueId) {
+                      ... on Issue {
+                        projectItems(first: 20) {
+                          nodes {
+                            id
+                            project {
+                              id
+                            }
+                            fieldValues(first: 20) {
+                              nodes {
+                                ... on ProjectV2ItemFieldSingleSelectValue {
+                                  field {
+                                    ... on ProjectV2SingleSelectField {
+                                      id
+                                      name
+                                    }
+                                  }
+                                  optionId
+                                  name
+                                }
+                              }
+                            }
+                          }
+                        }
                       }
                     }
-                  `, {
-                    projectId: projectId,
-                    contentId: context.payload.issue.node_id
-                  });
-                } catch (error) {
-                  console.error('Failed to add issue to project:', error);
-                  throw error;
-                }
+                  }
+                `, {
+                  issueId: issueNodeId
+                });
 
-                const itemId = addResult.addProjectV2ItemById.item.id;
-                console.log('Added issue to project, item ID:', itemId);
+                // Find if issue is already in this specific project
+                let itemId = null;
+                let currentStatusOptionId = null;
+                let currentKindOptionId = null;
 
-                // Set Status to "Needs Triage"
-                try {
-                  await github.graphql(`
-                    mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
-                      updateProjectV2ItemFieldValue(input: {
-                        projectId: $projectId,
-                        itemId: $itemId,
-                        fieldId: $fieldId,
-                        value: { singleSelectOptionId: $optionId }
-                      }) {
-                        projectV2Item { id }
+                const projectItems = existingItems?.node?.projectItems?.nodes || [];
+                for (const item of projectItems) {
+                  if (item.project && item.project.id === projectId) {
+                    itemId = item.id;
+                    console.log(`Issue #${issueNumber} already exists in project, item ID: ${itemId}`);
+
+                    // Check current field values
+                    const fieldValues = item.fieldValues?.nodes || [];
+                    for (const fieldValue of fieldValues) {
+                      if (fieldValue.field) {
+                        if (fieldValue.field.id === statusFieldId) {
+                          currentStatusOptionId = fieldValue.optionId;
+                          console.log(`Current Status: ${fieldValue.name} (${currentStatusOptionId})`);
+                        } else if (fieldValue.field.id === kindFieldId) {
+                          currentKindOptionId = fieldValue.optionId;
+                          console.log(`Current Kind: ${fieldValue.name} (${currentKindOptionId})`);
+                        }
                       }
                     }
-                  `, {
-                    projectId: projectId,
-                    itemId: itemId,
-                    fieldId: statusFieldId,
-                    optionId: needsTriageId
-                  });
-                  console.log('Set Status to Needs Triage');
-                } catch (error) {
-                  console.error(`Failed to set Status field for project item ${itemId}:`, error);
-                  throw error;
+                    break;
+                  }
                 }
 
-                // Set Kind to "Task"
-                try {
-                  await github.graphql(`
-                    mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
-                      updateProjectV2ItemFieldValue(input: {
-                        projectId: $projectId,
-                        itemId: $itemId,
-                        fieldId: $fieldId,
-                        value: { singleSelectOptionId: $optionId }
-                      }) {
-                        projectV2Item { id }
+                // Add issue to project if not already present
+                if (!itemId) {
+                  console.log(`Adding issue #${issueNumber} to project...`);
+                  try {
+                    const addResult = await github.graphql(`
+                      mutation($projectId: ID!, $contentId: ID!) {
+                        addProjectV2ItemById(input: {projectId: $projectId, contentId: $contentId}) {
+                          item { id }
+                        }
                       }
-                    }
-                  `, {
-                    projectId: projectId,
-                    itemId: itemId,
-                    fieldId: kindFieldId,
-                    optionId: taskId
-                  });
-                  console.log('Set Kind to Task');
-                } catch (error) {
-                  console.error(`Failed to set Kind field for project item ${itemId}:`, error);
-                  throw error;
+                    `, {
+                      projectId: projectId,
+                      contentId: issueNodeId
+                    });
+
+                    itemId = addResult.addProjectV2ItemById.item.id;
+                    console.log(`Added issue #${issueNumber} to project, item ID: ${itemId}`);
+                  } catch (error) {
+                    console.error(`Failed to add issue #${issueNumber} to project:`, error);
+                    throw error;
+                  }
                 }
 
-                console.log(`Issue #${context.payload.issue.number} added to project with Status: Needs Triage, Kind: Task`);
+                // Set Status to "Needs Triage" only if not already set
+                if (!currentStatusOptionId) {
+                  console.log('Status field is not set, setting to "Needs Triage"...');
+                  try {
+                    await github.graphql(`
+                      mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+                        updateProjectV2ItemFieldValue(input: {
+                          projectId: $projectId,
+                          itemId: $itemId,
+                          fieldId: $fieldId,
+                          value: { singleSelectOptionId: $optionId }
+                        }) {
+                          projectV2Item { id }
+                        }
+                      }
+                    `, {
+                      projectId: projectId,
+                      itemId: itemId,
+                      fieldId: statusFieldId,
+                      optionId: needsTriageId
+                    });
+                    console.log('Set Status to "Needs Triage"');
+                  } catch (error) {
+                    console.error(`Failed to set Status field for project item ${itemId}:`, error);
+                    throw error;
+                  }
+                } else {
+                  console.log('Status field already set, skipping update');
+                }
+
+                // Set Kind to "Task" only if not already set
+                if (!currentKindOptionId) {
+                  console.log('Kind field is not set, setting to "Task"...');
+                  try {
+                    await github.graphql(`
+                      mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+                        updateProjectV2ItemFieldValue(input: {
+                          projectId: $projectId,
+                          itemId: $itemId,
+                          fieldId: $fieldId,
+                          value: { singleSelectOptionId: $optionId }
+                        }) {
+                          projectV2Item { id }
+                        }
+                      }
+                    `, {
+                      projectId: projectId,
+                      itemId: itemId,
+                      fieldId: kindFieldId,
+                      optionId: taskId
+                    });
+                    console.log('Set Kind to "Task"');
+                  } catch (error) {
+                    console.error(`Failed to set Kind field for project item ${itemId}:`, error);
+                    throw error;
+                  }
+                } else {
+                  console.log('Kind field already set, skipping update');
+                }
+
+                console.log(`Issue #${issueNumber} triage completed successfully`);
               } catch (error) {
                 console.error('Issue triage workflow failed:', error);
                 throw error;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a GitHub Actions workflow to auto-triage newly opened issues. New issues are added to the project and set to Status: Needs Triage and Kind: Task.

<sup>Written for commit 604d718e99220c99e264571b6c7ce5a34a7d1e6f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

CI:
- Introduce a GitHub Actions workflow that adds newly opened issues to a specific project and initializes their Status to "Needs Triage" and Kind to "Task".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated issue triaging: new issues are automatically added to project tracking, set to "Needs Triage" and categorized as "Task". The process logs progress and errors, and is idempotent—existing triage fields are preserved and not overwritten on repeated runs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->