### PR TITLE
Fix: slow consultation pages - LEGACY BUG

### DIFF
--- a/database/mysql/oscarinit.sql
+++ b/database/mysql/oscarinit.sql
@@ -341,7 +341,15 @@ CREATE TABLE IF NOT EXISTS consultationRequests (
   `lastUpdateDate` datetime not null,
   fdid int(10),
   source varchar(50),
-  PRIMARY KEY  (requestId)
+  PRIMARY KEY  (requestId),
+  KEY `idx_consult_status_referaldate` (`status`, `referalDate`),
+  KEY `idx_consult_sendto_status_referaldate` (`sendTo`, `status`, `referalDate`),
+  KEY `idx_consult_providerno_status_referaldate` (`providerNo`, `status`, `referalDate`),
+  KEY `idx_consult_status_appointmentdate` (`status`, `appointmentDate`),
+  KEY `idx_consult_demographicno` (`demographicNo`),
+  KEY `idx_consult_serviceid` (`serviceId`),
+  KEY `idx_consult_specid` (`specId`),
+  KEY `idx_consult_lastupdatedate` (`lastUpdateDate`)
 ) ;
 
 CREATE TABLE consultationRequestsArchive (

--- a/database/mysql/oscarinit.sql
+++ b/database/mysql/oscarinit.sql
@@ -341,15 +341,7 @@ CREATE TABLE IF NOT EXISTS consultationRequests (
   `lastUpdateDate` datetime not null,
   fdid int(10),
   source varchar(50),
-  PRIMARY KEY  (requestId),
-  KEY `idx_consult_status_referaldate` (`status`, `referalDate`),
-  KEY `idx_consult_sendto_status_referaldate` (`sendTo`, `status`, `referalDate`),
-  KEY `idx_consult_providerno_status_referaldate` (`providerNo`, `status`, `referalDate`),
-  KEY `idx_consult_status_appointmentdate` (`status`, `appointmentDate`),
-  KEY `idx_consult_demographicno` (`demographicNo`),
-  KEY `idx_consult_serviceid` (`serviceId`),
-  KEY `idx_consult_specid` (`specId`),
-  KEY `idx_consult_lastupdatedate` (`lastUpdateDate`)
+  PRIMARY KEY  (requestId)
 ) ;
 
 CREATE TABLE consultationRequestsArchive (

--- a/database/mysql/updates/update-2026-01-26-consultation-indexes.sql
+++ b/database/mysql/updates/update-2026-01-26-consultation-indexes.sql
@@ -1,0 +1,26 @@
+-- Indexes for consultationRequests table to improve query performance
+-- Addresses slow consultation page load times by optimizing common query patterns
+
+-- Index for status + referral date filtering (common filter pattern)
+CREATE INDEX IF NOT EXISTS idx_consult_status_referaldate ON consultationRequests (status, referalDate);
+
+-- Index for team-based queries with status and date filtering (main team listing query)
+CREATE INDEX IF NOT EXISTS idx_consult_sendto_status_referaldate ON consultationRequests (sendTo, status, referalDate);
+
+-- Index for provider workload queries
+CREATE INDEX IF NOT EXISTS idx_consult_providerno_status_referaldate ON consultationRequests (providerNo, status, referalDate);
+
+-- Index for appointment date search mode
+CREATE INDEX IF NOT EXISTS idx_consult_status_appointmentdate ON consultationRequests (status, appointmentDate);
+
+-- Index for demographic lookups (heavily used)
+CREATE INDEX IF NOT EXISTS idx_consult_demographicno ON consultationRequests (demographicNo);
+
+-- Index for service foreign key lookups
+CREATE INDEX IF NOT EXISTS idx_consult_serviceid ON consultationRequests (serviceId);
+
+-- Index for specialist foreign key lookups
+CREATE INDEX IF NOT EXISTS idx_consult_specid ON consultationRequests (specId);
+
+-- Index for sync/update tracking queries
+CREATE INDEX IF NOT EXISTS idx_consult_lastupdatedate ON consultationRequests (lastUpdateDate);

--- a/src/main/java/ca/openosp/openo/commn/dao/ConsultationRequestDao.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/ConsultationRequestDao.java
@@ -86,8 +86,9 @@ public interface ConsultationRequestDao extends AbstractDao<ConsultationRequest>
 
     /**
      * Retrieves all consultation requests for a specific patient as lightweight DTOs, ordered by
-     * referral date descending. Uses the same DTO projection and batch extension loading as
-     * {@link #getConsultationDTOs}.
+     * referral date ascending. The ascending order is intentional because {@code EctDisplayConsult2Action}
+     * iterates the result list in reverse, producing a newest-first display.
+     * Uses the same DTO projection and batch extension loading as {@link #getConsultationDTOs}.
      *
      * @param demoNo Integer the demographic number of the patient
      * @return List of ConsultationListDTO for the specified patient

--- a/src/main/java/ca/openosp/openo/commn/dao/ConsultationRequestDao.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/ConsultationRequestDao.java
@@ -31,6 +31,7 @@ import java.util.Date;
 import java.util.List;
 
 import ca.openosp.openo.commn.model.ConsultationRequest;
+import ca.openosp.openo.consultation.dto.ConsultationListDTO;
 
 public interface ConsultationRequestDao extends AbstractDao<ConsultationRequest> {
 
@@ -59,4 +60,38 @@ public interface ConsultationRequestDao extends AbstractDao<ConsultationRequest>
     List<ConsultationRequest> findByDemographicAndServices(Integer demographicNo, List<String> serviceNameList);
 
     List<Integer> findNewConsultationsSinceDemoKey(String keyName);
+
+    /**
+     * Retrieves consultation requests as lightweight DTOs using a single JPQL constructor projection
+     * query with LEFT JOINs to Demographic, Provider (MRP and consulting), ConsultationServices, and
+     * ProfessionalSpecialist. Extensions (eReferral data) are batch-loaded in one additional query.
+     * <p>
+     * This replaces the previous N+1 pattern where each consultation triggered individual queries
+     * for demographics, providers, services, and extensions, reducing total queries from ~5N to 2.
+     * </p>
+     *
+     * @param team String the team/sendTo filter value (empty string for all teams)
+     * @param showCompleted boolean whether to include completed (status 4) consultations
+     * @param startDate Date the start date filter (null for no lower bound)
+     * @param endDate Date the end date filter (null for no upper bound)
+     * @param orderby String the sort column identifier (1-9), null for default referral date desc
+     * @param desc String "1" for descending sort, null/other for ascending
+     * @param searchDate String "1" to filter on appointment date instead of referral date
+     * @param offset Integer the pagination offset (null defaults to 0)
+     * @param limit Integer the page size (null defaults to {@link #DEFAULT_CONSULT_REQUEST_RESULTS_LIMIT})
+     * @return List of ConsultationListDTO with all display fields populated
+     * @since 2026-02-03
+     */
+    List<ConsultationListDTO> getConsultationDTOs(String team, boolean showCompleted, Date startDate, Date endDate, String orderby, String desc, String searchDate, Integer offset, Integer limit);
+
+    /**
+     * Retrieves all consultation requests for a specific patient as lightweight DTOs, ordered by
+     * referral date descending. Uses the same DTO projection and batch extension loading as
+     * {@link #getConsultationDTOs}.
+     *
+     * @param demoNo Integer the demographic number of the patient
+     * @return List of ConsultationListDTO for the specified patient
+     * @since 2026-02-03
+     */
+    List<ConsultationListDTO> getConsultationDTOsByDemographic(Integer demoNo);
 }

--- a/src/main/java/ca/openosp/openo/commn/dao/ConsultationRequestDaoImpl.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/ConsultationRequestDaoImpl.java
@@ -278,7 +278,7 @@ public class ConsultationRequestDaoImpl extends AbstractDaoImpl<ConsultationRequ
     public List<ConsultationListDTO> getConsultationDTOsByDemographic(Integer demoNo) {
         String sql = DTO_SELECT + DTO_FROM +
                 "WHERE cr.demographicId = ?1 " +
-                "ORDER BY cr.referralDate DESC";
+                "ORDER BY cr.referralDate ASC";
 
         Query query = entityManager.createQuery(sql, ConsultationListDTO.class);
         query.setParameter(1, demoNo);

--- a/src/main/java/ca/openosp/openo/commn/dao/ConsultationRequestDaoImpl.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/ConsultationRequestDaoImpl.java
@@ -110,30 +110,23 @@ public class ConsultationRequestDaoImpl extends AbstractDaoImpl<ConsultationRequ
             }
         }
 
-        String orderDesc = desc != null && desc.equals("1") ? "DESC" : "";
-        String service = ", service.serviceDesc";
         if (orderby == null) {
             sql.append("order by cr.referralDate desc ");
-        } else if (orderby.equals("1")) {               //1 = msgStatus
-            sql.append("order by cr.status " + orderDesc + service);
-        } else if (orderby.equals("2")) {               //2 = msgTeam
-            sql.append("order by cr.sendTo " + orderDesc + service);
-        } else if (orderby.equals("3")) {               //3 = msgPatient
-            sql.append("order by d.LastName " + orderDesc + service);
-        } else if (orderby.equals("4")) {               //4 = msgProvider
-            sql.append("order by p.LastName " + orderDesc + service);
-        } else if (orderby.equals("5")) {               //5 = msgService Desc
-            sql.append("order by service.serviceDesc " + orderDesc);
-        } else if (orderby.equals("6")) {               //6 = msgSpecialist Name
-            sql.append("order by specialist.lastName " + orderDesc + service);
-        } else if (orderby.equals("7")) {               //7 = msgRefDate
-            sql.append("order by cr.referralDate " + orderDesc);
-        } else if (orderby.equals("8")) {               //8 = Appointment Date
-            sql.append("order by cr.appointmentDate " + orderDesc);
-        } else if (orderby.equals("9")) {               //9 = FollowUp Date
-            sql.append("order by cr.followUpDate " + orderDesc);
         } else {
-            sql.append("order by cr.referralDate desc");
+            String orderDesc = desc != null && desc.equals("1") ? "DESC" : "";
+            String service = ", service.serviceDesc";
+            switch (orderby) {
+                case "1": sql.append("order by cr.status ").append(orderDesc).append(service); break;
+                case "2": sql.append("order by cr.sendTo ").append(orderDesc).append(service); break;
+                case "3": sql.append("order by d.LastName ").append(orderDesc).append(service); break;
+                case "4": sql.append("order by p.LastName ").append(orderDesc).append(service); break;
+                case "5": sql.append("order by service.serviceDesc ").append(orderDesc); break;
+                case "6": sql.append("order by specialist.lastName ").append(orderDesc).append(service); break;
+                case "7": sql.append("order by cr.referralDate ").append(orderDesc); break;
+                case "8": sql.append("order by cr.appointmentDate ").append(orderDesc); break;
+                case "9": sql.append("order by cr.followUpDate ").append(orderDesc); break;
+                default: sql.append("order by cr.referralDate desc"); break;
+            }
         }
 
 
@@ -342,30 +335,23 @@ public class ConsultationRequestDaoImpl extends AbstractDaoImpl<ConsultationRequ
             paramList.add(endDate);
         }
 
