### PR TITLE
Fix: 404 error when clicking on the red asterisk in the Rx Medications tab

### DIFF
--- a/src/main/webapp/oscarRx/SearchDrug3.jsp
+++ b/src/main/webapp/oscarRx/SearchDrug3.jsp
@@ -1309,7 +1309,7 @@ function renderRxStage() {
            var data="randomId="+randomId;
            new Ajax.Request(ctx + "/oscarRx/WriteScript.do?parameterValue=listPreviousInstructions",
            {method: 'post',parameters:data,asynchronous:false,onSuccess:function(transport){
-                 mb.show(randomId,'displayMedHistory', '200px');
+                 mb.show(randomId, ctx + '/oscarRx/displayMedHistory', '200px');
                 }});
     }
 


### PR DESCRIPTION
## In this PR, I have fixed:
- A 404 error when clicking on the red asterisk in the Rx medications tab

## I have tested this by:
- Testing the red asterisk functionality by staging multiple medications, and seeing the popup result when clicking on the red asterisk

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the 404 when clicking the red asterisk in the Rx Medications tab by updating the modal to use the correct displayMedHistory path (ctx + '/oscarRx/displayMedHistory').

<sup>Written for commit 0277215aa69f0bc1393b7cf12dd74165243771d3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Bug Fixes:
- Correct the modal popup URL invoked by the red asterisk in the Rx Medications tab so it loads the medication history instead of returning a 404.