### PR TITLE
chore: remove unused tagsoup and jersey-client dependencies

### DIFF
--- a/dependencies-lock-modern.json
+++ b/dependencies-lock-modern.json
@@ -482,27 +482,27 @@
   }, {
     "groupId" : "com.itextpdf.tool",
     "artifactId" : "xmlworker",
-    "version" : "5.5.13.4",
+    "version" : "5.5.13.5",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:Tj69vcCRv0r0mr78sY5gHPfpojQ2WCg7J6+/K1Jhbta/vUhRwmitDPUFrda8DQShTb3uGRkCbF0Rkw03+0zU2A=="
+    "integrity" : "sha512:qT6Z6M8/iR6PQgI1/y8xfPoGe6iQElOtmuL0OTTRy1KfedxSz6mNqE5KLmB8LdvEb89b3H+GiVl7G30smd7EOA=="
   }, {
     "groupId" : "com.itextpdf",
     "artifactId" : "itextpdf",
-    "version" : "5.5.13.4",
+    "version" : "5.5.13.5",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:HCHFwerQk+96YOD6L8Xbe65mrOsBWdffo4Ynwu7htpmUtv3IjNT5ZXOT87noUhYzO7ZVbkQjYAFOB388gGWWmw=="
+    "integrity" : "sha512:k8jO0QMHnJwgWpF6c1nn5ga8E6GsaZo2jDPwZWK6nTVoWa7i/OE3DT5vMwkx0vROptpnFABOnJ1Mm7R5JRD8Ag=="
   }, {
     "groupId" : "com.jcraft",
     "artifactId" : "jsch",
-    "version" : "0.1.54",
+    "version" : "0.1.55",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:l+xt5k9IcO48hPiDvTZkViv9YAyp8zZJZufb7n5OhSBkfAP5+B1oCOMwBSyhMz439JfWJSzSb+chqQ9XPL4gNg=="
+    "integrity" : "sha512:toJ9jeRxaC/RF0QIBmOup3YSoDd04uvMM1fHxJPV31DU7JyNUsT8ySi9/ddbYrQNPGDxhNqKe4q6RMkq/s7npQ=="
   }, {
     "groupId" : "com.medseek.clinical.service",
     "artifactId" : "SSOClinicalConnect",
@@ -857,14 +857,6 @@
     "optional" : false,
     "integrity" : "sha512:zH/dfXvRhRtI0QiDdm+snXKwQHcUs8ZTNpEw4yJL3Rmky5QfuBPd4ejH0puwelsaRNYRJA6tFxflGhWjHJYw+A=="
   }, {
-    "groupId" : "commons-dbcp",
-    "artifactId" : "commons-dbcp",
-    "version" : "1.4",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:wFErJVxKckJjS4IMeMOXKW/JOI3s603sGZd1NBWY8Mh7IRZEJal9/erfrZ88gOHU2rc10ysTYjd4IKQgS05aeA=="
-  }, {
     "groupId" : "commons-digester",
     "artifactId" : "commons-digester",
     "version" : "1.8",
@@ -912,14 +904,6 @@
     "type" : "jar",
     "optional" : false,
     "integrity" : "sha512:f9hVMOAiBKjK9GJ/JpNiA7H7rMu50LCcPGT1i2O3OOmqrimqC4ReCe+5pw2d0VQuu8eQJbPrCcH7YupPepydgQ=="
-  }, {
-    "groupId" : "commons-pool",
-    "artifactId" : "commons-pool",
-    "version" : "1.5.4",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:u1pm19qPOJZg+zacGm53KW85I5zKHWnKG3yA6OgcOKnSXevvtwKi6qyYfoOIWJjKDJXGOH2EQOVIZT1r2uaGpg=="
   }, {
     "groupId" : "commons-validator",
     "artifactId" : "commons-validator",
@@ -1065,6 +1049,14 @@
     "optional" : false,
     "integrity" : "sha512:HOSgWf2pocerdRr7E+wFRG11asQY3ZX4ztNpsE9pKKds9QAD+Jsbhtlryx34uPf/McUWtShxVe6pP2g/c9VKsQ=="
   }, {
+    "groupId" : "jakarta.transaction",
+    "artifactId" : "jakarta.transaction-api",
+    "version" : "1.3.3",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:dkrei6gHaC3NHsc4LDUnXz2KsJoD1bRcSOcyUBGQ4nOCaQgKryiqjdZWwR7oS/t9rmlT3Sdo8qzs06jPDKSWHg=="
+  }, {
     "groupId" : "jakarta.ws.rs",
     "artifactId" : "jakarta.ws.rs-api",
     "version" : "2.1.6",
@@ -1129,6 +1121,14 @@
     "optional" : false,
     "integrity" : "sha512:NYJKA86QsZiq+xjnlDWU7YM7JXvwLl75aQ14IiTmg4IyKYQwYnRVu163qRvNQhRLNCc8+Ec3GdfX9kY4FkyJ+Q=="
   }, {
+    "groupId" : "javax.inject",
+    "artifactId" : "javax.inject",
+    "version" : "1",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:4Sa3zPPkL9GYSgvu8QBKcmmjN8IC5Z4E6OKvcUKA0vLY0rpeb1lIG43NNKrzXJZqaI0LSOx+lvECwnTcDTs4Hg=="
+  }, {
     "groupId" : "javax.persistence",
     "artifactId" : "javax.persistence-api",
     "version" : "2.2",
@@ -1137,6 +1137,14 @@
     "optional" : false,
     "integrity" : "sha512:AT5ODv5ksc9nRNzkTtcWtNhROyrVtqATGvZjt5GOtlcFvQnU33Y/9KgQgp9Pa2wZjKdnDOQ5lAvleu0JFLUT+A=="
   }, {
+    "groupId" : "javax.servlet.jsp.jstl",
+    "artifactId" : "jstl-api",
+    "version" : "1.2",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:5PZoZ3fZ0HMj4bt4XpRKwtsJ8mpNXEbJhHKAEmzVUv4QR1jkR3U4xsiWNK6xx5S06zKjwhon9KFU3eHZ4yZC7w=="
+  }, {
     "groupId" : "javax.servlet.jsp",
     "artifactId" : "javax.servlet.jsp-api",
     "version" : "2.3.3",
@@ -1144,6 +1152,14 @@
     "type" : "jar",
     "optional" : false,
     "integrity" : "sha512:msaevADQDl7bKDAv3VFcjmeMrRwsusutSHs9hMdIJ1Y/yjeDgwYc4DuNnuUPmc7ZQYzJ2NZOSe7zInAjLWYMig=="
+  }, {
+    "groupId" : "javax.servlet.jsp",
+    "artifactId" : "jsp-api",
+    "version" : "2.1",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:8yCRW/J7BfX5OmlXL/Da1uaPAwtvD8sYMvgPf/5W26ngV13Y5rBCWzcErHXqK0p2Vr2tZLjMhhC/3NW8GYncxQ=="
   }, {
     "groupId" : "javax.servlet",
     "artifactId" : "javax.servlet-api",
@@ -1154,12 +1170,12 @@
     "integrity" : "sha512:dj3smAH2R7GkXkkusqZ/amD8YIvvRzjrexqS2T8fbbArMvTGVT1FV8Mg38JcDqC5hUxZ55MmK2ykU8ccrwXvOA=="
   }, {
     "groupId" : "javax.servlet",
-    "artifactId" : "jstl",
-    "version" : "1.2",
+    "artifactId" : "servlet-api",
+    "version" : "2.5",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:+2/jOSJjG7ohtgbLXVPERXBx5pXsVjIgUYUoHn2z4tY9lSSLQ7nH+yy1BC0Uome4fSxdp0LJiRdMNSbczyOu7A=="
+    "integrity" : "sha512:NjulWQQ2q4IGe3ouFLSBrrKxLKQEjXoVGaLlSbLTwJ3fcYrGTcK+bC/CTFH9ycgWAmEylAMRM2lYjOJ9h3cdtg=="
   }, {
     "groupId" : "javax.transaction",
     "artifactId" : "javax.transaction-api",
@@ -1370,6 +1386,14 @@
     "integrity" : "sha512:rL6qKQm4Cc1WHnFW3xg0DZarrLF5MlYi1zvda4LLmzh9b8saRNgZWq1OeG2imSieF1mKHTN7fH0cC8YQzBKHFA=="
   }, {
     "groupId" : "org.apache.commons",
+    "artifactId" : "commons-dbcp2",
+    "version" : "2.14.0",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:c7mb0d8bukC9ylZ+12JqbvGw14w2zbJhqPU7slAmXA1st0QxfHMVOdywimnA7fs5B49HPzFE+ts5nV55aNnFlA=="
+  }, {
+    "groupId" : "org.apache.commons",
     "artifactId" : "commons-digester3",
     "version" : "3.2",
     "scope" : "compile",
@@ -1403,11 +1427,11 @@
   }, {
     "groupId" : "org.apache.commons",
     "artifactId" : "commons-pool2",
-    "version" : "2.9.0",
+    "version" : "2.13.0",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:W9zIcix3+J/EB0sBl+/t0WXLZ5hPeHcMMv5krWULq4H9kO+nTNUJnV+qLy8UwVRkqIttKir/7X3jDiVYflt1UA=="
+    "integrity" : "sha512:n2531xBjmMJPLdTYfXIolF4l3S8JKgSo7AdsJ4vq26scJpDkJLTfBKAdxeXnd7RY/V2LwIzEgSvcm3myYMZAhw=="
   }, {
     "groupId" : "org.apache.commons",
     "artifactId" : "commons-text",
@@ -2043,11 +2067,11 @@
   }, {
     "groupId" : "org.apache.httpcomponents",
     "artifactId" : "httpmime",
-    "version" : "4.5.6",
+    "version" : "4.5.14",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:mEHbd3m2R95GaN7Zt56MUQplMHY4T8MFnvGG6l2Cgo4UneSMAWtcuJob6r5gmBQpJlqDJL4xCEc8V693piq9ag=="
+    "integrity" : "sha512:iEsGICj2gng4m3TM+8NRQsquSJztpd8B0sYN+IS5YEzUBVv04VJOA1hmH6DojpPmFPtr5ZDLlAUQsHo3wLCiDA=="
   }, {
     "groupId" : "org.apache.james",
     "artifactId" : "apache-mime4j-core",
@@ -2473,14 +2497,6 @@
     "optional" : false,
     "integrity" : "sha512:o+x8IvbnFuLAa56TsZkr2iPrkuoMw/Ovxb165EqSNf8iFtDACXeZow/S4t1hjn8wzCEAB9ph4d7i5yuPuw3hbw=="
   }, {
-    "groupId" : "org.ccil.cowan.tagsoup",
-    "artifactId" : "tagsoup",
-    "version" : "1.2.1",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:H7EdGdjGNkC0xAkHqAOEtBdpJPYOR9h7TGz2EaBiy6QiDZkMCLhTawNA/TKYXAj5aWUK/TNgpb0ojs2JEk8Zow=="
-  }, {
     "groupId" : "org.codehaus.jettison",
     "artifactId" : "jettison",
     "version" : "1.5.4",
@@ -2617,22 +2633,6 @@
     "optional" : false,
     "integrity" : "sha512:LYHZ3fzFPWK5UX8hDZ6NbuTSNxOJCTkqcxS7KT6keKWtrfs5fTE6UsXyP+TQLfL4fIECHBFIzjQkmcTRrC2/Mw=="
   }, {
-    "groupId" : "org.glassfish.hk2.external",
-    "artifactId" : "jakarta.inject",
-    "version" : "2.6.1",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:f8gZatnuA6gx3/+FyUXkFsOQYHGnqo6/ari3AI3+wK3MwfHcpT7WdorFZ2zUs8Q0cWdPl/9z4fYfWkJ6rtaOBQ=="
-  }, {
-    "groupId" : "org.glassfish.hk2",
-    "artifactId" : "osgi-resource-locator",
-    "version" : "1.0.3",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:TYSYOpsccvWGYbV2x4ykVqIQZgLCrSEc1+ctlEZMh3QXOzSjVinFB8fITJgvHeDJv0g1JFjoSAvl+HTSDW5pow=="
-  }, {
     "groupId" : "org.glassfish.jaxb",
     "artifactId" : "codemodel",
     "version" : "2.3.5",
@@ -2673,21 +2673,13 @@
     "optional" : false,
     "integrity" : "sha512:0zlZlzBD+BthlpEUF9Vz2Zx4P9NSs0BcQlT7BsfgE6OuXXJVXy509ABB/kbZlE6cNX7aWs/HsWaunJP7vI1AeQ=="
   }, {
-    "groupId" : "org.glassfish.jersey.core",
-    "artifactId" : "jersey-client",
-    "version" : "2.47",
+    "groupId" : "org.glassfish.web",
+    "artifactId" : "javax.servlet.jsp.jstl",
+    "version" : "1.2.5",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:CT7O9PcHVW5hAhQGyELTnD8RCfOVbNZBQ1ZWdkqq5A89D36woCox+EHptoVgu9s0CTNwIVsqFu1FdJ9Gm1KBRw=="
-  }, {
-    "groupId" : "org.glassfish.jersey.core",
-    "artifactId" : "jersey-common",
-    "version" : "2.47",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:YNRuc/rdLVLArjF/32MqCfbHbD3MFmaDBRhDayrPjf3kGkIFlX0cR+pi5cLGY3CgiZXxIfx9fN0RiYNVsgjkSQ=="
+    "integrity" : "sha512:cZ9OgJZT/tBmD4p5pvm/devpYwFzpkvpsoW6orSNoO0JVMOHKuYc5jQo5LfTOyrP5NqRN75NsoSpVSrq+0qI3Q=="
   }, {
     "groupId" : "org.hamcrest",
     "artifactId" : "hamcrest-core",
@@ -2851,11 +2843,11 @@
   }, {
     "groupId" : "org.jfree",
     "artifactId" : "jfreechart",
-    "version" : "1.5.4",
+    "version" : "1.5.6",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:ZpCfpiT7QTYw0PGVp/WzkPhPtIuYZs+BChY0AoT0DGa+vIIrhE3UOdMsUOQNx4rkwG2G2mKlbXcmDUUoFmOZcA=="
+    "integrity" : "sha512:UP+BTG33+WNTQHM+NO61sDUWysC7e01oQSzwtw0wOEKt7UZ+2w3I4as1hJXcwt7gK4n8SvupPEjrMIQW+FJSmA=="
   }, {
     "groupId" : "org.jrobin",
     "artifactId" : "jrobin",
@@ -3513,14 +3505,6 @@
     "optional" : false,
     "integrity" : "sha512:xpIViq24ZgebxTg1iWRchOCeDH2p82OoAnUV7GQgv/x9XWmY50Pg+lDegSAFuig2euhELQsAKVp1wxB87osjJA=="
   }, {
-    "groupId" : "taglibs",
-    "artifactId" : "standard",
-    "version" : "1.1.2",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:Wsytkm/UM33C98Ad3KdR1RXwPaFJRyI1Erbwr1MUxAuK9oY+RGBMqo8k5FwMyLALXdtEaHNmPRMbyw/4COxBLA=="
-  }, {
     "groupId" : "wsdl4j",
     "artifactId" : "wsdl4j",
     "version" : "1.6.3",
@@ -3528,6 +3512,22 @@
     "type" : "jar",
     "optional" : false,
     "integrity" : "sha512:N3k2Pv5LfPI7/Gg4jzxrUQXe25GSCA8URTT8rMincBT58+s64ZJzRKJnNkwk3u3r8l4wb4DfwpOFGXNoXMWMUg=="
+  }, {
+    "groupId" : "xalan",
+    "artifactId" : "serializer",
+    "version" : "2.7.2",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:iE2GWGWFikYwajaA32nz8O+g3xMTcGtU5pANNq8h4Xy2go9aa6xVHFn3+AvdHLZMP9veROITUZxK+Hlp6ecHdA=="
+  }, {
+    "groupId" : "xalan",
+    "artifactId" : "xalan",
+    "version" : "2.7.2",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:APhZxb1l9tyR45bOkf4vbTCyNU1rQZzZ6paYTFQD5c0TQruTYrCuHyeSYS8N9zHE96yS8WqCW7fiIInCehKcbA=="
   }, {
     "groupId" : "xerces",
     "artifactId" : "xercesImpl",

--- a/dependencies-lock.json
+++ b/dependencies-lock.json
@@ -482,27 +482,27 @@
   }, {
     "groupId" : "com.itextpdf.tool",
     "artifactId" : "xmlworker",
-    "version" : "5.5.13.4",
+    "version" : "5.5.13.5",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:Tj69vcCRv0r0mr78sY5gHPfpojQ2WCg7J6+/K1Jhbta/vUhRwmitDPUFrda8DQShTb3uGRkCbF0Rkw03+0zU2A=="
+    "integrity" : "sha512:qT6Z6M8/iR6PQgI1/y8xfPoGe6iQElOtmuL0OTTRy1KfedxSz6mNqE5KLmB8LdvEb89b3H+GiVl7G30smd7EOA=="
   }, {
     "groupId" : "com.itextpdf",
     "artifactId" : "itextpdf",
-    "version" : "5.5.13.4",
+    "version" : "5.5.13.5",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:HCHFwerQk+96YOD6L8Xbe65mrOsBWdffo4Ynwu7htpmUtv3IjNT5ZXOT87noUhYzO7ZVbkQjYAFOB388gGWWmw=="
+    "integrity" : "sha512:k8jO0QMHnJwgWpF6c1nn5ga8E6GsaZo2jDPwZWK6nTVoWa7i/OE3DT5vMwkx0vROptpnFABOnJ1Mm7R5JRD8Ag=="
   }, {
     "groupId" : "com.jcraft",
     "artifactId" : "jsch",
-    "version" : "0.1.54",
+    "version" : "0.1.55",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:l+xt5k9IcO48hPiDvTZkViv9YAyp8zZJZufb7n5OhSBkfAP5+B1oCOMwBSyhMz439JfWJSzSb+chqQ9XPL4gNg=="
+    "integrity" : "sha512:toJ9jeRxaC/RF0QIBmOup3YSoDd04uvMM1fHxJPV31DU7JyNUsT8ySi9/ddbYrQNPGDxhNqKe4q6RMkq/s7npQ=="
   }, {
     "groupId" : "com.medseek.clinical.service",
     "artifactId" : "SSOClinicalConnect",
@@ -857,14 +857,6 @@
     "optional" : false,
     "integrity" : "sha512:zH/dfXvRhRtI0QiDdm+snXKwQHcUs8ZTNpEw4yJL3Rmky5QfuBPd4ejH0puwelsaRNYRJA6tFxflGhWjHJYw+A=="
   }, {
-    "groupId" : "commons-dbcp",
-    "artifactId" : "commons-dbcp",
-    "version" : "1.4",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:wFErJVxKckJjS4IMeMOXKW/JOI3s603sGZd1NBWY8Mh7IRZEJal9/erfrZ88gOHU2rc10ysTYjd4IKQgS05aeA=="
-  }, {
     "groupId" : "commons-digester",
     "artifactId" : "commons-digester",
     "version" : "1.8",
@@ -912,14 +904,6 @@
     "type" : "jar",
     "optional" : false,
     "integrity" : "sha512:f9hVMOAiBKjK9GJ/JpNiA7H7rMu50LCcPGT1i2O3OOmqrimqC4ReCe+5pw2d0VQuu8eQJbPrCcH7YupPepydgQ=="
-  }, {
-    "groupId" : "commons-pool",
-    "artifactId" : "commons-pool",
-    "version" : "1.5.4",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:u1pm19qPOJZg+zacGm53KW85I5zKHWnKG3yA6OgcOKnSXevvtwKi6qyYfoOIWJjKDJXGOH2EQOVIZT1r2uaGpg=="
   }, {
     "groupId" : "commons-validator",
     "artifactId" : "commons-validator",
@@ -1065,6 +1049,14 @@
     "optional" : false,
     "integrity" : "sha512:HOSgWf2pocerdRr7E+wFRG11asQY3ZX4ztNpsE9pKKds9QAD+Jsbhtlryx34uPf/McUWtShxVe6pP2g/c9VKsQ=="
   }, {
+    "groupId" : "jakarta.transaction",
+    "artifactId" : "jakarta.transaction-api",
+    "version" : "1.3.3",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:dkrei6gHaC3NHsc4LDUnXz2KsJoD1bRcSOcyUBGQ4nOCaQgKryiqjdZWwR7oS/t9rmlT3Sdo8qzs06jPDKSWHg=="
+  }, {
     "groupId" : "jakarta.ws.rs",
     "artifactId" : "jakarta.ws.rs-api",
     "version" : "2.1.6",
@@ -1129,6 +1121,14 @@
     "optional" : false,
     "integrity" : "sha512:NYJKA86QsZiq+xjnlDWU7YM7JXvwLl75aQ14IiTmg4IyKYQwYnRVu163qRvNQhRLNCc8+Ec3GdfX9kY4FkyJ+Q=="
   }, {
+    "groupId" : "javax.inject",
+    "artifactId" : "javax.inject",
+    "version" : "1",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:4Sa3zPPkL9GYSgvu8QBKcmmjN8IC5Z4E6OKvcUKA0vLY0rpeb1lIG43NNKrzXJZqaI0LSOx+lvECwnTcDTs4Hg=="
+  }, {
     "groupId" : "javax.persistence",
     "artifactId" : "javax.persistence-api",
     "version" : "2.2",
@@ -1137,6 +1137,14 @@
     "optional" : false,
     "integrity" : "sha512:AT5ODv5ksc9nRNzkTtcWtNhROyrVtqATGvZjt5GOtlcFvQnU33Y/9KgQgp9Pa2wZjKdnDOQ5lAvleu0JFLUT+A=="
   }, {
+    "groupId" : "javax.servlet.jsp.jstl",
+    "artifactId" : "jstl-api",
+    "version" : "1.2",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:5PZoZ3fZ0HMj4bt4XpRKwtsJ8mpNXEbJhHKAEmzVUv4QR1jkR3U4xsiWNK6xx5S06zKjwhon9KFU3eHZ4yZC7w=="
+  }, {
     "groupId" : "javax.servlet.jsp",
     "artifactId" : "javax.servlet.jsp-api",
     "version" : "2.3.3",
@@ -1144,6 +1152,14 @@
     "type" : "jar",
     "optional" : false,
     "integrity" : "sha512:msaevADQDl7bKDAv3VFcjmeMrRwsusutSHs9hMdIJ1Y/yjeDgwYc4DuNnuUPmc7ZQYzJ2NZOSe7zInAjLWYMig=="
+  }, {
+    "groupId" : "javax.servlet.jsp",
+    "artifactId" : "jsp-api",
+    "version" : "2.1",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:8yCRW/J7BfX5OmlXL/Da1uaPAwtvD8sYMvgPf/5W26ngV13Y5rBCWzcErHXqK0p2Vr2tZLjMhhC/3NW8GYncxQ=="
   }, {
     "groupId" : "javax.servlet",
     "artifactId" : "javax.servlet-api",
@@ -1154,12 +1170,12 @@
     "integrity" : "sha512:dj3smAH2R7GkXkkusqZ/amD8YIvvRzjrexqS2T8fbbArMvTGVT1FV8Mg38JcDqC5hUxZ55MmK2ykU8ccrwXvOA=="
   }, {
     "groupId" : "javax.servlet",
-    "artifactId" : "jstl",
-    "version" : "1.2",
+    "artifactId" : "servlet-api",
+    "version" : "2.5",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:+2/jOSJjG7ohtgbLXVPERXBx5pXsVjIgUYUoHn2z4tY9lSSLQ7nH+yy1BC0Uome4fSxdp0LJiRdMNSbczyOu7A=="
+    "integrity" : "sha512:NjulWQQ2q4IGe3ouFLSBrrKxLKQEjXoVGaLlSbLTwJ3fcYrGTcK+bC/CTFH9ycgWAmEylAMRM2lYjOJ9h3cdtg=="
   }, {
     "groupId" : "javax.transaction",
     "artifactId" : "javax.transaction-api",
@@ -1370,6 +1386,14 @@
     "integrity" : "sha512:rL6qKQm4Cc1WHnFW3xg0DZarrLF5MlYi1zvda4LLmzh9b8saRNgZWq1OeG2imSieF1mKHTN7fH0cC8YQzBKHFA=="
   }, {
     "groupId" : "org.apache.commons",
+    "artifactId" : "commons-dbcp2",
+    "version" : "2.14.0",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:c7mb0d8bukC9ylZ+12JqbvGw14w2zbJhqPU7slAmXA1st0QxfHMVOdywimnA7fs5B49HPzFE+ts5nV55aNnFlA=="
+  }, {
+    "groupId" : "org.apache.commons",
     "artifactId" : "commons-digester3",
     "version" : "3.2",
     "scope" : "compile",
@@ -1403,11 +1427,11 @@
   }, {
     "groupId" : "org.apache.commons",
     "artifactId" : "commons-pool2",
-    "version" : "2.9.0",
+    "version" : "2.13.0",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:W9zIcix3+J/EB0sBl+/t0WXLZ5hPeHcMMv5krWULq4H9kO+nTNUJnV+qLy8UwVRkqIttKir/7X3jDiVYflt1UA=="
+    "integrity" : "sha512:n2531xBjmMJPLdTYfXIolF4l3S8JKgSo7AdsJ4vq26scJpDkJLTfBKAdxeXnd7RY/V2LwIzEgSvcm3myYMZAhw=="
   }, {
     "groupId" : "org.apache.commons",
     "artifactId" : "commons-text",
@@ -2043,11 +2067,11 @@
   }, {
     "groupId" : "org.apache.httpcomponents",
     "artifactId" : "httpmime",
-    "version" : "4.5.6",
+    "version" : "4.5.14",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:mEHbd3m2R95GaN7Zt56MUQplMHY4T8MFnvGG6l2Cgo4UneSMAWtcuJob6r5gmBQpJlqDJL4xCEc8V693piq9ag=="
+    "integrity" : "sha512:iEsGICj2gng4m3TM+8NRQsquSJztpd8B0sYN+IS5YEzUBVv04VJOA1hmH6DojpPmFPtr5ZDLlAUQsHo3wLCiDA=="
   }, {
     "groupId" : "org.apache.james",
     "artifactId" : "apache-mime4j-core",
@@ -2465,14 +2489,6 @@
     "optional" : false,
     "integrity" : "sha512:o+x8IvbnFuLAa56TsZkr2iPrkuoMw/Ovxb165EqSNf8iFtDACXeZow/S4t1hjn8wzCEAB9ph4d7i5yuPuw3hbw=="
   }, {
-    "groupId" : "org.ccil.cowan.tagsoup",
-    "artifactId" : "tagsoup",
-    "version" : "1.2.1",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:H7EdGdjGNkC0xAkHqAOEtBdpJPYOR9h7TGz2EaBiy6QiDZkMCLhTawNA/TKYXAj5aWUK/TNgpb0ojs2JEk8Zow=="
-  }, {
     "groupId" : "org.codehaus.jettison",
     "artifactId" : "jettison",
     "version" : "1.5.4",
@@ -2609,22 +2625,6 @@
     "optional" : false,
     "integrity" : "sha512:LYHZ3fzFPWK5UX8hDZ6NbuTSNxOJCTkqcxS7KT6keKWtrfs5fTE6UsXyP+TQLfL4fIECHBFIzjQkmcTRrC2/Mw=="
   }, {
-    "groupId" : "org.glassfish.hk2.external",
-    "artifactId" : "jakarta.inject",
-    "version" : "2.6.1",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:f8gZatnuA6gx3/+FyUXkFsOQYHGnqo6/ari3AI3+wK3MwfHcpT7WdorFZ2zUs8Q0cWdPl/9z4fYfWkJ6rtaOBQ=="
-  }, {
-    "groupId" : "org.glassfish.hk2",
-    "artifactId" : "osgi-resource-locator",
-    "version" : "1.0.3",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:TYSYOpsccvWGYbV2x4ykVqIQZgLCrSEc1+ctlEZMh3QXOzSjVinFB8fITJgvHeDJv0g1JFjoSAvl+HTSDW5pow=="
-  }, {
     "groupId" : "org.glassfish.jaxb",
     "artifactId" : "codemodel",
     "version" : "2.3.5",
@@ -2665,21 +2665,13 @@
     "optional" : false,
     "integrity" : "sha512:0zlZlzBD+BthlpEUF9Vz2Zx4P9NSs0BcQlT7BsfgE6OuXXJVXy509ABB/kbZlE6cNX7aWs/HsWaunJP7vI1AeQ=="
   }, {
-    "groupId" : "org.glassfish.jersey.core",
-    "artifactId" : "jersey-client",
-    "version" : "2.47",
+    "groupId" : "org.glassfish.web",
+    "artifactId" : "javax.servlet.jsp.jstl",
+    "version" : "1.2.5",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:CT7O9PcHVW5hAhQGyELTnD8RCfOVbNZBQ1ZWdkqq5A89D36woCox+EHptoVgu9s0CTNwIVsqFu1FdJ9Gm1KBRw=="
-  }, {
-    "groupId" : "org.glassfish.jersey.core",
-    "artifactId" : "jersey-common",
-    "version" : "2.47",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:YNRuc/rdLVLArjF/32MqCfbHbD3MFmaDBRhDayrPjf3kGkIFlX0cR+pi5cLGY3CgiZXxIfx9fN0RiYNVsgjkSQ=="
+    "integrity" : "sha512:cZ9OgJZT/tBmD4p5pvm/devpYwFzpkvpsoW6orSNoO0JVMOHKuYc5jQo5LfTOyrP5NqRN75NsoSpVSrq+0qI3Q=="
   }, {
     "groupId" : "org.hamcrest",
     "artifactId" : "hamcrest-core",
@@ -2843,11 +2835,11 @@
   }, {
     "groupId" : "org.jfree",
     "artifactId" : "jfreechart",
-    "version" : "1.5.4",
+    "version" : "1.5.6",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:ZpCfpiT7QTYw0PGVp/WzkPhPtIuYZs+BChY0AoT0DGa+vIIrhE3UOdMsUOQNx4rkwG2G2mKlbXcmDUUoFmOZcA=="
+    "integrity" : "sha512:UP+BTG33+WNTQHM+NO61sDUWysC7e01oQSzwtw0wOEKt7UZ+2w3I4as1hJXcwt7gK4n8SvupPEjrMIQW+FJSmA=="
   }, {
     "groupId" : "org.jrobin",
     "artifactId" : "jrobin",
@@ -3449,14 +3441,6 @@
     "optional" : false,
     "integrity" : "sha512:xpIViq24ZgebxTg1iWRchOCeDH2p82OoAnUV7GQgv/x9XWmY50Pg+lDegSAFuig2euhELQsAKVp1wxB87osjJA=="
   }, {
-    "groupId" : "taglibs",
-    "artifactId" : "standard",
-    "version" : "1.1.2",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:Wsytkm/UM33C98Ad3KdR1RXwPaFJRyI1Erbwr1MUxAuK9oY+RGBMqo8k5FwMyLALXdtEaHNmPRMbyw/4COxBLA=="
-  }, {
     "groupId" : "wsdl4j",
     "artifactId" : "wsdl4j",
     "version" : "1.6.3",
@@ -3464,6 +3448,22 @@
     "type" : "jar",
     "optional" : false,
     "integrity" : "sha512:N3k2Pv5LfPI7/Gg4jzxrUQXe25GSCA8URTT8rMincBT58+s64ZJzRKJnNkwk3u3r8l4wb4DfwpOFGXNoXMWMUg=="
+  }, {
+    "groupId" : "xalan",
+    "artifactId" : "serializer",
+    "version" : "2.7.2",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:iE2GWGWFikYwajaA32nz8O+g3xMTcGtU5pANNq8h4Xy2go9aa6xVHFn3+AvdHLZMP9veROITUZxK+Hlp6ecHdA=="
+  }, {
+    "groupId" : "xalan",
+    "artifactId" : "xalan",
+    "version" : "2.7.2",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:APhZxb1l9tyR45bOkf4vbTCyNU1rQZzZ6paYTFQD5c0TQruTYrCuHyeSYS8N9zHE96yS8WqCW7fiIInCehKcbA=="
   }, {
     "groupId" : "xerces",
     "artifactId" : "xercesImpl",

--- a/pom.xml
+++ b/pom.xml
@@ -880,21 +880,6 @@
             <version>1.79</version>
         </dependency>
 
-        <!-- Added for axis2 1.8.2 -->
-        <!-- https://mvnrepository.com/artifact/org.glassfish.jersey.core/jersey-client -->
-        <dependency>
-            <groupId>org.glassfish.jersey.core</groupId>
-            <artifactId>jersey-client</artifactId>
-            <version>2.47</version>
-            <!-- Exclude it to avoid conflict with the apache.cxf's jakarta.ws.rs-api -->
-            <exclusions>
-                <exclusion>
-                <groupId>jakarta.ws.rs</groupId>
-                <artifactId>jakarta.ws.rs-api</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
         <!-- AXIS2 (for OLIS) -->
         <!-- 
             Updated to 1.8.2 for Jakarta EE migration preparation,
@@ -1192,13 +1177,6 @@
             <version>0.10.0</version>
         </dependency>
 
-        <!--tagsoup-->
-        <dependency>
-            <groupId>org.ccil.cowan.tagsoup</groupId>
-            <artifactId>tagsoup</artifactId>
-            <version>1.2.1</version>
-        </dependency>
-
         <!-- can be found in the local_repo folder -->
 
         <!-- EBS and HCV Stubs -->
@@ -1459,6 +1437,13 @@
             <groupId>javax.annotation</groupId>
             <artifactId>javax.annotation-api</artifactId>
             <version>1.3.2</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/javax.inject/javax.inject -->
+        <!-- Required for @Inject annotation in OAuth resources (was transitive from jersey-client) -->
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+            <version>1</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/javax.servlet.jsp/javax.servlet.jsp-api -->
         <dependency>


### PR DESCRIPTION
## Summary

- Remove `org.ccil.cowan.tagsoup:tagsoup:1.2.1` - no code usage found in codebase
- Remove `org.glassfish.jersey.core:jersey-client:2.47` - was added for Axis2 but Axis2 uses Apache HttpComponents, not Jersey
- Add `javax.inject:javax.inject:1` - required for `@Inject` annotation in `AuthorizeResource.java` (was previously transitive from jersey-client)

## Verification

**Dependency Analysis:**
- No transitive dependencies on removed libraries
- No Spring/Struts/web.xml configuration references
- Maven `dependency:analyze` confirms both as unused
- "New Jersey" string matches in JSPs were US state references, not library usage

**Testing:**
- ✅ Build compiles successfully
- ✅ UI Smoke Test passes (login, dashboard, search, patient records)
- ✅ `@Inject` in OAuth AuthorizeResource verified working

## Risk Assessment

| Library | Risk | Reason |
|---------|------|--------|
| TagSoup | None | Zero code references |
| Jersey Client | None | Axis2 doesn't depend on it |
| javax.inject | None | Explicit declaration of previously transitive dep |

Relates to #2138

---

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Clean up Maven dependencies by removing unused libraries and explicitly declaring required injection support.

Build:
- Remove unused jersey-client and tagsoup dependencies from the Maven pom and lock files.
- Add an explicit javax.inject dependency to support @Inject usage previously provided transitively by jersey-client.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed unused TagSoup and Jersey Client, and added javax.inject explicitly for @Inject in OAuth resources, addressing #2138. This simplifies the build and avoids JAX-RS conflicts with no behavior changes.

- **Dependencies**
  - Removed org.ccil.cowan.tagsoup:tagsoup:1.2.1 (no code usage)
  - Removed org.glassfish.jersey.core:jersey-client:2.47 (Axis2 uses Apache HttpComponents)
  - Added javax.inject:javax.inject:1 for @Inject in AuthorizeResource

<sup>Written for commit 903fdfdacba19d22c9dfd9365b8027102b79cbee. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated multiple underlying libraries to newer versions for improved stability and performance
  * Migrated core dependencies to align with modern Java standards and best practices
  * Added new supporting libraries to enhance application functionality and capabilities
  * Removed legacy and deprecated library dependencies to reduce technical complexity
  * Improved overall application compatibility and future maintainability

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->