-        String orderDesc = desc != null && desc.equals("1") ? "DESC" : "";
-        String svcSort = ", svc.serviceDesc";
         if (orderby == null) {
             sql.append("ORDER BY cr.referralDate DESC ");
-        } else if (orderby.equals("1")) {
-            sql.append("ORDER BY cr.status ").append(orderDesc).append(svcSort);
-        } else if (orderby.equals("2")) {
-            sql.append("ORDER BY cr.sendTo ").append(orderDesc).append(svcSort);
-        } else if (orderby.equals("3")) {
-            sql.append("ORDER BY d.LastName ").append(orderDesc).append(svcSort);
-        } else if (orderby.equals("4")) {
-            sql.append("ORDER BY mrp.LastName ").append(orderDesc).append(svcSort);
-        } else if (orderby.equals("5")) {
-            sql.append("ORDER BY svc.serviceDesc ").append(orderDesc);
-        } else if (orderby.equals("6")) {
-            sql.append("ORDER BY specialist.lastName ").append(orderDesc).append(svcSort);
-        } else if (orderby.equals("7")) {
-            sql.append("ORDER BY cr.referralDate ").append(orderDesc);
-        } else if (orderby.equals("8")) {
-            sql.append("ORDER BY cr.appointmentDate ").append(orderDesc);
-        } else if (orderby.equals("9")) {
-            sql.append("ORDER BY cr.followUpDate ").append(orderDesc);
         } else {
-            sql.append("ORDER BY cr.referralDate DESC");
+            String orderDesc = desc != null && desc.equals("1") ? "DESC" : "";
+            String svcSort = ", svc.serviceDesc";
+            switch (orderby) {
+                case "1": sql.append("ORDER BY cr.status ").append(orderDesc).append(svcSort); break;
+                case "2": sql.append("ORDER BY cr.sendTo ").append(orderDesc).append(svcSort); break;
+                case "3": sql.append("ORDER BY d.LastName ").append(orderDesc).append(svcSort); break;
+                case "4": sql.append("ORDER BY mrp.LastName ").append(orderDesc).append(svcSort); break;
+                case "5": sql.append("ORDER BY svc.serviceDesc ").append(orderDesc); break;
+                case "6": sql.append("ORDER BY specialist.lastName ").append(orderDesc).append(svcSort); break;
+                case "7": sql.append("ORDER BY cr.referralDate ").append(orderDesc); break;
+                case "8": sql.append("ORDER BY cr.appointmentDate ").append(orderDesc); break;
+                case "9": sql.append("ORDER BY cr.followUpDate ").append(orderDesc); break;
+                default: sql.append("ORDER BY cr.referralDate DESC"); break;
+            }
         }
 
         return sql.toString();

--- a/src/main/java/ca/openosp/openo/commn/dao/ConsultationRequestDaoImpl.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/ConsultationRequestDaoImpl.java
@@ -28,14 +28,21 @@
 package ca.openosp.openo.commn.dao;
 
 import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import javax.persistence.Query;
 
 import org.apache.commons.lang3.time.DateFormatUtils;
 import ca.openosp.openo.commn.NativeSql;
 import ca.openosp.openo.commn.model.ConsultationRequest;
+import ca.openosp.openo.commn.model.ConsultationRequestExt;
+import ca.openosp.openo.consultation.dto.ConsultationListDTO;
 
 @SuppressWarnings("unchecked")
 public class ConsultationRequestDaoImpl extends AbstractDaoImpl<ConsultationRequest> implements ConsultationRequestDao {
@@ -212,5 +219,192 @@ public class ConsultationRequestDaoImpl extends AbstractDaoImpl<ConsultationRequ
         Query query = entityManager.createNativeQuery(sql);
         query.setParameter(1, keyName);
         return query.getResultList();
+    }
+
+    /**
+     * JPQL SELECT clause for DTO constructor projection. Field order must exactly match
+     * the {@link ConsultationListDTO} constructor parameter order.
+     */
+    private static final String DTO_SELECT = "SELECT NEW ca.openosp.openo.consultation.dto.ConsultationListDTO(" +
+            "cr.id, cr.status, cr.urgency, " +
+            "cr.demographicId, d.LastName, d.FirstName, " +
+            "d.ProviderNo, mrp.LastName, mrp.FirstName, " +
+            "cr.providerNo, cp.LastName, cp.FirstName, " +
+            "cr.serviceId, svc.serviceDesc, " +
+            "specialist.lastName, specialist.firstName, " +
+            "cr.referralDate, cr.appointmentDate, cr.appointmentTime, " +
+            "cr.patientWillBook, cr.followUpDate, " +
+            "cr.sendTo, cr.siteName) ";
+
+    /**
+     * JPQL FROM clause with LEFT JOINs for DTO projection. Joins:
+     * <ul>
+     *   <li>Demographic (patient name, provider number)</li>
+     *   <li>Provider as mrp (Most Responsible Provider from demographic)</li>
+     *   <li>Provider as cp (consulting provider from consultation request)</li>
+     *   <li>ConsultationServices (service description)</li>
+     *   <li>ProfessionalSpecialist (specialist name via entity relationship)</li>
+     * </ul>
+     */
+    private static final String DTO_FROM = "FROM ConsultationRequest cr " +
+            "LEFT JOIN Demographic d ON d.DemographicNo = cr.demographicId " +
+            "LEFT JOIN Provider mrp ON mrp.ProviderNo = d.ProviderNo " +
+            "LEFT JOIN Provider cp ON cp.ProviderNo = cr.providerNo " +
+            "LEFT JOIN ConsultationServices svc ON svc.serviceId = cr.serviceId " +
+            "LEFT JOIN cr.professionalSpecialist specialist ";
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since 2026-02-03
+     */
+    @Override
+    public List<ConsultationListDTO> getConsultationDTOs(String team, boolean showCompleted, Date startDate, Date endDate, String orderby, String desc, String searchDate, Integer offset, Integer limit) {
+        List<Object> paramList = new ArrayList<>();
+        String sql = buildConsultationDTOQuery(paramList, team, showCompleted, startDate, endDate, orderby, desc, searchDate);
+
+        Query query = entityManager.createQuery(sql, ConsultationListDTO.class);
+        for (int i = 0; i < paramList.size(); i++) {
+            query.setParameter(i + 1, paramList.get(i));
+        }
+        query.setFirstResult(offset != null ? offset : 0);
+        int myLimit = limit != null ? limit : DEFAULT_CONSULT_REQUEST_RESULTS_LIMIT;
+        query.setMaxResults(Math.min(myLimit, MAX_LIST_RETURN_SIZE));
+
+        List<ConsultationListDTO> dtos = query.getResultList();
+        loadExtensionsForDTOs(dtos);
+        return dtos;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since 2026-02-03
+     */
+    @Override
+    public List<ConsultationListDTO> getConsultationDTOsByDemographic(Integer demoNo) {
+        String sql = DTO_SELECT + DTO_FROM +
+                "WHERE cr.demographicId = ?1 " +
+                "ORDER BY cr.referralDate DESC";
+
+        Query query = entityManager.createQuery(sql, ConsultationListDTO.class);
+        query.setParameter(1, demoNo);
+
+        List<ConsultationListDTO> dtos = query.getResultList();
+        loadExtensionsForDTOs(dtos);
+        return dtos;
+    }
+
+    /**
+     * Builds the complete JPQL query string for DTO projection with parameterized filters and sorting.
+     * Uses positional parameters to prevent SQL injection (replacing the previous string concatenation pattern).
+     *
+     * @param paramList List to populate with positional query parameter values
+     * @param team String the team filter (null or empty to skip)
+     * @param showCompleted boolean whether to include completed consultations
+     * @param startDate Date the start date bound (null to skip)
+     * @param endDate Date the end date bound (null to skip)
+     * @param orderby String the sort column identifier (1-9)
+     * @param desc String "1" for descending, otherwise ascending
+     * @param searchDate String "1" to filter on appointment date instead of referral date
+     * @return String the complete JPQL query
+     */
+    private String buildConsultationDTOQuery(List<Object> paramList, String team, boolean showCompleted, Date startDate, Date endDate, String orderby, String desc, String searchDate) {
+        int paramIndex = 1;
+        StringBuilder sql = new StringBuilder(DTO_SELECT);
+        sql.append(DTO_FROM);
+        sql.append("WHERE 1=1 ");
+
+        if (!showCompleted) {
+            sql.append("AND cr.status != '4' ");
+        }
+
+        if (team != null && !team.isEmpty()) {
+            sql.append("AND cr.sendTo = ?").append(paramIndex++).append(" ");
+            paramList.add(team);
+        }
+
+        if (startDate != null) {
+            if ("1".equals(searchDate)) {
+                sql.append("AND cr.appointmentDate >= ?").append(paramIndex++).append(" ");
+            } else {
+                sql.append("AND cr.referralDate >= ?").append(paramIndex++).append(" ");
+            }
+            paramList.add(startDate);
+        }
+
+        if (endDate != null) {
+            if ("1".equals(searchDate)) {
+                sql.append("AND cr.appointmentDate <= ?").append(paramIndex++).append(" ");
+            } else {
+                sql.append("AND cr.referralDate <= ?").append(paramIndex++).append(" ");
+            }
+            paramList.add(endDate);
+        }
+
+        String orderDesc = desc != null && desc.equals("1") ? "DESC" : "";
+        String svcSort = ", svc.serviceDesc";
+        if (orderby == null) {
+            sql.append("ORDER BY cr.referralDate DESC ");
+        } else if (orderby.equals("1")) {
+            sql.append("ORDER BY cr.status ").append(orderDesc).append(svcSort);
+        } else if (orderby.equals("2")) {
+            sql.append("ORDER BY cr.sendTo ").append(orderDesc).append(svcSort);
+        } else if (orderby.equals("3")) {
+            sql.append("ORDER BY d.LastName ").append(orderDesc).append(svcSort);
+        } else if (orderby.equals("4")) {
+            sql.append("ORDER BY mrp.LastName ").append(orderDesc).append(svcSort);
+        } else if (orderby.equals("5")) {
+            sql.append("ORDER BY svc.serviceDesc ").append(orderDesc);
+        } else if (orderby.equals("6")) {
+            sql.append("ORDER BY specialist.lastName ").append(orderDesc).append(svcSort);
+        } else if (orderby.equals("7")) {
+            sql.append("ORDER BY cr.referralDate ").append(orderDesc);
+        } else if (orderby.equals("8")) {
+            sql.append("ORDER BY cr.appointmentDate ").append(orderDesc);
+        } else if (orderby.equals("9")) {
+            sql.append("ORDER BY cr.followUpDate ").append(orderDesc);
+        } else {
+            sql.append("ORDER BY cr.referralDate DESC");
+        }
+
+        return sql.toString();
+    }
+
+    /**
+     * Batch-loads all {@link ConsultationRequestExt} records for the given DTOs in a single
+     * {@code IN(:ids)} query, then groups them by request ID and applies each group to its
+     * corresponding DTO via {@link ConsultationListDTO#applyExtensions(Map)}.
+     * <p>
+     * This handles eReferral extension fields (ereferral_ref, ereferral_service, ereferral_doctor)
+     * that were previously fetched individually per consultation request in the N+1 loop.
+     * </p>
+     *
+     * @param dtos List of ConsultationListDTO to enrich with extension data
+     */
+    private void loadExtensionsForDTOs(List<ConsultationListDTO> dtos) {
+        if (dtos == null || dtos.isEmpty()) {
+            return;
+        }
+
+        List<Integer> consultIds = dtos.stream()
+                .map(ConsultationListDTO::getId)
+                .collect(Collectors.toList());
+
+        List<ConsultationRequestExt> allExts = entityManager
+                .createQuery("SELECT e FROM ConsultationRequestExt e WHERE e.requestId IN (:ids)", ConsultationRequestExt.class)
+                .setParameter("ids", consultIds)
+                .getResultList();
+
+        Map<Integer, Map<String, String>> extsByRequest = new HashMap<>();
+        for (ConsultationRequestExt ext : allExts) {
+            extsByRequest
+                    .computeIfAbsent(ext.getRequestId(), k -> new HashMap<>())
+                    .put(ext.getKey(), ext.getValue());
+        }
+
+        for (ConsultationListDTO dto : dtos) {
+            dto.applyExtensions(extsByRequest.getOrDefault(dto.getId(), Collections.emptyMap()));
+        }
     }
 }

