### PR TITLE
Fix: consultation sorting issues, updated XSS security on consultation page

### DIFF
--- a/src/main/webapp/oscarEncounter/oscarConsultationRequest/ViewConsultationRequests.jsp
+++ b/src/main/webapp/oscarEncounter/oscarConsultationRequest/ViewConsultationRequests.jsp
@@ -578,18 +578,18 @@ background-color:rgb(212, 212, 254);
                                     <%} %>
                                     </td>
                                     <td class="stat<%=Encode.forHtmlAttribute(status)%>">
-                                        <%=date%>
+                                        <%=Encode.forHtml(date)%>
                                     </td>
                                     <td class="stat<%=Encode.forHtmlAttribute(status)%>">
                                         <% if (patBook != null && patBook.trim().equals("1")) {%>
                                         Patient will book
                                         <%} else {%>
-                                        <%=appt%>
+                                        <%=Encode.forHtml(appt)%>
                                         <%}%>
                                     </td>
                                     <td class="stat<%=Encode.forHtmlAttribute(status)%>">
                                         <a href="javascript:popupOscarRx(700,960,'<%=request.getContextPath()%>/oscarEncounter/ViewRequest.do?requestId=<%=Encode.forUriComponent(id)%>')">
-                                            <%=followUpDate%>
+                                            <%=Encode.forHtml(followUpDate)%>
                                         </a>
 
                                     </td>


### PR DESCRIPTION
## In this PR, I have:
- Fixed the consultation sorting issues
     - Now the orderby works in both ascending and descending order, reversing each time a table field is clicked
     - And the values are persisted between pages
- Added increased XSS security by using OWASP encoding

## I have tested this by:
- Opening the consultation page, testing the sorting, and the options on the for searching, ensuring that they all persist between pages, and that I can do both ascending and descending sorting by clicking on a table field, which reverses every click

## Summary by Sourcery

Improve security and state handling on the consultation requests view page.

Bug Fixes:
- Ensure consultation sorting parameters and filters are persisted across pagination and interactions.

Enhancements:
- Use hidden fields to carry current sorting and paging state for consultation requests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes consultation sorting so column clicks reliably toggle asc/desc and filters persist across pages. Hardens the consultation requests page against XSS using OWASP Encoder.

- **Bug Fixes**
  - Persisted team, orderby, desc, offset, and limit via hidden inputs so params carry across pagination.
  - Column clicks now reverse sort order without resetting on navigation.

- **Security**
  - Encoded user-controlled text and attributes with Encode.forHtml / Encode.forHtmlAttribute, and requestId with Encode.forUriComponent, to prevent XSS.

<sup>Written for commit 944b618ec3ab25e9cd5843cfb250edec40a71a23. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented security enhancements in consultation request display to prevent potential vulnerabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->