### PR TITLE
Fix: set GCN_SEQNO in success path of RxChooseDrug2Action

### DIFF
--- a/src/main/java/ca/openosp/openo/prescript/pageUtil/RxChooseDrug2Action.java
+++ b/src/main/java/ca/openosp/openo/prescript/pageUtil/RxChooseDrug2Action.java
@@ -85,7 +85,7 @@ public final class RxChooseDrug2Action extends ActionSupport {
             try {
 
                 RxDrugData.DrugMonograph f = drugData.getDrug(drugId);
-//                    rx.setGCN_SEQNO(f.gcnCode);
+                rx.setGCN_SEQNO("0");
                 String genName = "";
                 genName = f.name;
                 rx.setAtcCode(f.atc);


### PR DESCRIPTION
## Summary

Fixed missing GCN_SEQNO assignment in the success path of RxChooseDrug2Action.execute().

## Changes

- Replaced commented-out line `rx.setGCN_SEQNO(f.gcnCode);` with `rx.setGCN_SEQNO("0");`
- Ensures GCN_SEQNO is consistently set in both success and error paths

## Rationale

The DrugMonograph class no longer provides a gcnCode field, so we set GCN_SEQNO to "0" to match:
1. The error/custom drug path behavior (line 125)
2. The default value in the Drug model
3. The pattern used elsewhere in the codebase when GCN data is unavailable

Fixes #1879

---

Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Bug Fixes:
- Set GCN_SEQNO to a default value of "0" in the success path of RxChooseDrug2Action to match existing error/custom drug handling and prevent missing GCN sequence numbers.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set GCN_SEQNO to "0" in the success path of RxChooseDrug2Action so prescriptions are populated consistently. Matches the error/custom drug path and model default now that DrugMonograph no longer provides gcnCode.

<sup>Written for commit 0a5cb30ce266ce5ac48fa1eeb65904f01b938b5d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