--- a/src/main/java/ca/openosp/openo/commn/dao/ConsultationServiceDao.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/ConsultationServiceDao.java
@@ -30,6 +30,7 @@ package ca.openosp.openo.commn.dao;
 import java.util.List;
 
 import ca.openosp.openo.commn.model.ConsultationServices;
+import ca.openosp.openo.encounter.oscarConsultationRequest.config.data.ConsultationServiceDto;
 
 public interface ConsultationServiceDao extends AbstractDao<ConsultationServices> {
     public String REFERRING_DOCTOR = "Referring Doctor";
@@ -47,4 +48,21 @@ public interface ConsultationServiceDao extends AbstractDao<ConsultationServices
     public ConsultationServices findByDescription(String description);
 
     public ConsultationServices findReferringDoctorService(boolean activeOnly);
+
+    /**
+     * Retrieves only the service description for a given service ID, without loading
+     * the full entity or its associated specialists collection.
+     *
+     * @param serviceId Integer the consultation service ID
+     * @return String the service description, or null if not found
+     */
+    public String getServiceDescription(Integer serviceId);
+
+    /**
+     * Retrieves active consultation service summaries (ID and description only) without
+     * loading the full entity or its associated specialists collection.
+     *
+     * @return List&lt;ConsultationServiceDto&gt; containing serviceId and serviceDesc
+     */
+    public List<ConsultationServiceDto> findActiveServiceSummaries();
 }

--- a/src/main/java/ca/openosp/openo/commn/dao/ConsultationServiceDaoImpl.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/ConsultationServiceDaoImpl.java
@@ -35,6 +35,7 @@ import java.util.List;
 import javax.persistence.Query;
 
 import ca.openosp.openo.commn.model.ConsultationServices;
+import ca.openosp.openo.encounter.oscarConsultationRequest.config.data.ConsultationServiceDto;
 import org.springframework.stereotype.Repository;
 
 /**
@@ -89,6 +90,29 @@ public class ConsultationServiceDaoImpl extends AbstractDaoImpl<ConsultationServ
         query.setParameter(2, description);
 
         return this.getSingleResultOrNull(query);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    public List<ConsultationServiceDto> findActiveServiceSummaries() {
+        Query query = entityManager.createQuery("SELECT NEW ca.openosp.openo.encounter.oscarConsultationRequest.config.data.ConsultationServiceDto(cs.serviceId, cs.serviceDesc) FROM ConsultationServices cs WHERE cs.active = :active ORDER BY cs.serviceDesc");
+        query.setParameter("active", ACTIVE);
+        return query.getResultList();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getServiceDescription(Integer serviceId) {
+        Query query = entityManager.createQuery("SELECT cs.serviceDesc FROM ConsultationServices cs WHERE cs.serviceId = :id");
+        query.setParameter("id", serviceId);
+        @SuppressWarnings("unchecked")
+        List<String> results = query.getResultList();
+        return results.isEmpty() ? null : results.get(0);
     }
 
     public ConsultationServices findReferringDoctorService(boolean activeOnly) {

--- a/src/main/java/ca/openosp/openo/commn/dao/FaxJobDao.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/FaxJobDao.java
@@ -42,6 +42,13 @@ public interface FaxJobDao extends AbstractDao<FaxJob> {
 
     public List<FaxJob> getInprogressFaxesByJobId();
 
+    /**
+     * Retrieves fax jobs by a list of IDs in a single batch query.
+     *
+     * @param ids List&lt;Integer&gt; the fax job IDs to retrieve
+     * @return List&lt;FaxJob&gt; the matching fax jobs, or an empty list if ids is null or empty
+     * @since 2026-02-03
+     */
     public List<FaxJob> findByIds(List<Integer> ids);
 
 }

--- a/src/main/java/ca/openosp/openo/commn/dao/FaxJobDao.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/FaxJobDao.java
@@ -42,4 +42,6 @@ public interface FaxJobDao extends AbstractDao<FaxJob> {
 
     public List<FaxJob> getInprogressFaxesByJobId();
 
+    public List<FaxJob> findByIds(List<Integer> ids);
+
 }

--- a/src/main/java/ca/openosp/openo/commn/dao/FaxJobDaoImpl.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/FaxJobDaoImpl.java
@@ -131,6 +131,11 @@ public class FaxJobDaoImpl extends AbstractDaoImpl<FaxJob> implements FaxJobDao 
         return query.getResultList();
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * @since 2026-02-03
+     */
     @SuppressWarnings("unchecked")
     @Override
     public List<FaxJob> findByIds(List<Integer> ids) {

--- a/src/main/java/ca/openosp/openo/commn/dao/FaxJobDaoImpl.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/FaxJobDaoImpl.java
@@ -133,6 +133,17 @@ public class FaxJobDaoImpl extends AbstractDaoImpl<FaxJob> implements FaxJobDao 
 
     @SuppressWarnings("unchecked")
     @Override
+    public List<FaxJob> findByIds(List<Integer> ids) {
+        if (ids == null || ids.isEmpty()) {
+            return Collections.emptyList();
+        }
+        Query query = entityManager.createQuery("SELECT f FROM FaxJob f WHERE f.id IN (:ids)");
+        query.setParameter("ids", ids);
+        return query.getResultList();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
     public List<FaxJob> getInprogressFaxesByJobId() {
         Query query = entityManager.createQuery(
                 "select job from FaxJob job where (job.status = ?1 or job.status = ?2) and job.jobId is not null");

--- a/src/main/java/ca/openosp/openo/commn/model/ConsultationRequest.java
+++ b/src/main/java/ca/openosp/openo/commn/model/ConsultationRequest.java
@@ -27,6 +27,11 @@
 package ca.openosp.openo.commn.model;
 
 import org.apache.commons.lang3.StringUtils;
+import org.hibernate.annotations.BatchSize;
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
+import org.hibernate.annotations.NotFound;
+import org.hibernate.annotations.NotFoundAction;
 
 import javax.persistence.*;
 import java.io.Serializable;
@@ -53,10 +58,16 @@ public class ConsultationRequest extends AbstractModel<Integer> implements Seria
 
     @ManyToOne(fetch = FetchType.EAGER, targetEntity = ProfessionalSpecialist.class, cascade = CascadeType.MERGE)
     @JoinColumn(name = "specId", referencedColumnName = "specId")
+    @NotFound(action = NotFoundAction.IGNORE)
+    @Fetch(FetchMode.SELECT)
+    @BatchSize(size = 25)
     private ProfessionalSpecialist professionalSpecialist;
 
     @ManyToOne(fetch = FetchType.EAGER, targetEntity = DemographicContact.class)
     @JoinColumn(name = "demographicContactId", referencedColumnName = "id")
+    @NotFound(action = NotFoundAction.IGNORE)
+    @Fetch(FetchMode.SELECT)
+    @BatchSize(size = 25)
     private DemographicContact demographicContact;
 
     @Temporal(TemporalType.DATE)
@@ -103,6 +114,9 @@ public class ConsultationRequest extends AbstractModel<Integer> implements Seria
 
     @ManyToOne(fetch = FetchType.EAGER, targetEntity = LookupListItem.class)
     @JoinColumn(name = "appointmentInstructions", referencedColumnName = "value", insertable = false, updatable = false)
+    @NotFound(action = NotFoundAction.IGNORE)
+    @Fetch(FetchMode.SELECT)
+    @BatchSize(size = 25)
     private LookupListItem lookupListItem;
 
     @Transient

--- a/src/main/java/ca/openosp/openo/commn/model/ConsultationRequest.java
+++ b/src/main/java/ca/openosp/openo/commn/model/ConsultationRequest.java
@@ -58,14 +58,12 @@ public class ConsultationRequest extends AbstractModel<Integer> implements Seria
 
     @ManyToOne(fetch = FetchType.EAGER, targetEntity = ProfessionalSpecialist.class, cascade = CascadeType.MERGE)
     @JoinColumn(name = "specId", referencedColumnName = "specId")
-    @NotFound(action = NotFoundAction.IGNORE)
     @Fetch(FetchMode.SELECT)
     @BatchSize(size = 25)
     private ProfessionalSpecialist professionalSpecialist;
 
     @ManyToOne(fetch = FetchType.EAGER, targetEntity = DemographicContact.class)
     @JoinColumn(name = "demographicContactId", referencedColumnName = "id")
-    @NotFound(action = NotFoundAction.IGNORE)
     @Fetch(FetchMode.SELECT)
     @BatchSize(size = 25)
     private DemographicContact demographicContact;
@@ -114,7 +112,6 @@ public class ConsultationRequest extends AbstractModel<Integer> implements Seria
 
     @ManyToOne(fetch = FetchType.EAGER, targetEntity = LookupListItem.class)
     @JoinColumn(name = "appointmentInstructions", referencedColumnName = "value", insertable = false, updatable = false)
-    @NotFound(action = NotFoundAction.IGNORE)
     @Fetch(FetchMode.SELECT)
     @BatchSize(size = 25)
     private LookupListItem lookupListItem;

--- a/src/main/java/ca/openosp/openo/commn/model/ConsultationRequest.java
+++ b/src/main/java/ca/openosp/openo/commn/model/ConsultationRequest.java
@@ -30,8 +30,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.Fetch;
 import org.hibernate.annotations.FetchMode;
-import org.hibernate.annotations.NotFound;
-import org.hibernate.annotations.NotFoundAction;
 
 import javax.persistence.*;
 import java.io.Serializable;

--- a/src/main/java/ca/openosp/openo/consultation/dto/ConsultationListDTO.java
+++ b/src/main/java/ca/openosp/openo/consultation/dto/ConsultationListDTO.java
@@ -1,0 +1,290 @@
+//CHECKSTYLE:OFF
+/**
+ * Copyright (c) 2026. Magenta Health. All Rights Reserved.
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
+package ca.openosp.openo.consultation.dto;
+
+import org.apache.commons.lang3.time.DateFormatUtils;
+
+import java.io.Serializable;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Data Transfer Object for consultation request list views.
+ * <p>
+ * Provides a lightweight, flat representation of consultation request data optimized for list display,
+ * eliminating N+1 query issues by fetching all display fields via a single JOIN query with batch-loaded
+ * extensions. Replaces the previous pattern of loading full entities and then individually querying
+ * related Demographics, Providers, Services, and Specialists per row.
+ * </p>
+ *
+ * @since 2026-02-03
+ */
+public class ConsultationListDTO implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final String NOT_APPLICABLE = "N/A";
+
+    private Integer id;
+    private String status;
+    private String urgency;
+    private Integer demographicNo;
+    private String demographicLastName;
+    private String demographicFirstName;
+    private String demographicProviderNo;
+    private String mrpLastName;
+    private String mrpFirstName;
+    private String consultProviderNo;
+    private String consultProviderLastName;
+    private String consultProviderFirstName;
+    private Integer serviceId;
+    private String serviceDescription;
+    private String specialistLastName;
+    private String specialistFirstName;
+    private Date referralDate;
+    private Date appointmentDate;
+    private Date appointmentTime;
+    private boolean patientWillBook;
+    private Date followUpDate;
+    private String sendTo;
+    private String siteName;
+
+    private boolean eReferral;
+    private String ereferralService;
+    private String ereferralDoctor;
+
+    /**
+     * Default constructor.
+     */
+    public ConsultationListDTO() {
+    }
+
+    /**
+     * Constructor for JPQL projection queries. Parameter order must match the SELECT NEW clause exactly.
+     *
+     * @param id Integer the consultation request ID
+     * @param status String the consultation status code
+     * @param urgency String the urgency level
+     * @param demographicNo Integer the patient demographic number
+     * @param demographicLastName String the patient's last name
+     * @param demographicFirstName String the patient's first name
+     * @param demographicProviderNo String the patient's MRP provider number
+     * @param mrpLastName String the MRP provider's last name
+     * @param mrpFirstName String the MRP provider's first name
+     * @param consultProviderNo String the consulting provider number
+     * @param consultProviderLastName String the consulting provider's last name
+     * @param consultProviderFirstName String the consulting provider's first name
+     * @param serviceId Integer the consultation service ID
+     * @param serviceDescription String the service description
+     * @param specialistLastName String the specialist's last name
+     * @param specialistFirstName String the specialist's first name
+     * @param referralDate Date the referral date
+     * @param appointmentDate Date the appointment date
+     * @param appointmentTime Date the appointment time
+     * @param patientWillBook boolean whether the patient will book
+     * @param followUpDate Date the follow-up date
+     * @param sendTo String the team/send-to value
+     * @param siteName String the site name
+     */
+    public ConsultationListDTO(Integer id, String status, String urgency,
+                               Integer demographicNo, String demographicLastName, String demographicFirstName,
+                               String demographicProviderNo, String mrpLastName, String mrpFirstName,
+                               String consultProviderNo, String consultProviderLastName, String consultProviderFirstName,
+                               Integer serviceId, String serviceDescription,
+                               String specialistLastName, String specialistFirstName,
+                               Date referralDate, Date appointmentDate, Date appointmentTime,
+                               boolean patientWillBook, Date followUpDate,
+                               String sendTo, String siteName) {
+        this.id = id;
+        this.status = status;
+        this.urgency = urgency;
+        this.demographicNo = demographicNo;
+        this.demographicLastName = demographicLastName;
+        this.demographicFirstName = demographicFirstName;
+        this.demographicProviderNo = demographicProviderNo;
+        this.mrpLastName = mrpLastName;
+        this.mrpFirstName = mrpFirstName;
+        this.consultProviderNo = consultProviderNo;
+        this.consultProviderLastName = consultProviderLastName;
+        this.consultProviderFirstName = consultProviderFirstName;
+        this.serviceId = serviceId;
+        this.serviceDescription = serviceDescription;
+        this.specialistLastName = specialistLastName;
+        this.specialistFirstName = specialistFirstName;
+        this.referralDate = referralDate;
+        this.appointmentDate = appointmentDate;
+        this.appointmentTime = appointmentTime;
+        this.patientWillBook = patientWillBook;
+        this.followUpDate = followUpDate;
+        this.sendTo = sendTo;
+        this.siteName = siteName;
+    }
+
+    /**
+     * Returns patient name formatted as "LastName, FirstName".
+     *
+     * @return String the formatted patient name
+     */
+    public String getPatientFormattedName() {
+        if (demographicLastName == null && demographicFirstName == null) {
+            return "";
+        }
+        if (demographicLastName == null) {
+            return demographicFirstName;
+        }
+        if (demographicFirstName == null) {
+            return demographicLastName;
+        }
+        return demographicLastName + ", " + demographicFirstName;
+    }
+
+    /**
+     * Returns MRP provider name formatted as "LastName, FirstName".
+     *
+     * @return String the formatted MRP name, or "N/A" if not available
+     */
+    public String getMrpFormattedName() {
+        if (mrpLastName == null && mrpFirstName == null) {
+            return NOT_APPLICABLE;
+        }
+        if (mrpLastName == null) {
+            return mrpFirstName;
+        }
+        if (mrpFirstName == null) {
+            return mrpLastName;
+        }
+        return mrpLastName + ", " + mrpFirstName;
+    }
+
+    /**
+     * Returns consulting provider name formatted as "LastName, FirstName".
+     *
+     * @return String the formatted consulting provider name, or "N/A" if not available
+     */
+    public String getConsultProviderFormattedName() {
+        if (consultProviderLastName == null && consultProviderFirstName == null) {
+            return NOT_APPLICABLE;
+        }
+        if (consultProviderLastName == null) {
+            return consultProviderFirstName;
+        }
+        if (consultProviderFirstName == null) {
+            return consultProviderLastName;
+        }
+        return consultProviderLastName + ", " + consultProviderFirstName;
+    }
+
+    /**
+     * Returns specialist name formatted as "LastName, FirstName".
+     * Falls back to eReferral doctor name if no specialist is set and serviceId is 0.
+     *
+     * @return String the formatted specialist name, or "N/A" if not available
+     */
+    public String getSpecialistFormattedName() {
+        if (specialistLastName != null || specialistFirstName != null) {
+            if (specialistLastName == null) return specialistFirstName;
+            if (specialistFirstName == null) return specialistLastName;
+            return specialistLastName + ", " + specialistFirstName;
+        }
+        if (serviceId != null && serviceId == 0 && ereferralDoctor != null) {
+            return ereferralDoctor;
+        }
+        return NOT_APPLICABLE;
+    }
+
+    /**
+     * Returns the effective service description.
+     * Falls back to eReferral service name if serviceId is 0.
+     *
+     * @return String the service description
+     */
+    public String getEffectiveServiceDescription() {
+        if (serviceId != null && serviceId == 0 && ereferralService != null) {
+            return ereferralService;
+        }
+        return serviceDescription != null ? serviceDescription : "";
+    }
+
+    /**
+     * Returns the referral date formatted as ISO date string.
+     *
+     * @return String the formatted referral date
+     */
+    public String getReferralDateFormatted() {
+        if (referralDate == null) return "";
+        return DateFormatUtils.ISO_DATE_FORMAT.format(referralDate);
+    }
+
+    /**
+     * Returns the appointment date and time formatted for display.
+     *
+     * @return String the formatted appointment date/time, or "N/A" if not set
+     */
+    public String getAppointmentDateFormatted() {
+        if (appointmentDate == null) {
+            return NOT_APPLICABLE;
+        }
+        if (appointmentTime == null) {
+            return DateFormatUtils.ISO_DATE_FORMAT.format(appointmentDate) + " T00:00:00";
+        }
+        return DateFormatUtils.ISO_DATE_FORMAT.format(appointmentDate) + " " + DateFormatUtils.ISO_TIME_FORMAT.format(appointmentTime);
+    }
+
+    /**
+     * Returns the follow-up date formatted as ISO date string.
+     *
+     * @return String the formatted follow-up date, or "N/A" if not set
+     */
+    public String getFollowUpDateFormatted() {
+        if (followUpDate == null) return NOT_APPLICABLE;
+        return DateFormatUtils.ISO_DATE_FORMAT.format(followUpDate);
+    }
+
+    /**
+     * Applies extension data (eReferral fields) from a pre-loaded map.
+     *
+     * @param extMap Map of extension key to value for this consultation request
+     */
+    public void applyExtensions(Map<String, String> extMap) {
+        if (extMap == null) return;
+        this.eReferral = extMap.containsKey("ereferral_ref");
+        this.ereferralService = extMap.getOrDefault("ereferral_service", null);
+        this.ereferralDoctor = extMap.getOrDefault("ereferral_doctor", null);
+    }
+
+    public Integer getId() { return id; }
+    public String getStatus() { return status; }
+    public String getUrgency() { return urgency; }
+    public Integer getDemographicNo() { return demographicNo; }
+    public String getDemographicProviderNo() { return demographicProviderNo; }
+    public String getConsultProviderNo() { return consultProviderNo; }
+    public String getConsultProviderLastName() { return consultProviderLastName; }
+    public String getConsultProviderFirstName() { return consultProviderFirstName; }
+    public Integer getServiceId() { return serviceId; }
+    public String getServiceDescription() { return serviceDescription; }
+    public Date getReferralDate() { return referralDate; }
+    public Date getAppointmentDate() { return appointmentDate; }
+    public Date getAppointmentTime() { return appointmentTime; }
+    public boolean isPatientWillBook() { return patientWillBook; }
+    public Date getFollowUpDate() { return followUpDate; }
+    public String getSendTo() { return sendTo; }
+    public String getSiteName() { return siteName; }
+    public boolean isEReferral() { return eReferral; }
+}

--- a/src/main/java/ca/openosp/openo/consultation/dto/ConsultationListDTO.java
+++ b/src/main/java/ca/openosp/openo/consultation/dto/ConsultationListDTO.java
@@ -1,21 +1,3 @@
-//CHECKSTYLE:OFF
-/**
- * Copyright (c) 2026. Magenta Health. All Rights Reserved.
- * This software is published under the GPL GNU General Public License.
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
- * <p>
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- * <p>
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
- */
 package ca.openosp.openo.consultation.dto;
 
 import org.apache.commons.lang3.time.DateFormatUtils;

--- a/src/main/java/ca/openosp/openo/consultation/dto/ConsultationListDTO.java
+++ b/src/main/java/ca/openosp/openo/consultation/dto/ConsultationListDTO.java
@@ -242,9 +242,9 @@ public class ConsultationListDTO implements Serializable {
             return NOT_APPLICABLE;
         }
         if (appointmentTime == null) {
-            return DateFormatUtils.ISO_DATE_FORMAT.format(appointmentDate) + "T00:00:00";
+            return DateFormatUtils.ISO_DATE_FORMAT.format(appointmentDate) + " T00:00:00";
         }
-        return DateFormatUtils.ISO_DATE_FORMAT.format(appointmentDate) + DateFormatUtils.ISO_TIME_FORMAT.format(appointmentTime);
+        return DateFormatUtils.ISO_DATE_FORMAT.format(appointmentDate) + " " + DateFormatUtils.ISO_TIME_FORMAT.format(appointmentTime);
     }
 
     /**

--- a/src/main/java/ca/openosp/openo/consultation/dto/ConsultationListDTO.java
+++ b/src/main/java/ca/openosp/openo/consultation/dto/ConsultationListDTO.java
@@ -242,9 +242,9 @@ public class ConsultationListDTO implements Serializable {
             return NOT_APPLICABLE;
         }
         if (appointmentTime == null) {
-            return DateFormatUtils.ISO_DATE_FORMAT.format(appointmentDate) + " T00:00:00";
+            return DateFormatUtils.ISO_DATE_FORMAT.format(appointmentDate) + "T00:00:00";
         }
-        return DateFormatUtils.ISO_DATE_FORMAT.format(appointmentDate) + " " + DateFormatUtils.ISO_TIME_FORMAT.format(appointmentTime);
+        return DateFormatUtils.ISO_DATE_FORMAT.format(appointmentDate) + DateFormatUtils.ISO_TIME_FORMAT.format(appointmentTime);
     }
 
     /**

--- a/src/main/java/ca/openosp/openo/consultation/dto/ConsultationListDTO.java
+++ b/src/main/java/ca/openosp/openo/consultation/dto/ConsultationListDTO.java
@@ -20,6 +20,8 @@ package ca.openosp.openo.consultation.dto;
 
 import org.apache.commons.lang3.time.DateFormatUtils;
 
+import ca.openosp.openo.commn.model.enumerator.ConsultationRequestExtKey;
+
 import java.io.Serializable;
 import java.util.Date;
 import java.util.HashMap;
@@ -264,9 +266,9 @@ public class ConsultationListDTO implements Serializable {
      */
     public void applyExtensions(Map<String, String> extMap) {
         if (extMap == null) return;
-        this.eReferral = extMap.containsKey("ereferral_ref");
-        this.ereferralService = extMap.getOrDefault("ereferral_service", null);
-        this.ereferralDoctor = extMap.getOrDefault("ereferral_doctor", null);
+        this.eReferral = extMap.containsKey(ConsultationRequestExtKey.EREFERRAL_REF.getKey());
+        this.ereferralService = extMap.getOrDefault(ConsultationRequestExtKey.EREFERRAL_SERVICE.getKey(), null);
+        this.ereferralDoctor = extMap.getOrDefault(ConsultationRequestExtKey.EREFERRAL_DOCTOR.getKey(), null);
     }
 
     public Integer getId() { return id; }

--- a/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/config/pageUtil/ConsultationLookup2Action.java
+++ b/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/config/pageUtil/ConsultationLookup2Action.java
@@ -17,7 +17,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import ca.openosp.openo.commn.dao.ConsultationServiceDao;
 import ca.openosp.openo.commn.dao.ServiceSpecialistsDao;
-import ca.openosp.openo.commn.model.ConsultationServices;
 import ca.openosp.openo.commn.model.ProfessionalSpecialist;
 import ca.openosp.openo.commn.model.ServiceSpecialists;
 import ca.openosp.openo.encounter.oscarConsultationRequest.config.data.ConsultationServiceDto;
@@ -92,16 +91,7 @@ public class ConsultationLookup2Action extends ActionSupport {
      */
     private String getServices() {
         try {
-            List<ConsultationServices> services = consultationServiceDao.findActive();
-            List<ConsultationServiceDto> serviceList = new ArrayList<>();
-
-            for (ConsultationServices service : services) {
-                serviceList.add(new ConsultationServiceDto(
-                    service.getServiceId(),
-                    service.getServiceDesc()
-                ));
-            }
-
+            List<ConsultationServiceDto> serviceList = consultationServiceDao.findActiveServiceSummaries();
             writeJsonResponse(serviceList);
             return null; // Response already written
 

--- a/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequestUtil.java
+++ b/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequestUtil.java
@@ -120,7 +120,13 @@ public class EctConsultationFormRequestUtil {
 
     public boolean estPatient(LoggedInInfo loggedInInfo, String demographicNo) {
 
-        int demographic_number = Integer.parseInt(demographicNo);
+        int demographic_number;
+        try {
+            demographic_number = Integer.parseInt(demographicNo);
+        } catch (NumberFormatException e) {
+            MiscUtils.getLogger().error("Invalid demographic number: non-numeric value provided", e);
+            return false;
+        }
         Demographic demographic = demographicManager.getDemographic(loggedInInfo, demographic_number);
         boolean estPatient = false;
         DemographicExt demographicExt = demographicManager.getDemographicExt(loggedInInfo, demographic_number, DemographicProperty.demo_cell);
@@ -217,7 +223,15 @@ public class EctConsultationFormRequestUtil {
 
         boolean verdict = true;
 
-		ConsultationRequest cr = consultationRequestDao.find(Integer.parseInt(id));
+        int requestId;
+        try {
+            requestId = Integer.parseInt(id);
+        } catch (NumberFormatException e) {
+            MiscUtils.getLogger().error("Invalid consultation request ID: non-numeric value provided", e);
+            return false;
+        }
+
+		ConsultationRequest cr = consultationRequestDao.find(requestId);
 		
 		if (cr != null) {
 			fdid = cr.getFdid();
@@ -289,6 +303,11 @@ public class EctConsultationFormRequestUtil {
                 if (specFax.equals("null")) { specFax = ""; }
                 if (specAddr.equals("null")) { specAddr = ""; }
                 if (specEmail.equalsIgnoreCase("null")) { specEmail = ""; }
+            } else {
+                specPhone = "";
+                specFax = "";
+                specAddr = "";
+                specEmail = "";
             }
 
 			Date appointmentTime = cr.getAppointmentTime();
@@ -303,7 +322,7 @@ public class EctConsultationFormRequestUtil {
 			setAppointmentInstructionsLabel( cr.getAppointmentInstructionsLabel() );
 			letterheadName = cr.getLetterheadName();
 
-			List<ConsultationRequestExt> allExts = consultationRequestExtDao.getConsultationRequestExts(Integer.parseInt(id));
+			List<ConsultationRequestExt> allExts = consultationRequestExtDao.getConsultationRequestExts(requestId);
 			Map<String, String> extMap = new HashMap<>();
 			for (ConsultationRequestExt ext : allExts) {
 				extMap.put(ext.getKey(), ext.getValue());

--- a/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequestUtil.java
+++ b/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequestUtil.java
@@ -42,6 +42,8 @@ import ca.openosp.openo.util.ConversionUtils;
 import ca.openosp.openo.util.StringUtils;
 
 import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 public class EctConsultationFormRequestUtil {
 
@@ -214,8 +216,6 @@ public class EctConsultationFormRequestUtil {
     public boolean estRequestFromId(LoggedInInfo loggedInInfo, String id) {
 
         boolean verdict = true;
-        getSpecailistsName(id);
-
 
 		ConsultationRequest cr = consultationRequestDao.find(Integer.parseInt(id));
 		
@@ -280,6 +280,16 @@ public class EctConsultationFormRequestUtil {
             // be available. This model is used in the Fax and PDF printing methods.
             professionalSpecialist = cr.getProfessionalSpecialist();
 
+            if (professionalSpecialist != null) {
+                specPhone = StringUtils.noNull(professionalSpecialist.getPhoneNumber());
+                specFax = StringUtils.noNull(professionalSpecialist.getFaxNumber());
+                specAddr = StringUtils.noNull(professionalSpecialist.getStreetAddress());
+                specEmail = StringUtils.noNull(professionalSpecialist.getEmailAddress());
+                if (specPhone.equals("null")) { specPhone = ""; }
+                if (specFax.equals("null")) { specFax = ""; }
+                if (specAddr.equals("null")) { specAddr = ""; }
+                if (specEmail.equalsIgnoreCase("null")) { specEmail = ""; }
+            }
 
 			Date appointmentTime = cr.getAppointmentTime();
 			reasonForConsultation = cr.getReasonForReferral();
@@ -292,7 +302,14 @@ public class EctConsultationFormRequestUtil {
 			setAppointmentInstructions( cr.getAppointmentInstructions() );
 			setAppointmentInstructionsLabel( cr.getAppointmentInstructionsLabel() );
 			letterheadName = cr.getLetterheadName();
-			letterheadTitle = consultationRequestExtDao.getConsultationRequestExtsByKey(Integer.parseInt(id),"letterheadTitle");
+
+			List<ConsultationRequestExt> allExts = consultationRequestExtDao.getConsultationRequestExts(Integer.parseInt(id));
+			Map<String, String> extMap = new HashMap<>();
+			for (ConsultationRequestExt ext : allExts) {
+				extMap.put(ext.getKey(), ext.getValue());
+			}
+
+			letterheadTitle = extMap.get("letterheadTitle");
 			letterheadAddress = cr.getLetterheadAddress();
 			letterheadPhone = cr.getLetterheadPhone();
 			letterheadFax = cr.getLetterheadFax();
@@ -346,7 +363,7 @@ public class EctConsultationFormRequestUtil {
                 }
             }
 
-			isEReferral = consultationRequestExtDao.getConsultationRequestExtsByKey(Integer.parseInt(id),ConsultationRequestExtKey.EREFERRAL_REF.getKey()) != null;
+			isEReferral = extMap.get(ConsultationRequestExtKey.EREFERRAL_REF.getKey()) != null;
         }
 
         getFaxLogs(id);
@@ -357,23 +374,30 @@ public class EctConsultationFormRequestUtil {
     private void getFaxLogs(String requestId) {
 
         List<FaxClientLog> faxClientLogs = faxClientLogDao.findClientLogbyRequestId(Integer.parseInt(requestId));
+        if (faxClientLogs.isEmpty()) {
+            return;
+        }
+
+        List<Integer> faxIds = faxClientLogs.stream()
+                .map(FaxClientLog::getFaxId)
+                .collect(Collectors.toList());
+        Map<Integer, FaxJob> faxJobMap = faxJobDao.findByIds(faxIds).stream()
+                .collect(Collectors.toMap(FaxJob::getId, Function.identity()));
+
+        String specialistFax = "";
+        if (this.professionalSpecialist != null) {
+            specialistFax = this.professionalSpecialist.getFaxNumber();
+        }
+        if (specialistFax == null) {
+            specialistFax = "";
+        }
+        if (!specialistFax.isEmpty()) {
+            specialistFax = specialistFax.trim().replaceAll("\\D", "");
+        }
+
         for (FaxClientLog faxClientLog : faxClientLogs) {
-            FaxJob faxJob = faxJobDao.find(faxClientLog.getFaxId());
+            FaxJob faxJob = faxJobMap.get(faxClientLog.getFaxId());
             FaxRecipient faxRecipient = null;
-            String specialistFax = "";
-
-            if (this.professionalSpecialist != null) {
-                specialistFax = this.professionalSpecialist.getFaxNumber();
-            }
-
-            // overcome those silly default nulls in the database.
-            if (specialistFax == null) {
-                specialistFax = "";
-            }
-
-            if (!specialistFax.isEmpty()) {
-                specialistFax = specialistFax.trim().replaceAll("\\D", "");
-            }
 
             if (faxJob != null) {
                 faxRecipient = new FaxRecipient();
@@ -384,7 +408,6 @@ public class EctConsultationFormRequestUtil {
 
                 MiscUtils.getLogger().debug("Does this fax number " + specialistFax + " equal this fax number " + faxRecipient.getFax());
             }
-
 
             // isolate the main specialist fax log
             if (faxRecipient != null && specialistFax.equals(faxRecipient.getFax())) {

--- a/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequestUtil.java
+++ b/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequestUtil.java
@@ -523,13 +523,8 @@ public class EctConsultationFormRequestUtil {
     }
 
     public String getServiceName(String id) {
-        String retval = new String();
-        ConsultationServices cs = consultationServiceDao.find(Integer.parseInt(id));
-        if (cs != null) {
-            retval = cs.getServiceDesc();
-        }
-
-        return retval;
+        String desc = consultationServiceDao.getServiceDescription(Integer.parseInt(id));
+        return desc != null ? desc : "";
     }
 
     public String getClinicName() {

--- a/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequestUtil.java
+++ b/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequestUtil.java
@@ -523,8 +523,16 @@ public class EctConsultationFormRequestUtil {
     }
 
     public String getServiceName(String id) {
-        String desc = consultationServiceDao.getServiceDescription(Integer.parseInt(id));
-        return desc != null ? desc : "";
+        if (id == null || id.isEmpty()) {
+            return "";
+        }
+        try {
+            String desc = consultationServiceDao.getServiceDescription(Integer.parseInt(id));
+            return desc != null ? desc : "";
+        } catch (NumberFormatException e) {
+            MiscUtils.getLogger().warn("Invalid service ID: non-numeric value provided");
+            return "";
+        }
     }
 
     public String getClinicName() {

--- a/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/pageUtil/EctViewConsultationRequestsUtil.java
+++ b/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/pageUtil/EctViewConsultationRequestsUtil.java
@@ -121,7 +121,7 @@ public class EctViewConsultationRequestsUtil {
           List<ConsultationListDTO> dtos = consultReqDao.getConsultationDTOs(team, showCompleted, startDate, endDate, orderby, desc, searchDate, offset, limit);
 
           for (ConsultationListDTO dto : dtos) {
-              ids.add(dto.getId().toString());
+              ids.add(dto.getId() != null ? dto.getId().toString() : "");
               status.add(dto.getStatus());
               patient.add(dto.getPatientFormattedName());
               provider.add(dto.getMrpFormattedName());
@@ -130,7 +130,7 @@ public class EctViewConsultationRequestsUtil {
               vSpecialist.add(dto.getSpecialistFormattedName());
               urgency.add(dto.getUrgency());
               date.add(dto.getReferralDateFormatted());
-              demographicNo.add(dto.getDemographicNo().toString());
+              demographicNo.add(dto.getDemographicNo() != null ? dto.getDemographicNo().toString() : "0");
               siteName.add(dto.getSiteName());
               teams.add(dto.getSendTo());
               eReferral.add(dto.isEReferral());
@@ -143,6 +143,7 @@ public class EctViewConsultationRequestsUtil {
               cProv.setFirstName(dto.getConsultProviderFirstName());
               consultProvider.add(cProv);
           }
+
       } catch(Exception e) {
          MiscUtils.getLogger().error("Error", e);
          verdict = false;
@@ -167,11 +168,12 @@ public class EctViewConsultationRequestsUtil {
 
       boolean verdict = true;
       try {
+          int demographicId = Integer.parseInt(demoNo);
           ConsultationRequestDao consultReqDao = SpringUtils.getBean(ConsultationRequestDao.class);
-          List<ConsultationListDTO> dtos = consultReqDao.getConsultationDTOsByDemographic(Integer.parseInt(demoNo));
+          List<ConsultationListDTO> dtos = consultReqDao.getConsultationDTOsByDemographic(demographicId);
 
           for (ConsultationListDTO dto : dtos) {
-              ids.add(dto.getId().toString());
+              ids.add(dto.getId() != null ? dto.getId().toString() : "");
               status.add(dto.getStatus());
               patient.add(dto.getPatientFormattedName());
               provider.add(dto.getMrpFormattedName());
@@ -186,6 +188,10 @@ public class EctViewConsultationRequestsUtil {
               cProv.setFirstName(dto.getConsultProviderFirstName());
               consultProvider.add(cProv);
           }
+
+      } catch (NumberFormatException e) {
+         MiscUtils.getLogger().error("Invalid demographic number: non-numeric value provided", e);
+         verdict = false;
       } catch(Exception e) {
          MiscUtils.getLogger().error("Error", e);
          verdict = false;

--- a/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/pageUtil/EctViewConsultationRequestsUtil.java
+++ b/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/pageUtil/EctViewConsultationRequestsUtil.java
@@ -125,7 +125,7 @@ public class EctViewConsultationRequestsUtil {
               status.add(dto.getStatus());
               patient.add(dto.getPatientFormattedName());
               provider.add(dto.getMrpFormattedName());
-              providerNo.add(dto.getDemographicProviderNo() != null ? dto.getDemographicProviderNo() : "-1");
+              providerNo.add(isBlank(dto.getDemographicProviderNo()) ? "-1" : dto.getDemographicProviderNo());
               service.add(dto.getEffectiveServiceDescription());
               vSpecialist.add(dto.getSpecialistFormattedName());
               urgency.add(dto.getUrgency());
@@ -138,14 +138,11 @@ public class EctViewConsultationRequestsUtil {
               patientWillBook.add(String.valueOf(dto.isPatientWillBook()));
               followUpDate.add(dto.getFollowUpDateFormatted());
 
-              Provider cProv = new Provider();
-              cProv.setLastName(dto.getConsultProviderLastName());
-              cProv.setFirstName(dto.getConsultProviderFirstName());
-              consultProvider.add(cProv);
+              consultProvider.add(buildConsultProvider(dto));
           }
 
       } catch(Exception e) {
-         MiscUtils.getLogger().error("Error", e);
+         MiscUtils.getLogger().error("Error loading consultation list for team: " + (team != null ? team : "all"), e);
          verdict = false;
       }
       return verdict;
@@ -177,26 +174,48 @@ public class EctViewConsultationRequestsUtil {
               status.add(dto.getStatus());
               patient.add(dto.getPatientFormattedName());
               provider.add(dto.getMrpFormattedName());
+              providerNo.add(isBlank(dto.getDemographicProviderNo()) ? "-1" : dto.getDemographicProviderNo());
               service.add(dto.getEffectiveServiceDescription());
               vSpecialist.add(dto.getSpecialistFormattedName());
               urgency.add(dto.getUrgency());
               patientWillBook.add(String.valueOf(dto.isPatientWillBook()));
               date.add(dto.getReferralDateFormatted());
+              demographicNo.add(dto.getDemographicNo() != null ? dto.getDemographicNo().toString() : "0");
+              siteName.add(dto.getSiteName());
+              teams.add(dto.getSendTo());
+              eReferral.add(dto.isEReferral());
+              apptDate.add(dto.getAppointmentDateFormatted());
+              followUpDate.add(dto.getFollowUpDateFormatted());
 
-              Provider cProv = new Provider();
-              cProv.setLastName(dto.getConsultProviderLastName());
-              cProv.setFirstName(dto.getConsultProviderFirstName());
-              consultProvider.add(cProv);
+              consultProvider.add(buildConsultProvider(dto));
           }
 
       } catch (NumberFormatException e) {
          MiscUtils.getLogger().error("Invalid demographic number: non-numeric value provided", e);
          verdict = false;
       } catch(Exception e) {
-         MiscUtils.getLogger().error("Error", e);
+         MiscUtils.getLogger().error("Error loading consultations for demographic: " + demoNo, e);
          verdict = false;
       }
       return verdict;
+   }
+
+   /**
+    * Builds a Provider object from DTO consulting provider fields, returning null when no provider data exists
+    * so JSPs can render blank instead of "null, null".
+    */
+   private Provider buildConsultProvider(ConsultationListDTO dto) {
+      if (dto.getConsultProviderLastName() == null && dto.getConsultProviderFirstName() == null) {
+         return null;
+      }
+      Provider cProv = new Provider();
+      cProv.setLastName(dto.getConsultProviderLastName() != null ? dto.getConsultProviderLastName() : "");
+      cProv.setFirstName(dto.getConsultProviderFirstName() != null ? dto.getConsultProviderFirstName() : "");
+      return cProv;
+   }
+
+   private boolean isBlank(String value) {
+      return value == null || value.trim().isEmpty();
    }
 
    /**

--- a/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/pageUtil/EctViewConsultationRequestsUtil.java
+++ b/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/pageUtil/EctViewConsultationRequestsUtil.java
@@ -82,15 +82,15 @@ public class EctViewConsultationRequestsUtil {
    }
    /** @see #estConsultationVecByTeam(LoggedInInfo, String, boolean, Date, Date, String, String, String, Integer, Integer) */
    public boolean estConsultationVecByTeam(LoggedInInfo loggedInInfo, String team,boolean showCompleted,Date startDate, Date endDate) {
-      return estConsultationVecByTeam(loggedInInfo,team,showCompleted,null,null,null);
+      return estConsultationVecByTeam(loggedInInfo,team,showCompleted,startDate,endDate,null);
    }
    /** @see #estConsultationVecByTeam(LoggedInInfo, String, boolean, Date, Date, String, String, String, Integer, Integer) */
    public boolean estConsultationVecByTeam(LoggedInInfo loggedInInfo, String team,boolean showCompleted,Date startDate, Date endDate,String orderby) {
-      return estConsultationVecByTeam(loggedInInfo,team,showCompleted,null,null,null,null);
+      return estConsultationVecByTeam(loggedInInfo,team,showCompleted,startDate,endDate,orderby,null);
    }
    /** @see #estConsultationVecByTeam(LoggedInInfo, String, boolean, Date, Date, String, String, String, Integer, Integer) */
    public boolean estConsultationVecByTeam(LoggedInInfo loggedInInfo, String team,boolean showCompleted,Date startDate, Date endDate,String orderby,String desc) {
-      return estConsultationVecByTeam(loggedInInfo,team,showCompleted,null,null,null,null,null,null,null);
+      return estConsultationVecByTeam(loggedInInfo,team,showCompleted,startDate,endDate,orderby,desc,null,null,null);
    }
 
    /**

--- a/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/pageUtil/EctViewConsultationRequestsUtil.java
+++ b/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/pageUtil/EctViewConsultationRequestsUtil.java
@@ -4,7 +4,7 @@
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version. 
+ * of the License, or (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -25,26 +25,29 @@
 
 package ca.openosp.openo.encounter.oscarConsultationRequest.pageUtil;
 
-import org.apache.commons.lang3.time.DateFormatUtils;
-import ca.openosp.openo.PMmodule.dao.ProviderDao;
 import ca.openosp.openo.commn.dao.ConsultationRequestDao;
-import ca.openosp.openo.commn.dao.ConsultationRequestExtDao;
-import ca.openosp.openo.commn.dao.ConsultationServiceDao;
-import ca.openosp.openo.commn.model.*;
-import ca.openosp.openo.commn.model.enumerator.ConsultationRequestExtKey;
-import ca.openosp.openo.managers.ConsultationManager;
-import ca.openosp.openo.managers.DemographicManager;
+import ca.openosp.openo.commn.model.Provider;
+import ca.openosp.openo.consultation.dto.ConsultationListDTO;
 import ca.openosp.openo.utility.LoggedInInfo;
 import ca.openosp.openo.utility.MiscUtils;
 import ca.openosp.openo.utility.SpringUtils;
 
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
-import java.util.Map;
 
-public class EctViewConsultationRequestsUtil {  
+/**
+ * Utility class that populates parallel lists of consultation request data for JSP display.
+ * <p>
+ * Uses {@link ConsultationRequestDao#getConsultationDTOs} and
+ * {@link ConsultationRequestDao#getConsultationDTOsByDemographic} to fetch all display fields
+ * via a single JPQL constructor projection with batch-loaded extensions, replacing the previous
+ * N+1 pattern that individually queried Demographics, Providers, Services, and Extensions per row.
+ * </p>
+ *
+ * @since 2001-08-17
+ */
+public class EctViewConsultationRequestsUtil {
    public List<String> ids;
    public List<String> status;
    public List<String> patient;
@@ -58,28 +61,142 @@ public class EctViewConsultationRequestsUtil {
    public List<String> patientWillBook;
    public List<String> urgency;
    public List<String> followUpDate;
-   public List<String> providerNo;   
+   public List<String> providerNo;
    public List<String> siteName;
    public List<Provider> consultProvider;
-   public List<Boolean> eReferral; 
-   
-   public boolean estConsultationVecByTeam(LoggedInInfo loggedInInfo,String team) {   
+   public List<Boolean> eReferral;
+
+   /**
+    * Populates consultation list data filtered by team with default parameters.
+    *
+    * @param loggedInInfo LoggedInInfo the current user session
+    * @param team String the team/sendTo filter value
+    * @return boolean true if data was loaded successfully, false on error
+    */
+   public boolean estConsultationVecByTeam(LoggedInInfo loggedInInfo,String team) {
       return estConsultationVecByTeam(loggedInInfo,team,false,null,null);
    }
-   public boolean estConsultationVecByTeam(LoggedInInfo loggedInInfo,String team,boolean showCompleted) {   
+   /** @see #estConsultationVecByTeam(LoggedInInfo, String, boolean, Date, Date, String, String, String, Integer, Integer) */
+   public boolean estConsultationVecByTeam(LoggedInInfo loggedInInfo,String team,boolean showCompleted) {
       return estConsultationVecByTeam(loggedInInfo,team,showCompleted,null,null);
-   }   
+   }
+   /** @see #estConsultationVecByTeam(LoggedInInfo, String, boolean, Date, Date, String, String, String, Integer, Integer) */
    public boolean estConsultationVecByTeam(LoggedInInfo loggedInInfo, String team,boolean showCompleted,Date startDate, Date endDate) {
       return estConsultationVecByTeam(loggedInInfo,team,showCompleted,null,null,null);
-   }   
-   public boolean estConsultationVecByTeam(LoggedInInfo loggedInInfo, String team,boolean showCompleted,Date startDate, Date endDate,String orderby) {   
+   }
+   /** @see #estConsultationVecByTeam(LoggedInInfo, String, boolean, Date, Date, String, String, String, Integer, Integer) */
+   public boolean estConsultationVecByTeam(LoggedInInfo loggedInInfo, String team,boolean showCompleted,Date startDate, Date endDate,String orderby) {
       return estConsultationVecByTeam(loggedInInfo,team,showCompleted,null,null,null,null);
-   }   
-   public boolean estConsultationVecByTeam(LoggedInInfo loggedInInfo, String team,boolean showCompleted,Date startDate, Date endDate,String orderby,String desc) { 
+   }
+   /** @see #estConsultationVecByTeam(LoggedInInfo, String, boolean, Date, Date, String, String, String, Integer, Integer) */
+   public boolean estConsultationVecByTeam(LoggedInInfo loggedInInfo, String team,boolean showCompleted,Date startDate, Date endDate,String orderby,String desc) {
       return estConsultationVecByTeam(loggedInInfo,team,showCompleted,null,null,null,null,null,null,null);
-   }  
-            
-   public boolean estConsultationVecByTeam(LoggedInInfo loggedInInfo, String team,boolean showCompleted,Date startDate, Date endDate,String orderby,String desc,String searchDate, Integer offset, Integer limit) {       
+   }
+
+   /**
+    * Populates parallel lists of consultation request data filtered by team and optional criteria.
+    * <p>
+    * Delegates to {@link ConsultationRequestDao#getConsultationDTOs} which executes a single JPQL
+    * constructor projection query with LEFT JOINs, followed by one batch extension query.
+    * </p>
+    *
+    * @param loggedInInfo LoggedInInfo the current user session
+    * @param team String the team/sendTo filter value (empty string for all teams)
+    * @param showCompleted boolean whether to include completed (status 4) consultations
+    * @param startDate Date the start date filter (null for no lower bound)
+    * @param endDate Date the end date filter (null for no upper bound)
+    * @param orderby String the sort column identifier (1-9), null for default referral date desc
+    * @param desc String "1" for descending sort, null/other for ascending
+    * @param searchDate String "1" to filter on appointment date instead of referral date
+    * @param offset Integer the pagination offset (null defaults to 0)
+    * @param limit Integer the page size (null defaults to {@link ConsultationRequestDao#DEFAULT_CONSULT_REQUEST_RESULTS_LIMIT})
+    * @return boolean true if data was loaded successfully, false on error
+    */
+   public boolean estConsultationVecByTeam(LoggedInInfo loggedInInfo, String team,boolean showCompleted,Date startDate, Date endDate,String orderby,String desc,String searchDate, Integer offset, Integer limit) {
+      initLists();
+
+      boolean verdict = true;
+      try {
+          ConsultationRequestDao consultReqDao = SpringUtils.getBean(ConsultationRequestDao.class);
+          List<ConsultationListDTO> dtos = consultReqDao.getConsultationDTOs(team, showCompleted, startDate, endDate, orderby, desc, searchDate, offset, limit);
+
+          for (ConsultationListDTO dto : dtos) {
+              ids.add(dto.getId().toString());
+              status.add(dto.getStatus());
+              patient.add(dto.getPatientFormattedName());
+              provider.add(dto.getMrpFormattedName());
+              providerNo.add(dto.getDemographicProviderNo() != null ? dto.getDemographicProviderNo() : "-1");
+              service.add(dto.getEffectiveServiceDescription());
+              vSpecialist.add(dto.getSpecialistFormattedName());
+              urgency.add(dto.getUrgency());
+              date.add(dto.getReferralDateFormatted());
+              demographicNo.add(dto.getDemographicNo().toString());
+              siteName.add(dto.getSiteName());
+              teams.add(dto.getSendTo());
+              eReferral.add(dto.isEReferral());
+              apptDate.add(dto.getAppointmentDateFormatted());
+              patientWillBook.add(String.valueOf(dto.isPatientWillBook()));
+              followUpDate.add(dto.getFollowUpDateFormatted());
+
+              Provider cProv = new Provider();
+              cProv.setLastName(dto.getConsultProviderLastName());
+              cProv.setFirstName(dto.getConsultProviderFirstName());
+              consultProvider.add(cProv);
+          }
+      } catch(Exception e) {
+         MiscUtils.getLogger().error("Error", e);
+         verdict = false;
+      }
+      return verdict;
+   }
+
+
+   /**
+    * Populates parallel lists of consultation request data for a specific patient.
+    * <p>
+    * Delegates to {@link ConsultationRequestDao#getConsultationDTOsByDemographic} which executes
+    * a single JPQL constructor projection query with batch-loaded extensions.
+    * </p>
+    *
+    * @param loggedInInfo LoggedInInfo the current user session
+    * @param demoNo String the demographic number of the patient
+    * @return boolean true if data was loaded successfully, false on error
+    */
+   public boolean estConsultationVecByDemographic(LoggedInInfo loggedInInfo, String demoNo) {
+      initLists();
+
+      boolean verdict = true;
+      try {
+          ConsultationRequestDao consultReqDao = SpringUtils.getBean(ConsultationRequestDao.class);
+          List<ConsultationListDTO> dtos = consultReqDao.getConsultationDTOsByDemographic(Integer.parseInt(demoNo));
+
+          for (ConsultationListDTO dto : dtos) {
+              ids.add(dto.getId().toString());
+              status.add(dto.getStatus());
+              patient.add(dto.getPatientFormattedName());
+              provider.add(dto.getMrpFormattedName());
+              service.add(dto.getEffectiveServiceDescription());
+              vSpecialist.add(dto.getSpecialistFormattedName());
+              urgency.add(dto.getUrgency());
+              patientWillBook.add(String.valueOf(dto.isPatientWillBook()));
+              date.add(dto.getReferralDateFormatted());
+
+              Provider cProv = new Provider();
+              cProv.setLastName(dto.getConsultProviderLastName());
+              cProv.setFirstName(dto.getConsultProviderFirstName());
+              consultProvider.add(cProv);
+          }
+      } catch(Exception e) {
+         MiscUtils.getLogger().error("Error", e);
+         verdict = false;
+      }
+      return verdict;
+   }
+
+   /**
+    * Initializes all parallel lists to empty ArrayLists.
+    */
+   private void initLists() {
       ids = new ArrayList<>();
       status = new ArrayList<>();
       patient = new ArrayList<>();
@@ -97,184 +214,5 @@ public class EctViewConsultationRequestsUtil {
       followUpDate = new ArrayList<>();
       consultProvider = new ArrayList<>();
       eReferral = new ArrayList<>();
-      
-      boolean verdict = true;
-      try {
-          ConsultationRequestDao consultReqDao = (ConsultationRequestDao) SpringUtils.getBean(ConsultationRequestDao.class);
-          ConsultationRequestExtDao consultationRequestExtDao = SpringUtils.getBean(ConsultationRequestExtDao.class);
-          DemographicManager demographicManager = SpringUtils.getBean(DemographicManager.class);
-          ConsultationManager consultationManager = SpringUtils.getBean(ConsultationManager.class);
-          ProviderDao providerDao = (ProviderDao) SpringUtils.getBean(ProviderDao.class);
-          ConsultationServiceDao serviceDao = (ConsultationServiceDao) SpringUtils.getBean(ConsultationServiceDao.class);
-          ConsultationRequest consult;
-          Demographic demo;
-          Provider prov;
-          ProfessionalSpecialist specialist;
-          ConsultationServices services;
-          Calendar cal = Calendar.getInstance();
-          Date date1, date2;
-          String providerId, providerName, specialistName;
-          List<ConsultationRequest> consultList = consultReqDao.getConsults(team, showCompleted, startDate, endDate, orderby, desc, searchDate, offset, limit);
-
-          for( int idx = 0; idx < consultList.size(); ++idx ) {
-              consult = (ConsultationRequest)consultList.get(idx);
-              demo = demographicManager.getDemographic(loggedInInfo, consult.getDemographicId());
-
-              List<ConsultationRequestExt> extras = consultationRequestExtDao.getConsultationRequestExts(consult.getId());
-              Map<String, String> extraMap = consultationManager.getExtValuesAsMap(extras);
-              
-              String serviceDescription = "";
-              // If service id is 0, check the extensions table
-              if (consult.getServiceId() == 0) {
-                 serviceDescription = extraMap.getOrDefault(ConsultationRequestExtKey.EREFERRAL_SERVICE.getKey(), "");
-              } else {
-                 services = serviceDao.find(consult.getServiceId());
-                 if (services != null) {
-                    serviceDescription = services.getServiceDesc();
-                 }
-              }
-
-              providerId = demo.getProviderNo();
-              if( providerId != null && !providerId.equals("")) {
-                  prov = providerDao.getProvider(demo.getProviderNo());
-                  providerName = prov.getFormattedName();
-                  providerNo.add(prov.getProviderNo());
-              }
-              else {
-                  providerName = "N/A";
-                  providerNo.add("-1");
-              }
-
-              if( consult.getProfessionalSpecialist() == null ) {
-                  specialistName = "N/A";
-                  if (consult.getServiceId() == 0) {
-                     specialistName = extraMap.getOrDefault(ConsultationRequestExtKey.EREFERRAL_DOCTOR.getKey(), "N/A");
-                  }
-              }
-              else {
-                  specialist = consult.getProfessionalSpecialist();
-                  specialistName = specialist.getLastName() + ", " + specialist.getFirstName();
-              }
-
-              boolean isEReferral = extraMap.containsKey(ConsultationRequestExtKey.EREFERRAL_REF.getKey());
-
-              demographicNo.add(consult.getDemographicId().toString());
-              date.add(DateFormatUtils.ISO_DATE_FORMAT.format(consult.getReferralDate()));
-              ids.add(consult.getId().toString());
-              status.add(consult.getStatus());
-              patient.add(demo.getFormattedName());
-              provider.add(providerName);
-              service.add(serviceDescription);
-              vSpecialist.add(specialistName);
-              urgency.add(consult.getUrgency());
-              siteName.add(consult.getSiteName());
-              teams.add(consult.getSendTo());
-              eReferral.add(isEReferral);
-              
-              date1 = consult.getAppointmentDate();
-              date2 = consult.getAppointmentTime();
-              
-              String apptDateStr = "";
-              if( date1 == null ) {
-            	  apptDateStr = "N/A";
-              } else if( date1 != null && date2 == null ) {
-            	  apptDateStr = DateFormatUtils.ISO_DATE_FORMAT.format(date1) + " T00:00:00";
-              } else {
-            	  apptDateStr = DateFormatUtils.ISO_DATE_FORMAT.format(date1) + " " +  DateFormatUtils.ISO_TIME_FORMAT.format(date2);
-              }
-              
-              apptDate.add(apptDateStr);
-              patientWillBook.add(""+consult.isPatientWillBook());
-              
-              date1 = consult.getFollowUpDate();
-              if( date1 == null ) {
-                  followUpDate.add("N/A");
-              }
-              else {
-                followUpDate.add(DateFormatUtils.ISO_DATE_FORMAT.format(date1));
-              }
-              
-              Provider cProv = providerDao.getProvider(consult.getProviderNo());
-              consultProvider.add(cProv);
-          }
-      } catch(Exception e) {            
-         MiscUtils.getLogger().error("Error", e);            
-         verdict = false;            
-      }                     
-      return verdict;      
-   }      
-   
-      
-   public boolean estConsultationVecByDemographic(LoggedInInfo loggedInInfo, String demoNo) {      
-      ids = new ArrayList<>();
-      status = new ArrayList<>();
-      patient = new ArrayList<>();
-      provider = new ArrayList<>();
-      service = new ArrayList<>();
-      vSpecialist = new ArrayList<>();
-      date = new ArrayList<>();
-      patientWillBook = new ArrayList<>();
-      urgency = new ArrayList<>();
-      apptDate = new ArrayList<>();
-      consultProvider = new ArrayList<>();
-      
-      boolean verdict = true;      
-      try {                           
-
-          ConsultationRequestDao consultReqDao = (ConsultationRequestDao) SpringUtils.getBean(ConsultationRequestDao.class);
-          ConsultationRequestExtDao consultationRequestExtDao = SpringUtils.getBean(ConsultationRequestExtDao.class);
-          ProviderDao providerDao = (ProviderDao) SpringUtils.getBean(ProviderDao.class);
-          DemographicManager demoManager = SpringUtils.getBean(DemographicManager.class);
-          ConsultationServiceDao serviceDao = (ConsultationServiceDao) SpringUtils.getBean(ConsultationServiceDao.class);
-
-          ProfessionalSpecialist specialist;
-          String specialistName = "";
-
-          List <ConsultationRequest> consultList = consultReqDao.getConsults(Integer.parseInt(demoNo));
-          for( ConsultationRequest consult : consultList ) {
-              String serviceDescription = "unknown";
-              // If service id is 0, check the extensions table
-              if (consult.getServiceId() == 0) {
-                 serviceDescription = consultationRequestExtDao.getConsultationRequestExtsByKey(consult.getId(), ConsultationRequestExtKey.EREFERRAL_SERVICE.getKey());
-              } else {
-                 ConsultationServices services = serviceDao.find(consult.getServiceId());
-                 if (services != null) {
-                    serviceDescription = services.getServiceDesc();
-                 }
-              }
-
-               if(consult.getProfessionalSpecialist() == null) {
-                  specialistName = "N/A";
-                  if (consult.getServiceId() == 0) {
-                     specialistName = consultationRequestExtDao.getConsultationRequestExtsByKey(consult.getId(), ConsultationRequestExtKey.EREFERRAL_DOCTOR.getKey());
-                  }
-               }
-               else {
-                  specialist = consult.getProfessionalSpecialist();
-                  specialistName = specialist.getLastName() + ", " + specialist.getFirstName();
-               }
-
-              Demographic demo = demoManager.getDemographic(loggedInInfo, consult.getDemographicId());
-              String providerId = demo.getProviderNo();
-              String providerName = (providerId != null && !providerId.isEmpty()) ? providerDao.getProvider(providerId).getFormattedName() : "N/A";
-
-              ids.add(consult.getId().toString());
-              status.add(consult.getStatus());
-              patient.add(demo.getFormattedName());
-              provider.add(providerName);
-              service.add(serviceDescription);
-              vSpecialist.add(specialistName);
-              urgency.add(consult.getUrgency());
-              patientWillBook.add(""+consult.isPatientWillBook());
-              date.add(DateFormatUtils.ISO_DATE_FORMAT.format(consult.getReferralDate()));
-              
-              Provider cProv = providerDao.getProvider(consult.getProviderNo());
-              consultProvider.add(cProv);
-          }
-      } catch(Exception e) {         
-         MiscUtils.getLogger().error("Error", e);         
-         verdict = false;         
-      }      
-      return verdict;      
    }
 }

--- a/src/main/java/ca/openosp/openo/managers/ConsultationManagerImpl.java
+++ b/src/main/java/ca/openosp/openo/managers/ConsultationManagerImpl.java
@@ -52,6 +52,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import com.itextpdf.text.DocumentException;
 import org.apache.logging.log4j.Logger;
+import org.owasp.encoder.Encode;
 import ca.openosp.openo.commn.dao.ClinicDAO;
 import ca.openosp.openo.commn.dao.ConsultDocsDao;
 import ca.openosp.openo.commn.dao.ConsultRequestDao;
@@ -727,7 +728,7 @@ public class ConsultationManagerImpl implements ConsultationManager {
                     result.add(map);
                 }
             } catch (Exception e) {
-                MiscUtils.getLogger().warn("Failed to load HRM document " + attachedDoc.getDocumentNo() + " attached to consultation request " + requestId, e);
+                MiscUtils.getLogger().warn("Failed to load HRM document " + attachedDoc.getDocumentNo() + " attached to consultation request " + Encode.forJava(requestId), e);
             }
         }
         return result;

--- a/src/main/java/ca/openosp/openo/managers/ConsultationManagerImpl.java
+++ b/src/main/java/ca/openosp/openo/managers/ConsultationManagerImpl.java
@@ -96,6 +96,7 @@ import ca.openosp.openo.consultations.ConsultationRequestSearchFilter;
 import ca.openosp.openo.consultations.ConsultationRequestSearchFilter.SORTDIR;
 import ca.openosp.openo.consultations.ConsultationResponseSearchFilter;
 import ca.openosp.openo.hospitalReportManager.HRMUtil;
+import ca.openosp.openo.hospitalReportManager.model.HRMDocument;
 import ca.openosp.openo.utility.LoggedInInfo;
 import ca.openosp.openo.utility.MiscUtils;
 import ca.openosp.openo.utility.PDFGenerationException;
@@ -715,20 +716,21 @@ public class ConsultationManagerImpl implements ConsultationManager {
     @Override
     public ArrayList<HashMap<String, ? extends Object>> getAttachedHRMDocuments(LoggedInInfo loggedInInfo, String demographicNo, String requestId) {
         List<ConsultDocs> attachedHRMDocuments = getAttachedDocumentsByType(loggedInInfo, Integer.parseInt(requestId), ConsultDocs.DOCTYPE_HRM);
-        //TODO: refactor HRMUtil so that it's possible to call a function, pass in a particular HRM ID, and return the same information for that HRM that listHRMDocuments does
-        //		once this is done, would be possible to simply iterate over attachedHRMDocuments
-        //		In the absence of the above refactoring, the following gets the full listHRMDocuments and then filters for only the items that are actually attached to the consult
-        ArrayList<HashMap<String, ? extends Object>> allHRMDocuments = HRMUtil.listHRMDocuments(loggedInInfo, "report_date", false, demographicNo, false);
-        ArrayList<HashMap<String, ? extends Object>> filteredHRMDocuments = new ArrayList<>(attachedHRMDocuments.size());
-        for (ConsultDocs attachedHRMDocument : attachedHRMDocuments) {
-            for (HashMap<String, ? extends Object> hrmDocument : allHRMDocuments) {
-                if (((Integer) hrmDocument.get("id")) == attachedHRMDocument.getDocumentNo()) {
-                    filteredHRMDocuments.add(hrmDocument);
+        ArrayList<HashMap<String, ? extends Object>> result = new ArrayList<>(attachedHRMDocuments.size());
+        for (ConsultDocs attachedDoc : attachedHRMDocuments) {
+            try {
+                HRMDocument hrmDoc = HRMUtil.getHRMDocumentById(loggedInInfo, attachedDoc.getDocumentNo());
+                if (hrmDoc != null) {
+                    HashMap<String, Object> map = new HashMap<>();
+                    map.put("id", hrmDoc.getId());
+                    map.put("name", hrmDoc.getDisplayName());
+                    result.add(map);
                 }
+            } catch (Exception e) {
+                MiscUtils.getLogger().warn("Failed to load HRM document " + attachedDoc.getDocumentNo() + " attached to consultation request " + requestId, e);
             }
         }
-        //return the subset of listHRMDocuments that is attached
-        return filteredHRMDocuments;
+        return result;
     }
 
     @Override


### PR DESCRIPTION
## In this PR, I have fixed:
- Slow consultation pages
     -  Fixed using DTO projection, and leveraging smaller datasets when applicable (avoid pulling all data into DB calls to reduce DB hits overall), as well as adding a migration script for indexing to the DB, and adding batch fetching to related entity classes
- Additional upgrades 
     - catching exceptions, nulls, etc, handling them
     - Encoding sanitation and more explanatory logging

## I have tested these by:
- Displaying, creating constulations, using the multitude of consultation pages for verification, matching with the hotfix branch behaviour 

## Summary by Sourcery

Optimize consultation request listing and form loading by introducing DTO-based queries, batching related lookups, and adding database indexes to reduce query count and page load times.

New Features:
- Expose ConsultationListDTO-based APIs on ConsultationRequestDao for team and demographic consultation listings.
- Add DAO methods to fetch active consultation service summaries and scalar service descriptions without loading full entities.
- Introduce batch lookup of FaxJob records by ID to support more efficient fax log loading.

Bug Fixes:
- Validate and safely parse demographic and consultation request identifiers before use, avoiding NumberFormatException crashes.
- Ensure specialist contact fields on consultation forms are consistently populated and normalized even when underlying data contains null or "null" values.

Enhancements:
- Refactor consultation list utilities to populate JSP view models from a single constructor projection query plus batch-loaded extensions instead of per-row entity lookups.
- Batch-load consultation request extensions and eReferral metadata in DAO layer and apply them to DTOs to avoid N+1 queries.
- Switch consultation DTO queries to parameterized JPQL with structured ORDER BY handling to reduce SQL injection risk and centralize sorting logic.
- Retrieve consultation service information via lightweight projections and scalar queries to avoid eager loading of related collections.
- Batch HRM document loading by ID for consult attachments instead of filtering over full HRM document lists.
- Add @Fetch and @BatchSize hints on key ConsultationRequest relations to improve ORM fetching behavior for specialists, contacts, and lookup items.
- Clean up consultation utilities to centralize list initialization and improve logging when invalid input is encountered.

Build:
- Add a MySQL migration script that creates targeted indexes on consultationRequests for common status, team, provider, date, demographic, service, specialist, and lastUpdateDate access patterns.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up consultation pages by replacing N+1 queries with a single DTO projection and adding targeted DB indexes. Page loads drop from ~5N queries to 2, with extra batching for fax logs and direct HRM document lookups.

- **Refactors**
  - Added `ConsultationListDTO` and DAO methods to load list rows via one JPQL constructor with LEFT JOINs; batch-load eReferral extensions in one IN query.
  - Updated consultation list utilities to use DTOs for team/demographic views with filtering, sorting, and pagination; avoid "null, null" provider names and keep legacy appointment date/time formatting.
  - Added `@Fetch(FetchMode.SELECT)` and `@BatchSize` on key `ConsultationRequest` relations.
  - Switched to positional JPQL parameters and centralized ORDER BY handling to reduce SQL injection risk.
  - Batched fax job loading (`FaxJobDao.findByIds`) and fetched HRM documents by ID to cut extra queries.
  - Used scalar JPQL for service descriptions and active service summaries to avoid loading full `ConsultationServices` and eager specialist collections.
  - Hardened input parsing and null checks in form/list flows; improved and sanitized logging.

- **Migration**
  - Run `database/mysql/updates/update-2026-01-26-consultation-indexes.sql` to add indexes on `consultationRequests` for common filters (status, sendTo, providerNo, dates, demographicNo, serviceId, specId, lastUpdateDate).

<sup>Written for commit 83918da1341c2d2d5543b4e6710366ed3a6fad2c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Performance Improvements**
* Optimized consultation list loading with batch data retrieval, significantly reducing page load times
* Added database indexes to accelerate frequently used consultation request queries
* Enhanced lookup efficiency for consultation-related data retrieval
* Streamlined data fetching operations across the application

<!-- end of auto-generated comment: release notes by coderabbit.ai -->