### PR TITLE
Performance/Improvement: tickler pagination not working correctly - LEGACY BUG

### DIFF
--- a/src/main/java/ca/openosp/openo/commn/dao/TicklerDao.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/TicklerDao.java
@@ -80,7 +80,7 @@ public interface TicklerDao extends AbstractDao<Tickler> {
      *
      * @param filter CustomFilter the filter criteria including status, provider, date range, etc.
      * @param offset int the starting position for pagination (0-based)
-     * @param limit int the maximum number of results to return
+     * @param limit int the maximum number of results to return, or &lt;= 0 for no limit
      * @return List&lt;TicklerListDTO&gt; matching the filter with comments and links populated,
      *         or empty list if no matches found
      * @since 2026-01-30

--- a/src/main/java/ca/openosp/openo/commn/dao/TicklerDaoImpl.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/TicklerDaoImpl.java
@@ -439,7 +439,9 @@ public class TicklerDaoImpl extends AbstractDaoImpl<Tickler> implements TicklerD
             query.setParameter(x + 1, paramList.get(x));
         }
         query.setFirstResult(offset);
-        setLimit(query, limit);
+        if (limit > 0) {
+            setLimit(query, limit);
+        }
 
         List<TicklerListDTO> ticklerDTOs = query.getResultList();
 

--- a/src/main/java/ca/openosp/openo/tickler/pageUtil/TicklerList2Action.java
+++ b/src/main/java/ca/openosp/openo/tickler/pageUtil/TicklerList2Action.java
@@ -21,6 +21,7 @@ import com.opensymphony.xwork2.ActionSupport;
 
 import ca.openosp.OscarProperties;
 import ca.openosp.openo.commn.model.CustomFilter;
+import ca.openosp.openo.log.LogAction;
 import ca.openosp.openo.managers.SecurityInfoManager;
 import ca.openosp.openo.managers.TicklerManager;
 import ca.openosp.openo.tickler.dto.TicklerCommentDTO;
@@ -38,10 +39,8 @@ import ca.openosp.openo.utility.SpringUtils;
  */
 public class TicklerList2Action extends ActionSupport {
 
-    HttpServletRequest request = ServletActionContext.getRequest();
-    HttpServletResponse response = ServletActionContext.getResponse();
-
     private static final ObjectMapper objectMapper = new ObjectMapper();
+    private static final int MAX_PAGE_SIZE = 500;
 
     private TicklerManager ticklerManager = SpringUtils.getBean(TicklerManager.class);
     private SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
@@ -56,35 +55,47 @@ public class TicklerList2Action extends ActionSupport {
      */
     @Override
     public String execute() throws IOException {
+        HttpServletRequest request = ServletActionContext.getRequest();
+        HttpServletResponse response = ServletActionContext.getResponse();
+
         LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
 
         if (!securityInfoManager.hasPrivilege(loggedInInfo, "_tickler", "r", null)) {
-            throw new SecurityException("missing required sec object (_tickler)");
+            writeJsonError(response, HttpServletResponse.SC_FORBIDDEN, "Access denied");
+            return null;
         }
 
-        int draw = parseIntParam("draw", 1);
-        int start = Math.max(0, parseIntParam("start", 0));
-        int length = parseIntParam("length", 50);
+        int draw = parseIntParam(request, "draw", 1);
+        int start = Math.max(0, parseIntParam(request, "start", 0));
+        int length = parseIntParam(request, "length", 50);
         if (length > 0) {
-            length = Math.min(length, 500);
+            length = Math.min(length, MAX_PAGE_SIZE);
         }
-        boolean showAll = (length <= 0);
 
         Locale locale = request.getLocale();
 
-        CustomFilter filter = buildFilterFromRequest();
+        CustomFilter filter;
+        try {
+            filter = buildFilterFromRequest(request);
+        } catch (IllegalArgumentException e) {
+            writeJsonError(response, HttpServletResponse.SC_BAD_REQUEST,
+                    "Invalid date format, use yyyy-MM-dd");
+            return null;
+        }
 
         int totalRecords = ticklerManager.getNumTicklers(loggedInInfo, filter);
+
         List<TicklerListDTO> ticklers;
-        if (showAll) {
-            ticklers = ticklerManager.getTicklerDTOs(loggedInInfo, filter);
+        if (length <= 0) {
+            ticklers = ticklerManager.getTicklerDTOs(loggedInInfo, filter, 0, totalRecords);
         } else {
             ticklers = ticklerManager.getTicklerDTOs(loggedInInfo, filter, start, length);
         }
 
-        long ticklerWarnDays = getTicklerWarnDays();
-        boolean ignoreWarning = (ticklerWarnDays <= 0);
+        LogAction.addLogSynchronous(loggedInInfo, "TicklerList2Action.execute",
+                "ticklers=" + ticklers.size() + ",total=" + totalRecords);
 
+        long ticklerWarnDays = getTicklerWarnDays();
         DateFormat datetimeFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss", locale);
         DateFormat dateOnlyFormat = new SimpleDateFormat("yyyy-MM-dd", locale);
         DateFormat timeOnlyFormat = new SimpleDateFormat("HH:mm:ss", locale);
@@ -93,59 +104,13 @@ public class TicklerList2Action extends ActionSupport {
         ObjectNode commentsMap = objectMapper.createObjectNode();
 
         for (TicklerListDTO tickler : ticklers) {
-            boolean warning = false;
-            if (!ignoreWarning && tickler.getServiceDate() != null) {
-                LocalDateTime serviceDate = tickler.getServiceDate().toInstant()
-                        .atZone(ZoneId.systemDefault()).toLocalDateTime();
-                long daysDifference = Duration.between(serviceDate, LocalDateTime.now()).toDays();
-                warning = (daysDifference >= ticklerWarnDays);
-            }
-
-            ObjectNode row = objectMapper.createObjectNode();
-            row.put("id", tickler.getId());
-            row.put("demoNo", tickler.getDemographicNo());
-            row.put("demoLastName", tickler.getDemographicLastName());
-            row.put("demoFirstName", tickler.getDemographicFirstName());
-            row.put("creator", tickler.getCreatorFormattedName());
-            row.put("serviceDate", tickler.getServiceDate() != null ? dateOnlyFormat.format(tickler.getServiceDate()) : "");
-            row.put("createDate", tickler.getCreateDate() != null ? datetimeFormat.format(tickler.getCreateDate()) : "");
-            row.put("priority", String.valueOf(tickler.getPriority()));
-            row.put("assignee", tickler.getAssigneeFormattedName());
-            row.put("status", tickler.getStatusDesc(locale));
-            row.put("message", tickler.getMessage());
-            row.put("warning", warning);
-
-            ArrayNode linksArray = objectMapper.createArrayNode();
-            List<TicklerLinkDTO> linkList = tickler.getLinks();
-            if (linkList != null) {
-                for (TicklerLinkDTO tl : linkList) {
-                    ObjectNode linkNode = objectMapper.createObjectNode();
-                    linkNode.put("tableName", tl.getTableName());
-                    linkNode.put("tableId", tl.getTableId());
-                    linksArray.add(linkNode);
-                }
-            }
-            row.set("links", linksArray);
-
-            dataArray.add(row);
+            boolean warning = isWarning(tickler.getServiceDate(), ticklerWarnDays);
+            dataArray.add(buildTicklerRow(tickler, warning, datetimeFormat, dateOnlyFormat, locale));
 
             List<TicklerCommentDTO> tcomments = tickler.getComments();
             if (tcomments != null && !tcomments.isEmpty()) {
-                ArrayNode commentArray = objectMapper.createArrayNode();
-                for (TicklerCommentDTO tc : tcomments) {
-                    ObjectNode commentObj = objectMapper.createObjectNode();
-                    commentObj.put("creator", tc.getProviderFormattedName());
-                    if (tc.getUpdateDate() == null) {
-                        commentObj.put("createDate", "");
-                    } else if (tc.isUpdateDateToday()) {
-                        commentObj.put("createDate", timeOnlyFormat.format(tc.getUpdateDate()));
-                    } else {
-                        commentObj.put("createDate", datetimeFormat.format(tc.getUpdateDate()));
-                    }
-                    commentObj.put("message", tc.getMessage());
-                    commentArray.add(commentObj);
-                }
-                commentsMap.set(String.valueOf(tickler.getId()), commentArray);
+                commentsMap.set(String.valueOf(tickler.getId()),
+                        buildCommentsArray(tcomments, datetimeFormat, timeOnlyFormat));
             }
         }
 
@@ -164,19 +129,109 @@ public class TicklerList2Action extends ActionSupport {
     }
 
     /**
+     * Checks whether a tickler's service date exceeds the configured warning period.
+     *
+     * @param serviceDate Date the tickler service date
+     * @param warnDays long the warning threshold in days, 0 or negative disables warnings
+     * @return boolean true if the service date is past the warning threshold
+     */
+    private boolean isWarning(java.util.Date serviceDate, long warnDays) {
+        if (serviceDate == null || warnDays <= 0) {
+            return false;
+        }
+        LocalDateTime service = serviceDate.toInstant()
+                .atZone(ZoneId.systemDefault()).toLocalDateTime();
+        long daysDifference = Duration.between(service, LocalDateTime.now()).toDays();
+        return daysDifference >= warnDays;
+    }
+
+    /**
+     * Builds a JSON object node representing a single tickler data row.
+     *
+     * @param tickler TicklerListDTO the tickler data
+     * @param warning boolean whether this tickler has triggered a warning
+     * @param datetimeFormat DateFormat for full datetime display
+     * @param dateOnlyFormat DateFormat for date-only display
+     * @param locale Locale for localized status text
+     * @return ObjectNode the JSON row
+     */
+    private ObjectNode buildTicklerRow(TicklerListDTO tickler, boolean warning,
+                                       DateFormat datetimeFormat, DateFormat dateOnlyFormat,
+                                       Locale locale) {
+        ObjectNode row = objectMapper.createObjectNode();
+        row.put("id", tickler.getId());
+        row.put("demoNo", tickler.getDemographicNo());
+        row.put("demoLastName", tickler.getDemographicLastName());
+        row.put("demoFirstName", tickler.getDemographicFirstName());
+        row.put("creator", tickler.getCreatorFormattedName());
+        row.put("serviceDate",
+                tickler.getServiceDate() != null ? dateOnlyFormat.format(tickler.getServiceDate()) : "");
+        row.put("createDate",
+                tickler.getCreateDate() != null ? datetimeFormat.format(tickler.getCreateDate()) : "");
+        row.put("priority", String.valueOf(tickler.getPriority()));
+        row.put("assignee", tickler.getAssigneeFormattedName());
+        row.put("status", tickler.getStatusDesc(locale));
+        row.put("message", tickler.getMessage());
+        row.put("warning", warning);
+
+        ArrayNode linksArray = objectMapper.createArrayNode();
+        List<TicklerLinkDTO> linkList = tickler.getLinks();
+        if (linkList != null) {
+            for (TicklerLinkDTO tl : linkList) {
+                ObjectNode linkNode = objectMapper.createObjectNode();
+                linkNode.put("tableName", tl.getTableName());
+                linkNode.put("tableId", tl.getTableId());
+                linksArray.add(linkNode);
+            }
+        }
+        row.set("links", linksArray);
+
+        return row;
+    }
+
+    /**
+     * Builds a JSON array of comment objects for a tickler.
+     *
+     * @param comments List of TicklerCommentDTO the comments to serialize
+     * @param datetimeFormat DateFormat for full datetime display
+     * @param timeOnlyFormat DateFormat for time-only display (used for today's comments)
+     * @return ArrayNode the JSON array of comments
+     */
+    private ArrayNode buildCommentsArray(List<TicklerCommentDTO> comments,
+                                         DateFormat datetimeFormat, DateFormat timeOnlyFormat) {
+        ArrayNode commentArray = objectMapper.createArrayNode();
+        for (TicklerCommentDTO tc : comments) {
+            ObjectNode commentObj = objectMapper.createObjectNode();
+            commentObj.put("creator", tc.getProviderFormattedName());
+            if (tc.getUpdateDate() == null) {
+                commentObj.put("createDate", "");
+            } else if (tc.isUpdateDateToday()) {
+                commentObj.put("createDate", timeOnlyFormat.format(tc.getUpdateDate()));
+            } else {
+                commentObj.put("createDate", datetimeFormat.format(tc.getUpdateDate()));
+            }
+            commentObj.put("message", tc.getMessage());
+            commentArray.add(commentObj);
+        }
+        return commentArray;
+    }
+
+    /**
      * Parses request parameters and constructs a CustomFilter for the tickler query.
      * Handles both general and demographic-specific filtering through a single path.
      *
+     * @param request HttpServletRequest the current request
      * @return CustomFilter populated from request parameters
+     * @throws IllegalArgumentException if date parameters are in an invalid format
      */
-    private CustomFilter buildFilterFromRequest() {
-        String ticklerview = getStringParam("ticklerview", "A");
-        String providerview = getStringParam("providerview", "all");
-        String assignedTo = getStringParam("assignedTo", "all");
-        String mrpview = getStringParam("mrpview", "all");
-        String dateBegin = getStringParam("xml_vdate", "1950-01-01");
-        String dateEnd = getStringParam("xml_appointment_date", "");
-        int targetDemographic = parseIntParam("demographic_no", 0);
+    private CustomFilter buildFilterFromRequest(HttpServletRequest request) {
+        String ticklerview = getStringParam(request, "ticklerview", "A");
+        String providerview = getStringParam(request, "providerview", "all");
+        String assignedTo = getStringParam(request, "assignedTo", "all");
+        String mrpview = getStringParam(request, "mrpview", "all");
+        String dateBegin = getStringParam(request, "xml_vdate", "1950-01-01");
+        String dateEnd = getStringParam(request, "xml_appointment_date", "");
+        int targetDemographic = parseIntParam(request, "demographic_no", 0);
 
         if (targetDemographic > 0) {
             if (dateEnd.isEmpty()) {
@@ -196,8 +251,6 @@ public class TicklerList2Action extends ActionSupport {
 
         if (targetDemographic > 0) {
             filter.setDemographicNo(String.valueOf(targetDemographic));
-            // When viewing a specific demographic's ticklers, only filter by
-            // demographic, status, and date range (matches old search_tickler_bydemo behavior)
             filter.setMrp(null);
             filter.setProvider(null);
             filter.setAssignee(null);
@@ -213,12 +266,30 @@ public class TicklerList2Action extends ActionSupport {
             }
         }
 
-        String sortDir = getStringParam("order[0][dir]", "desc");
+        String sortDir = getStringParam(request, "order[0][dir]", "desc");
         if (!"asc".equalsIgnoreCase(sortDir)) {
             sortDir = "desc";
         }
         filter.setSort_order(sortDir);
         return filter;
+    }
+
+    /**
+     * Writes a JSON error response with the given HTTP status code.
+     *
+     * @param response HttpServletResponse the response to write to
+     * @param statusCode int the HTTP status code
+     * @param message String the error message
+     * @throws IOException if writing fails
+     */
+    private void writeJsonError(HttpServletResponse response, int statusCode,
+                                String message) throws IOException {
+        response.setStatus(statusCode);
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        ObjectNode error = objectMapper.createObjectNode();
+        error.put("error", message);
+        response.getWriter().write(error.toString());
     }
 
     /**
@@ -238,7 +309,7 @@ public class TicklerList2Action extends ActionSupport {
         }
     }
 
-    private int parseIntParam(String name, int defaultValue) {
+    private int parseIntParam(HttpServletRequest request, String name, int defaultValue) {
         String val = request.getParameter(name);
         if (val == null || val.isEmpty()) {
             return defaultValue;
@@ -250,7 +321,7 @@ public class TicklerList2Action extends ActionSupport {
         }
     }
 
-    private String getStringParam(String name, String defaultValue) {
+    private String getStringParam(HttpServletRequest request, String name, String defaultValue) {
         String val = request.getParameter(name);
         if (val == null || val.isEmpty()) {
             return defaultValue;

--- a/src/main/java/ca/openosp/openo/tickler/pageUtil/TicklerList2Action.java
+++ b/src/main/java/ca/openosp/openo/tickler/pageUtil/TicklerList2Action.java
@@ -228,7 +228,11 @@ public class TicklerList2Action extends ActionSupport {
             }
         }
 
-        filter.setSort_order("desc");
+        String sortDir = getStringParam("order[0][dir]", "desc");
+        if (!"asc".equalsIgnoreCase(sortDir)) {
+            sortDir = "desc";
+        }
+        filter.setSort_order(sortDir);
         return filter;
     }
 

--- a/src/main/java/ca/openosp/openo/tickler/pageUtil/TicklerList2Action.java
+++ b/src/main/java/ca/openosp/openo/tickler/pageUtil/TicklerList2Action.java
@@ -90,6 +90,7 @@ public class TicklerList2Action extends ActionSupport {
         DateFormat timeOnlyFormat = new SimpleDateFormat("HH:mm:ss", locale);
 
         ArrayNode dataArray = objectMapper.createArrayNode();
+        ObjectNode commentsMap = objectMapper.createObjectNode();
 
         for (TicklerListDTO tickler : ticklers) {
             boolean warning = false;
@@ -113,7 +114,6 @@ public class TicklerList2Action extends ActionSupport {
             row.put("status", tickler.getStatusDesc(locale));
             row.put("message", tickler.getMessage());
             row.put("warning", warning);
-            row.put("rowType", "tickler");
 
             ArrayNode linksArray = objectMapper.createArrayNode();
             List<TicklerLinkDTO> linkList = tickler.getLinks();
@@ -130,31 +130,22 @@ public class TicklerList2Action extends ActionSupport {
             dataArray.add(row);
 
             List<TicklerCommentDTO> tcomments = tickler.getComments();
-            if (tcomments != null) {
+            if (tcomments != null && !tcomments.isEmpty()) {
+                ArrayNode commentArray = objectMapper.createArrayNode();
                 for (TicklerCommentDTO tc : tcomments) {
-                    ObjectNode commentRow = objectMapper.createObjectNode();
-                    commentRow.put("id", tickler.getId());
-                    commentRow.put("demoNo", tickler.getDemographicNo());
-                    commentRow.put("demoLastName", tickler.getDemographicLastName());
-                    commentRow.put("demoFirstName", tickler.getDemographicFirstName());
-                    commentRow.put("creator", tc.getProviderFormattedName());
-                    commentRow.put("serviceDate", tickler.getServiceDate() != null ? dateOnlyFormat.format(tickler.getServiceDate()) : "");
+                    ObjectNode commentObj = objectMapper.createObjectNode();
+                    commentObj.put("creator", tc.getProviderFormattedName());
                     if (tc.getUpdateDate() == null) {
-                        commentRow.put("createDate", "");
+                        commentObj.put("createDate", "");
                     } else if (tc.isUpdateDateToday()) {
-                        commentRow.put("createDate", timeOnlyFormat.format(tc.getUpdateDate()));
+                        commentObj.put("createDate", timeOnlyFormat.format(tc.getUpdateDate()));
                     } else {
-                        commentRow.put("createDate", datetimeFormat.format(tc.getUpdateDate()));
+                        commentObj.put("createDate", datetimeFormat.format(tc.getUpdateDate()));
                     }
-                    commentRow.put("priority", String.valueOf(tickler.getPriority()));
-                    commentRow.put("assignee", "");
-                    commentRow.put("status", "");
-                    commentRow.put("message", tc.getMessage());
-                    commentRow.put("warning", false);
-                    commentRow.put("rowType", "comment");
-
-                    dataArray.add(commentRow);
+                    commentObj.put("message", tc.getMessage());
+                    commentArray.add(commentObj);
                 }
+                commentsMap.set(String.valueOf(tickler.getId()), commentArray);
             }
         }
 
@@ -163,6 +154,7 @@ public class TicklerList2Action extends ActionSupport {
         result.put("recordsTotal", totalRecords);
         result.put("recordsFiltered", totalRecords);
         result.set("data", dataArray);
+        result.set("comments", commentsMap);
 
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");

--- a/src/main/java/ca/openosp/openo/tickler/pageUtil/TicklerList2Action.java
+++ b/src/main/java/ca/openosp/openo/tickler/pageUtil/TicklerList2Action.java
@@ -54,6 +54,7 @@ public class TicklerList2Action extends ActionSupport {
      * @return null since the response is written directly
      * @throws IOException if writing the JSON response fails
      */
+    @Override
     public String execute() throws IOException {
         LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
 
@@ -62,8 +63,11 @@ public class TicklerList2Action extends ActionSupport {
         }
 
         int draw = parseIntParam("draw", 1);
-        int start = parseIntParam("start", 0);
+        int start = Math.max(0, parseIntParam("start", 0));
         int length = parseIntParam("length", 50);
+        if (length > 0) {
+            length = Math.min(length, 500);
+        }
         boolean showAll = (length <= 0);
 
         Locale locale = request.getLocale();
@@ -88,10 +92,13 @@ public class TicklerList2Action extends ActionSupport {
         ArrayNode dataArray = objectMapper.createArrayNode();
 
         for (TicklerListDTO tickler : ticklers) {
-            LocalDateTime serviceDate = tickler.getServiceDate().toInstant()
-                    .atZone(ZoneId.systemDefault()).toLocalDateTime();
-            long daysDifference = Duration.between(serviceDate, LocalDateTime.now()).toDays();
-            boolean warning = !ignoreWarning && (daysDifference >= ticklerWarnDays);
+            boolean warning = false;
+            if (!ignoreWarning && tickler.getServiceDate() != null) {
+                LocalDateTime serviceDate = tickler.getServiceDate().toInstant()
+                        .atZone(ZoneId.systemDefault()).toLocalDateTime();
+                long daysDifference = Duration.between(serviceDate, LocalDateTime.now()).toDays();
+                warning = (daysDifference >= ticklerWarnDays);
+            }
 
             ObjectNode row = objectMapper.createObjectNode();
             row.put("id", tickler.getId());
@@ -99,8 +106,8 @@ public class TicklerList2Action extends ActionSupport {
             row.put("demoLastName", tickler.getDemographicLastName());
             row.put("demoFirstName", tickler.getDemographicFirstName());
             row.put("creator", tickler.getCreatorFormattedName());
-            row.put("serviceDate", dateOnlyFormat.format(tickler.getServiceDate()));
-            row.put("createDate", datetimeFormat.format(tickler.getCreateDate()));
+            row.put("serviceDate", tickler.getServiceDate() != null ? dateOnlyFormat.format(tickler.getServiceDate()) : "");
+            row.put("createDate", tickler.getCreateDate() != null ? datetimeFormat.format(tickler.getCreateDate()) : "");
             row.put("priority", String.valueOf(tickler.getPriority()));
             row.put("assignee", tickler.getAssigneeFormattedName());
             row.put("status", tickler.getStatusDesc(locale));
@@ -131,8 +138,10 @@ public class TicklerList2Action extends ActionSupport {
                     commentRow.put("demoLastName", tickler.getDemographicLastName());
                     commentRow.put("demoFirstName", tickler.getDemographicFirstName());
                     commentRow.put("creator", tc.getProviderFormattedName());
-                    commentRow.put("serviceDate", dateOnlyFormat.format(tickler.getServiceDate()));
-                    if (tc.isUpdateDateToday()) {
+                    commentRow.put("serviceDate", tickler.getServiceDate() != null ? dateOnlyFormat.format(tickler.getServiceDate()) : "");
+                    if (tc.getUpdateDate() == null) {
+                        commentRow.put("createDate", "");
+                    } else if (tc.isUpdateDateToday()) {
                         commentRow.put("createDate", timeOnlyFormat.format(tc.getUpdateDate()));
                     } else {
                         commentRow.put("createDate", datetimeFormat.format(tc.getUpdateDate()));
@@ -177,6 +186,16 @@ public class TicklerList2Action extends ActionSupport {
         String dateEnd = getStringParam("xml_appointment_date", "");
         int targetDemographic = parseIntParam("demographic_no", 0);
 
+        if (targetDemographic > 0) {
+            if (dateEnd.isEmpty()) {
+                dateEnd = "8888-12-31";
+            }
+        } else {
+            if (dateEnd.isEmpty()) {
+                dateEnd = new SimpleDateFormat("yyyy-MM-dd").format(new java.util.Date());
+            }
+        }
+
         CustomFilter filter = new CustomFilter();
         filter.setPriority(null);
         filter.setStatus(ticklerview);
@@ -190,9 +209,6 @@ public class TicklerList2Action extends ActionSupport {
             filter.setMrp(null);
             filter.setProvider(null);
             filter.setAssignee(null);
-            if (dateEnd.isEmpty()) {
-                filter.setEndDateWeb("8888-12-31");
-            }
         } else {
             if (!mrpview.isEmpty() && !"all".equals(mrpview)) {
                 filter.setMrp(mrpview);
@@ -221,9 +237,13 @@ public class TicklerList2Action extends ActionSupport {
     private long getTicklerWarnDays() {
         String numDaysUntilWarn = OscarProperties.getInstance().getProperty("tickler_warn_period");
         if (numDaysUntilWarn == null || numDaysUntilWarn.isEmpty()) {
-            numDaysUntilWarn = "0";
+            return 0;
         }
-        return Long.parseLong(numDaysUntilWarn);
+        try {
+            return Long.parseLong(numDaysUntilWarn);
+        } catch (NumberFormatException e) {
+            return 0;
+        }
     }
 
     private int parseIntParam(String name, int defaultValue) {

--- a/src/main/java/ca/openosp/openo/tickler/pageUtil/TicklerList2Action.java
+++ b/src/main/java/ca/openosp/openo/tickler/pageUtil/TicklerList2Action.java
@@ -1,26 +1,3 @@
-/**
- * Copyright (c) 2001-2002. Department of Family Medicine, McMaster University. All Rights Reserved.
- * This software is published under the GPL GNU General Public License.
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
- * <p>
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- * <p>
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
- * <p>
- * This software was written for the
- * Department of Family Medicine
- * McMaster University
- * Hamilton
- * Ontario, Canada
- */
 package ca.openosp.openo.tickler.pageUtil;
 
 import java.io.IOException;

--- a/src/main/java/ca/openosp/openo/tickler/pageUtil/TicklerList2Action.java
+++ b/src/main/java/ca/openosp/openo/tickler/pageUtil/TicklerList2Action.java
@@ -1,0 +1,267 @@
+/**
+ * Copyright (c) 2001-2002. Department of Family Medicine, McMaster University. All Rights Reserved.
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ * <p>
+ * This software was written for the
+ * Department of Family Medicine
+ * McMaster University
+ * Hamilton
+ * Ontario, Canada
+ */
+package ca.openosp.openo.tickler.pageUtil;
+
+import java.io.IOException;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Locale;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.struts2.ServletActionContext;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.opensymphony.xwork2.ActionSupport;
+
+import ca.openosp.OscarProperties;
+import ca.openosp.openo.commn.model.CustomFilter;
+import ca.openosp.openo.managers.SecurityInfoManager;
+import ca.openosp.openo.managers.TicklerManager;
+import ca.openosp.openo.tickler.dto.TicklerCommentDTO;
+import ca.openosp.openo.tickler.dto.TicklerLinkDTO;
+import ca.openosp.openo.tickler.dto.TicklerListDTO;
+import ca.openosp.openo.utility.LoggedInInfo;
+import ca.openosp.openo.utility.SpringUtils;
+
+/**
+ * Struts2 action that returns paginated tickler data as JSON for DataTables
+ * server-side processing. Returns raw data objects; HTML rendering is handled
+ * by client-side DataTables column render functions.
+ *
+ * @since 2026-02-05
+ */
+public class TicklerList2Action extends ActionSupport {
+
+    HttpServletRequest request = ServletActionContext.getRequest();
+    HttpServletResponse response = ServletActionContext.getResponse();
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    private TicklerManager ticklerManager = SpringUtils.getBean(TicklerManager.class);
+    private SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
+
+    /**
+     * Handles DataTables server-side processing requests. Accepts standard
+     * DataTables parameters (draw, start, length) plus tickler filter parameters.
+     * Returns JSON with raw data fields for client-side rendering.
+     *
+     * @return null since the response is written directly
+     * @throws IOException if writing the JSON response fails
+     */
+    public String execute() throws IOException {
+        LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
+
+        if (!securityInfoManager.hasPrivilege(loggedInInfo, "_tickler", "r", null)) {
+            throw new SecurityException("missing required sec object (_tickler)");
+        }
+
+        int draw = parseIntParam("draw", 1);
+        int start = parseIntParam("start", 0);
+        int length = parseIntParam("length", 50);
+        boolean showAll = (length <= 0);
+
+        Locale locale = request.getLocale();
+
+        CustomFilter filter = buildFilterFromRequest();
+
+        int totalRecords = ticklerManager.getNumTicklers(loggedInInfo, filter);
+        List<TicklerListDTO> ticklers;
+        if (showAll) {
+            ticklers = ticklerManager.getTicklerDTOs(loggedInInfo, filter);
+        } else {
+            ticklers = ticklerManager.getTicklerDTOs(loggedInInfo, filter, start, length);
+        }
+
+        long ticklerWarnDays = getTicklerWarnDays();
+        boolean ignoreWarning = (ticklerWarnDays <= 0);
+
+        DateFormat datetimeFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss", locale);
+        DateFormat dateOnlyFormat = new SimpleDateFormat("yyyy-MM-dd", locale);
+        DateFormat timeOnlyFormat = new SimpleDateFormat("HH:mm:ss", locale);
+
+        ArrayNode dataArray = objectMapper.createArrayNode();
+
+        for (TicklerListDTO tickler : ticklers) {
+            LocalDateTime serviceDate = tickler.getServiceDate().toInstant()
+                    .atZone(ZoneId.systemDefault()).toLocalDateTime();
+            long daysDifference = Duration.between(serviceDate, LocalDateTime.now()).toDays();
+            boolean warning = !ignoreWarning && (daysDifference >= ticklerWarnDays);
+
+            ObjectNode row = objectMapper.createObjectNode();
+            row.put("id", tickler.getId());
+            row.put("demoNo", tickler.getDemographicNo());
+            row.put("demoLastName", tickler.getDemographicLastName());
+            row.put("demoFirstName", tickler.getDemographicFirstName());
+            row.put("creator", tickler.getCreatorFormattedName());
+            row.put("serviceDate", dateOnlyFormat.format(tickler.getServiceDate()));
+            row.put("createDate", datetimeFormat.format(tickler.getCreateDate()));
+            row.put("priority", String.valueOf(tickler.getPriority()));
+            row.put("assignee", tickler.getAssigneeFormattedName());
+            row.put("status", tickler.getStatusDesc(locale));
+            row.put("message", tickler.getMessage());
+            row.put("warning", warning);
+            row.put("rowType", "tickler");
+
+            ArrayNode linksArray = objectMapper.createArrayNode();
+            List<TicklerLinkDTO> linkList = tickler.getLinks();
+            if (linkList != null) {
+                for (TicklerLinkDTO tl : linkList) {
+                    ObjectNode linkNode = objectMapper.createObjectNode();
+                    linkNode.put("tableName", tl.getTableName());
+                    linkNode.put("tableId", tl.getTableId());
+                    linksArray.add(linkNode);
+                }
+            }
+            row.set("links", linksArray);
+
+            dataArray.add(row);
+
+            List<TicklerCommentDTO> tcomments = tickler.getComments();
+            if (tcomments != null) {
+                for (TicklerCommentDTO tc : tcomments) {
+                    ObjectNode commentRow = objectMapper.createObjectNode();
+                    commentRow.put("id", tickler.getId());
+                    commentRow.put("demoNo", tickler.getDemographicNo());
+                    commentRow.put("demoLastName", tickler.getDemographicLastName());
+                    commentRow.put("demoFirstName", tickler.getDemographicFirstName());
+                    commentRow.put("creator", tc.getProviderFormattedName());
+                    commentRow.put("serviceDate", dateOnlyFormat.format(tickler.getServiceDate()));
+                    if (tc.isUpdateDateToday()) {
+                        commentRow.put("createDate", timeOnlyFormat.format(tc.getUpdateDate()));
+                    } else {
+                        commentRow.put("createDate", datetimeFormat.format(tc.getUpdateDate()));
+                    }
+                    commentRow.put("priority", String.valueOf(tickler.getPriority()));
+                    commentRow.put("assignee", "");
+                    commentRow.put("status", "");
+                    commentRow.put("message", tc.getMessage());
+                    commentRow.put("warning", false);
+                    commentRow.put("rowType", "comment");
+
+                    dataArray.add(commentRow);
+                }
+            }
+        }
+
+        ObjectNode result = objectMapper.createObjectNode();
+        result.put("draw", draw);
+        result.put("recordsTotal", totalRecords);
+        result.put("recordsFiltered", totalRecords);
+        result.set("data", dataArray);
+
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(result.toString());
+
+        return null;
+    }
+
+    /**
+     * Parses request parameters and constructs a CustomFilter for the tickler query.
+     * Handles both general and demographic-specific filtering through a single path.
+     *
+     * @return CustomFilter populated from request parameters
+     */
+    private CustomFilter buildFilterFromRequest() {
+        String ticklerview = getStringParam("ticklerview", "A");
+        String providerview = getStringParam("providerview", "all");
+        String assignedTo = getStringParam("assignedTo", "all");
+        String mrpview = getStringParam("mrpview", "all");
+        String dateBegin = getStringParam("xml_vdate", "1950-01-01");
+        String dateEnd = getStringParam("xml_appointment_date", "");
+        int targetDemographic = parseIntParam("demographic_no", 0);
+
+        CustomFilter filter = new CustomFilter();
+        filter.setPriority(null);
+        filter.setStatus(ticklerview);
+        filter.setStartDateWeb(dateBegin);
+        filter.setEndDateWeb(dateEnd);
+
+        if (targetDemographic > 0) {
+            filter.setDemographicNo(String.valueOf(targetDemographic));
+            // When viewing a specific demographic's ticklers, only filter by
+            // demographic, status, and date range (matches old search_tickler_bydemo behavior)
+            filter.setMrp(null);
+            filter.setProvider(null);
+            filter.setAssignee(null);
+            if (dateEnd.isEmpty()) {
+                filter.setEndDateWeb("8888-12-31");
+            }
+        } else {
+            if (!mrpview.isEmpty() && !"all".equals(mrpview)) {
+                filter.setMrp(mrpview);
+            }
+            if (!providerview.isEmpty() && !"all".equals(providerview)) {
+                filter.setProvider(providerview);
+            }
+            if (!assignedTo.isEmpty() && !"all".equals(assignedTo)) {
+                filter.setAssignee(assignedTo);
+            }
+        }
+
+        filter.setSort_order("desc");
+        return filter;
+    }
+
+    /**
+     * Reads the tickler warning period from application properties.
+     *
+     * @return the number of days after which a tickler triggers a warning, or 0 if not configured
+     */
+    private long getTicklerWarnDays() {
+        String numDaysUntilWarn = OscarProperties.getInstance().getProperty("tickler_warn_period");
+        if (numDaysUntilWarn == null || numDaysUntilWarn.isEmpty()) {
+            numDaysUntilWarn = "0";
+        }
+        return Long.parseLong(numDaysUntilWarn);
+    }
+
+    private int parseIntParam(String name, int defaultValue) {
+        String val = request.getParameter(name);
+        if (val == null || val.isEmpty()) {
+            return defaultValue;
+        }
+        try {
+            return Integer.parseInt(val);
+        } catch (NumberFormatException e) {
+            return defaultValue;
+        }
+    }
+
+    private String getStringParam(String name, String defaultValue) {
+        String val = request.getParameter(name);
+        if (val == null || val.isEmpty()) {
+            return defaultValue;
+        }
+        return val;
+    }
+}

--- a/src/main/java/ca/openosp/openo/tickler/pageUtil/TicklerList2Action.java
+++ b/src/main/java/ca/openosp/openo/tickler/pageUtil/TicklerList2Action.java
@@ -87,7 +87,7 @@ public class TicklerList2Action extends ActionSupport {
 
         List<TicklerListDTO> ticklers;
         if (length <= 0) {
-            ticklers = ticklerManager.getTicklerDTOs(loggedInInfo, filter, 0, totalRecords);
+            ticklers = ticklerManager.getTicklerDTOs(loggedInInfo, filter, 0, 0);
         } else {
             ticklers = ticklerManager.getTicklerDTOs(loggedInInfo, filter, start, length);
         }

--- a/src/main/webapp/WEB-INF/classes/struts.xml
+++ b/src/main/webapp/WEB-INF/classes/struts.xml
@@ -1530,6 +1530,8 @@
         <action name="tickler/AddTickler" class="ca.openosp.openo.tickler.pageUtil.AddTickler2Action">
             <result name="close">/close.html</result>
         </action>
+        <action name="tickler/ListTicklers" class="ca.openosp.openo.tickler.pageUtil.TicklerList2Action">
+        </action>
         <action name="eform/uploadHtml" class="ca.openosp.openo.eform.upload.HtmlUpload2Action">
             <result name="success">/eform/partials/upload.jsp</result>
             <result name="fail">/eform/partials/upload.jsp</result>

--- a/src/main/webapp/tickler/ticklerMain.jsp
+++ b/src/main/webapp/tickler/ticklerMain.jsp
@@ -261,7 +261,7 @@
                 var safeTableId = encodeURIComponent(tableId);
                 var href;
                 if (type === 'MDS') {
-                    href = "javascript:reportWindow('SegmentDisplay.jsp?segmentID=" + safeTableId +
+                    href = "javascript:reportWindow('" + ctx + "/oscarMDS/SegmentDisplay.jsp?segmentID=" + safeTableId +
                         "&providerNo=" + uNo + "&searchProviderNo=" + uNo + "&status=')";
                 } else if (type === 'CML') {
                     href = "javascript:reportWindow('" + ctx + "/lab/CA/ON/CMLDisplay.jsp?segmentID=" + safeTableId +

--- a/src/main/webapp/tickler/ticklerMain.jsp
+++ b/src/main/webapp/tickler/ticklerMain.jsp
@@ -36,6 +36,7 @@
 <%@ page import="ca.openosp.openo.commn.model.Site" %>
 <%@ page import="ca.openosp.openo.commn.dao.SiteDao" %>
 <%@ page import="java.util.*" %>
+<%@ page import="org.owasp.encoder.Encode" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
@@ -205,7 +206,7 @@
 
 
             const ctx = '${pageContext.request.contextPath}';
-            const userNo = '<%=user_no%>';
+            const userNo = '<%=Encode.forJavaScript(user_no)%>';
 
             function escapeHtml(text) {
                 if (!text) return '';
@@ -687,12 +688,12 @@
                     <div class="form-group">
                         <label for="xml_vdate">From</label>
                         <input type="date" class="form-control" name="xml_vdate" id="xml_vdate"
-                               value="<%=xml_vdate%>">
+                               value="<%=Encode.forHtmlAttribute(xml_vdate)%>">
                     </div>
                     <div class="form-group">
                         <label for="xml_appointment_date">To</label>
                         <input type="date" class="form-control" name="xml_appointment_date" id="xml_appointment_date"
-                               value="<%=xml_appointment_date%>">
+                               value="<%=Encode.forHtmlAttribute(xml_appointment_date)%>">
                     </div>
 
                     <div class="form-group">
@@ -704,8 +705,8 @@
                                 List<Provider> providers = providerDao.getActiveProviders();
                                 for (Provider p : providers) {
                             %>
-                            <option value="<%=p.getProviderNo()%>" <%=mrpview.equals(p.getProviderNo()) ? "selected" : ""%>><%=p.getLastName()%>
-                                ,<%=p.getFirstName()%>
+                            <option value="<%=Encode.forHtmlAttribute(p.getProviderNo())%>" <%=mrpview.equals(p.getProviderNo()) ? "selected" : ""%>><%=Encode.forHtml(p.getLastName())%>
+                                ,<%=Encode.forHtml(p.getFirstName())%>
                             </option>
                             <%
                                 }
@@ -720,8 +721,8 @@
                             <%
                                 for (Provider p : providers) {
                             %>
-                            <option value="<%=p.getProviderNo()%>" <%=providerview.equals(p.getProviderNo()) ? "selected" : ""%>><%=p.getLastName()%>
-                                ,<%=p.getFirstName()%>
+                            <option value="<%=Encode.forHtmlAttribute(p.getProviderNo())%>" <%=providerview.equals(p.getProviderNo()) ? "selected" : ""%>><%=Encode.forHtml(p.getLastName())%>
+                                ,<%=Encode.forHtml(p.getFirstName())%>
                             </option>
                             <%
                                 }
@@ -738,10 +739,10 @@
                         <script>
                             let _providers = [];
                             <%for (int i=0; i<sites.size(); i++) {%>
-                            _providers["<%=sites.get(i).getSiteId()%>"] = "<%Iterator<Provider> iter = sites.get(i).getProviders().iterator();
+                            _providers["<%=Encode.forJavaScript(sites.get(i).getSiteId().toString())%>"] = "<%Iterator<Provider> iter = sites.get(i).getProviders().iterator();
 							while (iter.hasNext()) {
 								Provider p=iter.next();
-								if ("1".equals(p.getStatus())) {%><option value='<%=p.getProviderNo()%>'><%=p.getLastName()%>, <%=p.getFirstName()%></option><%}%>";
+								if ("1".equals(p.getStatus())) {%><option value='<%=Encode.forJavaScript(p.getProviderNo())%>'><%=Encode.forJavaScript(p.getLastName())%>, <%=Encode.forJavaScript(p.getFirstName())%><\/option><%}%>";
                             <%}}%>
 
                             function changeSite(sel) {
@@ -753,7 +754,7 @@
                             <%
                                 for (int i = 0; i < sites.size(); i++) {
                             %>
-                            <option value="<%=sites.get(i).getSiteId()%>" <%=sites.get(i).getSiteId().toString().equals(request.getParameter("site")) ? "selected" : ""%>><%=sites.get(i).getName()%>
+                            <option value="<%=Encode.forHtmlAttribute(sites.get(i).getSiteId().toString())%>" <%=sites.get(i).getSiteId().toString().equals(request.getParameter("site")) ? "selected" : ""%>><%=Encode.forHtml(sites.get(i).getName())%>
                             </option>
                             <%
                                 }
@@ -765,7 +766,7 @@
                         %>
                         <script>
                             changeSite(document.getElementById("site"));
-                            document.getElementById("assignedTo").value = '<%=request.getParameter("assignedTo")%>';
+                            document.getElementById("assignedTo").value = '<%=Encode.forJavaScript(request.getParameter("assignedTo"))%>';
                         </script>
                         <%
                             }
@@ -786,8 +787,8 @@
                                 List<Provider> providersActive = providerDao.getActiveProviders();
                                 for (Provider p : providersActive) {
                             %>
-                            <option value="<%=p.getProviderNo()%>" <%=assignedTo.equals(p.getProviderNo()) ? "selected" : ""%>><%=p.getLastName()%>
-                                , <%=p.getFirstName()%>
+                            <option value="<%=Encode.forHtmlAttribute(p.getProviderNo())%>" <%=assignedTo.equals(p.getProviderNo()) ? "selected" : ""%>><%=Encode.forHtml(p.getLastName())%>
+                                , <%=Encode.forHtml(p.getFirstName())%>
                             </option>
                             <%
                                 }

--- a/src/main/webapp/tickler/ticklerMain.jsp
+++ b/src/main/webapp/tickler/ticklerMain.jsp
@@ -258,24 +258,25 @@
 
             function buildAttachmentLink(type, tableId) {
                 var uNo = encodeURIComponent(userNo);
+                var safeTableId = encodeURIComponent(tableId);
                 var href;
                 if (type === 'MDS') {
-                    href = "javascript:reportWindow('SegmentDisplay.jsp?segmentID=" + tableId +
+                    href = "javascript:reportWindow('SegmentDisplay.jsp?segmentID=" + safeTableId +
                         "&providerNo=" + uNo + "&searchProviderNo=" + uNo + "&status=')";
                 } else if (type === 'CML') {
-                    href = "javascript:reportWindow('" + ctx + "/lab/CA/ON/CMLDisplay.jsp?segmentID=" + tableId +
+                    href = "javascript:reportWindow('" + ctx + "/lab/CA/ON/CMLDisplay.jsp?segmentID=" + safeTableId +
                         "&providerNo=" + uNo + "&searchProviderNo=" + uNo + "&status=')";
                 } else if (type === 'HL7') {
-                    href = "javascript:reportWindow('" + ctx + "/lab/CA/ALL/labDisplay.jsp?segmentID=" + tableId +
+                    href = "javascript:reportWindow('" + ctx + "/lab/CA/ALL/labDisplay.jsp?segmentID=" + safeTableId +
                         "&providerNo=" + uNo + "&searchProviderNo=" + uNo + "&status=')";
                 } else if (type === 'DOC') {
-                    href = "javascript:reportWindow('" + ctx + "/documentManager/ManageDocument.do?method=display&doc_no=" + tableId +
+                    href = "javascript:reportWindow('" + ctx + "/documentManager/ManageDocument.do?method=display&doc_no=" + safeTableId +
                         "&providerNo=" + uNo + "&searchProviderNo=" + uNo + "&status=')";
                 } else if (type === 'HRM') {
-                    href = "javascript:reportWindow('" + ctx + "/hospitalReportManager/Display.do?id=" + tableId +
-                        "&segmentID=" + tableId + "')";
+                    href = "javascript:reportWindow('" + ctx + "/hospitalReportManager/Display.do?id=" + safeTableId +
+                        "&segmentID=" + safeTableId + "')";
                 } else {
-                    href = "javascript:reportWindow('" + ctx + "/lab/CA/BC/labDisplay.jsp?segmentID=" + tableId +
+                    href = "javascript:reportWindow('" + ctx + "/lab/CA/BC/labDisplay.jsp?segmentID=" + safeTableId +
                         "&providerNo=" + uNo + "&searchProviderNo=" + uNo + "&status=')";
                 }
                 return ' <a title="View attachment" href="' + href +
@@ -350,6 +351,8 @@
                         let api = this.api();
                         let rows = api.rows({page: 'current'}).nodes();
                         let numCols = jQuery('#ticklerResults thead th').length;
+
+                        jQuery('#ticklerResults tbody tr.comment-row').remove();
 
                         api.column(idColumn, {page: 'current'})
                             .data()
@@ -751,8 +754,8 @@
                             _providers["<%=Encode.forJavaScript(sites.get(i).getSiteId().toString())%>"] = "<%Iterator<Provider> iter = sites.get(i).getProviders().iterator();
 							while (iter.hasNext()) {
 								Provider p=iter.next();
-								if ("1".equals(p.getStatus())) {%><option value='<%=Encode.forJavaScript(p.getProviderNo())%>'><%=Encode.forJavaScript(p.getLastName())%>, <%=Encode.forJavaScript(p.getFirstName())%><\/option><%}%>";
-                            <%}}%>
+								if ("1".equals(p.getStatus())) {%><option value='<%=Encode.forJavaScript(Encode.forHtmlAttribute(p.getProviderNo()))%>'><%=Encode.forJavaScript(Encode.forHtml(p.getLastName()))%>, <%=Encode.forJavaScript(Encode.forHtml(p.getFirstName()))%><\/option><%}}%>";
+                            <%}%>
 
                             function changeSite(sel) {
                                 sel.form.assignedTo.innerHTML = sel.value == "none" ? "" : _providers[sel.value];

--- a/src/main/webapp/tickler/ticklerMain.jsp
+++ b/src/main/webapp/tickler/ticklerMain.jsp
@@ -685,7 +685,8 @@
                             href="javascript:void(0)" id="dateRange" onClick="allYear()"><fmt:setBundle basename="oscarResources"/><fmt:message key="tickler.ticklerMain.btnViewAll"/></a></label>
                     <div class="form-group">
                         <label for="xml_vdate">From</label>
-                        <input type="date" class="form-control" name="xml_vdate" id="xml_vdate">
+                        <input type="date" class="form-control" name="xml_vdate" id="xml_vdate"
+                               value="<%=xml_vdate%>">
                     </div>
                     <div class="form-group">
                         <label for="xml_appointment_date">To</label>

--- a/src/main/webapp/tickler/ticklerMain.jsp
+++ b/src/main/webapp/tickler/ticklerMain.jsp
@@ -24,12 +24,10 @@
 
 --%>
 <!DOCTYPE html>
-<%@page import="ca.openosp.openo.utility.LoggedInInfo" %>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
 
 <%@ page import="ca.openosp.openo.utility.SpringUtils" %>
 <%@ page import="ca.openosp.openo.commn.model.*" %>
-<%@ page import="ca.openosp.openo.lab.ca.on.*" %>
 <%@ page import="ca.openosp.openo.PMmodule.dao.ProviderDao" %>
 <%@ page import="ca.openosp.openo.commn.dao.ViewDao" %>
 <%@ page import="ca.openosp.openo.commn.model.View" %>
@@ -37,19 +35,7 @@
 <%@ page import="ca.openosp.OscarProperties" %>
 <%@ page import="ca.openosp.openo.commn.model.Site" %>
 <%@ page import="ca.openosp.openo.commn.dao.SiteDao" %>
-<%@ page import="ca.openosp.openo.commn.model.CustomFilter" %>
-<%@ page import="ca.openosp.openo.managers.TicklerManager" %>
-<%@ page import="ca.openosp.openo.tickler.dto.TicklerListDTO" %>
-<%@ page import="ca.openosp.openo.tickler.dto.TicklerCommentDTO" %>
-<%@ page import="ca.openosp.openo.tickler.dto.TicklerLinkDTO" %>
-<%@ page import="java.text.DateFormat" %>
-<%@ page import="java.text.SimpleDateFormat" %>
-<%@ page import="org.owasp.encoder.Encode" %>
 <%@ page import="java.util.*" %>
-<%@ page import="java.time.ZoneId" %>
-<%@ page import="java.time.LocalDateTime" %>
-<%@ page import="java.time.Duration" %>
-<%@ page import="ca.openosp.openo.lab.ca.on.LabResultData" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
@@ -69,7 +55,6 @@
     }
 %>
 <%!
-    TicklerManager ticklerManager = SpringUtils.getBean(TicklerManager.class);
     ViewDao viewDao = SpringUtils.getBean(ViewDao.class);
 %>
 
@@ -79,7 +64,6 @@
         labReqVer = "07";
     }
 
-    LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
     String user_no = (String) session.getAttribute("user");
     String createReport = request.getParameter("Submit");
     boolean doCreateReport = createReport != null && createReport.equals("Create Report");
@@ -221,6 +205,86 @@
 
 
             const ctx = '${pageContext.request.contextPath}';
+            const userNo = '<%=user_no%>';
+
+            function escapeHtml(text) {
+                if (!text) return '';
+                var div = document.createElement('div');
+                div.appendChild(document.createTextNode(text));
+                return div.innerHTML;
+            }
+
+            function renderCheckbox(data, type, row) {
+                if (row.rowType === 'comment') return '';
+                return '<input type="checkbox" name="checkbox" value="' + row.id + '" class="noprint">';
+            }
+
+            function renderEditIcon(data, type, row) {
+                if (row.rowType === 'comment') return '';
+                return '<a href="javascript:void(0)" title="Edit Tickler" ' +
+                    'onClick="window.open(\'' + ctx + '/tickler/ticklerEdit.jsp?tickler_no=' + row.id +
+                    '\', \'edit_tickler\', \'width=800, height=650\')">' +
+                    '<span class="glyphicon glyphicon-pencil"></span></a>';
+            }
+
+            function renderDemoName(data, type, row) {
+                var name = escapeHtml(row.demoLastName) + ',' + escapeHtml(row.demoFirstName);
+                if (row.rowType === 'comment') return name;
+                return '<a href="javascript:void(0)" ' +
+                    'onClick="popupPage(600,800,\'' + ctx +
+                    '/demographic/demographiccontrol.jsp?demographic_no=' +
+                    encodeURIComponent(row.demoNo) +
+                    '&displaymode=edit&dboperation=search_detail\')">' + name + '</a>';
+            }
+
+            function renderText(data) {
+                return escapeHtml(data);
+            }
+
+            function renderMessage(data, type, row) {
+                var html = '<span style="white-space:pre-wrap">' + escapeHtml(row.message) + '</span>';
+                if (row.rowType === 'tickler' && row.links) {
+                    for (var i = 0; i < row.links.length; i++) {
+                        html += buildAttachmentLink(row.links[i].tableName, row.links[i].tableId);
+                    }
+                }
+                return html;
+            }
+
+            function renderNoteIcon(data, type, row) {
+                if (row.rowType === 'comment') return '';
+                return '<a href="javascript:void(0)" class="noteDialogLink noprint" ' +
+                    'onClick="openNoteDialog(\'' + row.demoNo + '\',\'' + row.id + '\')" ' +
+                    'title="Add Encounter Note">' +
+                    '<span class="glyphicon glyphicon-comment"></span></a>';
+            }
+
+            function buildAttachmentLink(type, tableId) {
+                var uNo = encodeURIComponent(userNo);
+                var href;
+                if (type === 'MDS') {
+                    href = "javascript:reportWindow('SegmentDisplay.jsp?segmentID=" + tableId +
+                        "&providerNo=" + uNo + "&searchProviderNo=" + uNo + "&status=')";
+                } else if (type === 'CML') {
+                    href = "javascript:reportWindow('" + ctx + "/lab/CA/ON/CMLDisplay.jsp?segmentID=" + tableId +
+                        "&providerNo=" + uNo + "&searchProviderNo=" + uNo + "&status=')";
+                } else if (type === 'HL7') {
+                    href = "javascript:reportWindow('" + ctx + "/lab/CA/ALL/labDisplay.jsp?segmentID=" + tableId +
+                        "&providerNo=" + uNo + "&searchProviderNo=" + uNo + "&status=')";
+                } else if (type === 'DOC') {
+                    href = "javascript:reportWindow('" + ctx + "/documentManager/ManageDocument.do?method=display&doc_no=" + tableId +
+                        "&providerNo=" + uNo + "&searchProviderNo=" + uNo + "&status=')";
+                } else if (type === 'HRM') {
+                    href = "javascript:reportWindow('" + ctx + "/hospitalReportManager/Display.do?id=" + tableId +
+                        "&segmentID=" + tableId + "')";
+                } else {
+                    href = "javascript:reportWindow('" + ctx + "/lab/CA/BC/labDisplay.jsp?segmentID=" + tableId +
+                        "&providerNo=" + uNo + "&searchProviderNo=" + uNo + "&status=')";
+                }
+                return ' <a title="View attachment" href="' + href +
+                    '"><i class="glyphicon glyphicon-paperclip"></i></a>';
+            }
+
             let ticklerResultsTable;
             jQuery(document).ready(function () {
                 jQuery("#note-form").dialog({
@@ -241,45 +305,63 @@
                 //     }
                 // });
                 let groupColumn = 11;
+                let warningColumn = 12;
                 ticklerResultsTable = jQuery("#ticklerResults").dataTable({
-                    // cache the datatable state to persist through page refreshes
-                    bStateSave: true,
-                    fnStateSave: function (oSettings, oData) {
+                    "bStateSave": true,
+                    "fnStateSave": function (oSettings, oData) {
                         localStorage.setItem('ticklerDataTable', JSON.stringify(oData));
                     },
-                    fnStateLoad: function () {
+                    "fnStateLoad": function () {
                         return JSON.parse(localStorage.getItem('ticklerDataTable'));
                     },
                     "searching": false,
                     "aLengthMenu": [[25, 50, 75, -1], [25, 50, 75, "All"]],
                     "iDisplayLength": 50,
-                    columns: [
-                        {orderable: false}, //checkbox column, so shouldn't be orderable
-                        {orderable: false}, //edit icon column, so shouldn't be orderable
-                        {orderable: false}, //demographic name column. should not be made orderable until row group is refactored, otherwise tickler comments are not grouped properly
-                        {orderable: false}, //creator column. should not be made orderable until row group is refactored, otherwise tickler comments are not grouped properly
-                        {}, //service date column
-                        {orderable: false}, //update date column
-                        {}, //priority column
-                        {orderable: false}, //assigned to column. should not be made orderable until row group is refactored, otherwise tickler comments are not grouped properly
-                        {orderable: false}, //status column. should not be made orderable until row group is refactored, otherwise tickler comments are not grouped properly
-                        {orderable: false}, //comment column.
-                        {orderable: false}, //note icon column, so shouldn't be orderable
-                        {orderable: false} //hidden group id column, so shouldn't be orderable
+                    "serverSide": true,
+                    "ajax": {
+                        "url": ctx + "/tickler/ListTicklers.do",
+                        "data": function (d) {
+                            d.ticklerview = jQuery("#ticklerview").val();
+                            d.providerview = jQuery("#providerview").val() || "all";
+                            d.assignedTo = jQuery("#assignedTo").val() || "all";
+                            d.mrpview = jQuery("#mrpview").val() || "all";
+                            d.xml_vdate = jQuery("#xml_vdate").val() || "";
+                            d.xml_appointment_date = jQuery("#xml_appointment_date").val() || "";
+                            d.demographic_no = jQuery("input[name='demoview']").val() || "0";
+                        }
+                    },
+                    "columns": [
+                        {data: null, orderable: false, render: renderCheckbox},
+                        {data: null, orderable: false, render: renderEditIcon},
+                        {data: null, orderable: false, render: renderDemoName},
+                        {data: "creator", orderable: false, render: renderText},
+                        {data: "serviceDate", orderable: false},
+                        {data: "createDate", orderable: false},
+                        {data: "priority", orderable: false},
+                        {data: "assignee", orderable: false, render: renderText},
+                        {data: "status", orderable: false, render: renderText},
+                        {data: null, orderable: false, render: renderMessage},
+                        {data: null, orderable: false, render: renderNoteIcon},
+                        {data: "id", orderable: false},
+                        {data: "rowType", orderable: false}
                     ],
-                    columnDefs: [
-                        {visible: false, targets: groupColumn}
+                    "columnDefs": [
+                        {visible: false, targets: groupColumn},
+                        {visible: false, targets: warningColumn}
                     ],
-                    drawCallback: function (settings) {
+                    "createdRow": function (row, data, dataIndex) {
+                        if (data.warning === true) {
+                            jQuery(row).addClass('error');
+                        } else if (data.rowType === 'comment') {
+                            jQuery(row).addClass('followup-comment-' + data.id + ' comment-row no-sort');
+                        }
+                    },
+                    "drawCallback": function (settings) {
                         let api = this.api();
                         let rows = api.rows({page: 'current'}).nodes();
                         let last = null;
 
-                        api.column(groupColumn, {page: 'current'}) //TODO: this code reorders the rows on the current page, the global order based on the current sort.
-                            //      this means if a global sort is done that results in the tickler comments to NOT be on the current page
-                            //      they will not be visible.  A workaround has been implemented by adding the service date and priority
-                            //      into the tickler comment rows as well.  The datatables row group plugin might be a better approach,
-                            //      but will require refactoring of this code
+                        api.column(groupColumn, {page: 'current'})
                             .data()
                             .each(function (group, i) {
                                 if (last !== group) {
@@ -290,16 +372,14 @@
                                 }
                             });
                     },
-                    order: [[4, 'desc']]
-
+                    "order": [[4, 'desc']]
                 })
 
                 /*
-                 * Reload the search results with the Tickler status is changed.
+                 * Reload the search results when the Tickler status is changed.
                  */
                 jQuery("#ticklerview").change(function () {
-                    document.forms['serviceform'].Submit.value = 'Create Report';
-                    document.forms['serviceform'].submit();
+                    ticklerResultsTable.api().ajax.reload();
                 })
 
             });
@@ -741,6 +821,7 @@
                 </div>
 
             </c:if>
+            <c:if test="${not empty param.demoview}">
             <div class="pull-left" style="margin-bottom:10px;">
                 <label for="ticklerview">Filter</label>
                 <select id="ticklerview" class="form-control" name="ticklerview">
@@ -749,10 +830,10 @@
                     <option value="D" <%=ticklerview.equals("D") ? "selected" : ""%>><fmt:setBundle basename="oscarResources"/><fmt:message key="tickler.ticklerMain.formDeleted"/></option>
                 </select>
             </div>
+            </c:if>
         </form>
 
         <form name="ticklerform" method="post" action="dbTicklerMain.jsp">
-            <% Locale locale = request.getLocale();%>
             <input type="hidden" name="parentAjaxId" value="<c:out value='${param.parentAjaxId}' />"/>
             <table id="ticklerResults" class="table table-striped table-compact" style="width:100%">
                 <thead>
@@ -788,217 +869,10 @@
                     </th>
                     <th></th>
                     <th></th>
+                    <th></th>
                 </tr>
                 </thead>
                 <tbody>
-                <%
-                    String dateBegin = xml_vdate;
-                    String dateEnd = xml_appointment_date;
-
-                    String vGrantdate = "1980-01-07 00:00:00.0";
-                    DateFormat datetimeFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss", locale);
-                    DateFormat dateOnlyFormat = new SimpleDateFormat("yyyy-MM-dd", locale);
-                    DateFormat timeOnlyFormat = new SimpleDateFormat("HH:mm:ss", locale);
-
-                    if (dateEnd.compareTo("") == 0) {
-                        dateEnd = MyDateFormat.getMysqlStandardDate(curYear, curMonth, curDay);
-                    }
-
-                    if (dateBegin.compareTo("") == 0) {
-                        dateBegin = "1950-01-01"; // any early start date should suffice for selecting since the beginning
-                    }
-
-                    CustomFilter filter = new CustomFilter();
-                    filter.setPriority(null);
-
-                    filter.setStatus(ticklerview);
-
-                    filter.setStartDateWeb(dateBegin);
-                    filter.setEndDateWeb(dateEnd);
-                    filter.setPriority(null);
-
-                    if (!mrpview.isEmpty() && !mrpview.equals("all")) {
-                        filter.setMrp(mrpview);
-                    }
-
-                    if (!providerview.isEmpty() && !providerview.equals("all")) {
-                        filter.setProvider(providerview);
-                    }
-
-                    if (!assignedTo.isEmpty() && !assignedTo.equals("all")) {
-                        filter.setAssignee(assignedTo);
-                    }
-
-                    filter.setSort_order("desc");
-
-                    int targetDemographic = Integer.parseInt(demographic_no);
-                    if (targetDemographic > 0) {
-                        filter.setDemographicNo(String.valueOf(targetDemographic));
-                        // Preserve old search_tickler_bydemo behavior: when viewing a specific
-                        // demographic's ticklers, only filter by demographic, status, and date range
-                        filter.setMrp(null);
-                        filter.setProvider(null);
-                        filter.setAssignee(null);
-                        filter.setPriority(null);
-                        filter.setProgramId(null);
-                        filter.setMessage(null);
-                        filter.setClient(null);
-                    }
-
-                    // Use DTO projection for optimized list view (reduces queries from ~25 to 3)
-                    List<TicklerListDTO> ticklers = ticklerManager.getTicklerDTOs(loggedInInfo, filter);
-
-                    String numDaysUntilWarn = OscarProperties.getInstance().getProperty("tickler_warn_period");
-                    if (numDaysUntilWarn == null || numDaysUntilWarn.isEmpty()) {
-                        numDaysUntilWarn = "0";
-                    }
-
-                    // Single rendering path using DTOs
-                    for (TicklerListDTO tickler : ticklers) {
-                            LocalDateTime serviceDate = tickler.getServiceDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime();
-                            LocalDateTime currentDate = LocalDateTime.now();
-
-                            long daysDifference = Duration.between(serviceDate, currentDate).toDays();
-                            long ticklerWarnDays = Long.parseLong(numDaysUntilWarn);
-                            boolean ignoreWarning = (ticklerWarnDays <= 0);
-                            boolean warning = false;
-
-                            String warnColour = "";
-                            if (!ignoreWarning && (daysDifference >= ticklerWarnDays)) {
-                                warnColour = "Red";
-                                warning = true;
-                            }
-
-                            String cellColour = warnColour;
-                %>
-
-                <tr <%=warning ? "class='error'" : ""%> >
-                    <td class="<%=cellColour%>"><input type="checkbox" name="checkbox" value="<%=tickler.getId()%>"
-                                                       class="noprint"></td>
-                    <td class="<%=cellColour%>">
-                        <a href="javascript:void(0)" title="<fmt:setBundle basename="oscarResources"/><fmt:message key="tickler.ticklerMain.editTickler"/>"
-                           onClick="window.open('<%= request.getContextPath() %>/tickler/ticklerEdit.jsp?tickler_no=<%=tickler.getId()%>', 'edit_tickler', 'width=800, height=650')">
-                            <span class="glyphicon glyphicon-pencil"></span>
-                        </a>
-                    </td>
-                    <td class="<%=cellColour%>"><a href="javascript:void(0)"
-                                                   onClick="popupPage(600,800,'<%= request.getContextPath() %>/demographic/demographiccontrol.jsp?demographic_no=<%=Encode.forUriComponent(String.valueOf(tickler.getDemographicNo()))%>&displaymode=edit&dboperation=search_detail')">
-                        <%=Encode.forHtmlContent(tickler.getDemographicLastName())%>,<%=Encode.forHtmlContent(tickler.getDemographicFirstName())%>
-                    </a></td>
-                    <td class="<%=cellColour%>"><%=Encode.forHtmlContent(tickler.getCreatorFormattedName())%>
-                    </td>
-                    <td class="<%=cellColour%>"><%=dateOnlyFormat.format(tickler.getServiceDate())%>
-                    </td>
-                    <td class="<%=cellColour%>"><%=datetimeFormat.format(tickler.getCreateDate())%>
-                    </td>
-                    <td class="<%=cellColour%>"><%=tickler.getPriority()%>
-                    </td>
-                    <td class="<%=cellColour%>"><%=Encode.forHtmlContent(tickler.getAssigneeFormattedName())%>
-                    </td>
-                    <td class="<%=cellColour%>"><%=tickler.getStatusDesc(locale)%>
-                    </td>
-                    <td class="<%=cellColour%>"><span
-                            style="white-space:pre-wrap"><%=Encode.forHtmlContent(tickler.getMessage())%></span>
-
-                        <%
-                            List<TicklerLinkDTO> linkList = tickler.getLinks();
-                            if (linkList != null) {
-                                for (TicklerLinkDTO tl : linkList) {
-                                    String type = tl.getTableName();
-                        %>
-
-                        <%
-                            if (LabResultData.isMDS(type)) {
-                        %>
-                        <a title="View attachment"
-                           href="javascript:reportWindow('SegmentDisplay.jsp?segmentID=<%=tl.getTableId()%>&providerNo=<%=user_no%>&searchProviderNo=<%=user_no%>&status=')"><i
-                                class="glyphicon glyphicon-paperclip"></i></a>
-                        <%
-                        } else if (LabResultData.isCML(type)) {
-                        %>
-                        <a title="View attachment"
-                           href="javascript:reportWindow('<%= request.getContextPath() %>/lab/CA/ON/CMLDisplay.jsp?segmentID=<%=tl.getTableId()%>&providerNo=<%=user_no%>&searchProviderNo=<%=user_no%>&status=')"><i
-                                class="glyphicon glyphicon-paperclip"></i></a>
-                        <%
-                        } else if (LabResultData.isHL7TEXT(type)) {
-                        %>
-                        <a title="View attachment"
-                           href="javascript:reportWindow('<%= request.getContextPath() %>/lab/CA/ALL/labDisplay.jsp?segmentID=<%=tl.getTableId()%>&providerNo=<%=user_no%>&searchProviderNo=<%=user_no%>&status=')"><i
-                                class="glyphicon glyphicon-paperclip"></i></a>
-                        <%
-                        } else if (LabResultData.isDocument(type)) {
-                        %>
-                        <a title="View attachment"
-                           href="javascript:reportWindow('<%=request.getContextPath()%>/documentManager/ManageDocument.do?method=display&doc_no=<%=tl.getTableId()%>&providerNo=<%=user_no%>&searchProviderNo=<%=user_no%>&status=')"><i
-                                class="glyphicon glyphicon-paperclip"></i></a>
-                        <%
-                        } else if (LabResultData.isHRM(type)) {
-                        %>
-                        <a title="View attachment"
-                           href="javascript:reportWindow('<%=request.getContextPath()%>/hospitalReportManager/Display.do?id=<%=tl.getTableId()%>&segmentID=<%=tl.getTableId()%>')"><i
-                                class="glyphicon glyphicon-paperclip"></i></a>
-                        <%
-                        } else {
-                        %>
-                        <a title="View attachment"
-                           href="javascript:reportWindow('<%= request.getContextPath() %>/lab/CA/BC/labDisplay.jsp?segmentID=<%=tl.getTableId()%>&providerNo=<%=user_no%>&searchProviderNo=<%=user_no%>&status=')"><i
-                                class="glyphicon glyphicon-paperclip"></i></a>
-                        <%
-                            }
-                        %>
-                        <%
-                                }
-                            }
-                        %>
-
-                    </td>
-                    <td class="<%=cellColour%> noprint">
-                        <a href="javascript:void(0)" class="noteDialogLink"
-                           onClick="openNoteDialog('<%=Encode.forJavaScriptAttribute(String.valueOf(tickler.getDemographicNo()))%>','<%=Encode.forJavaScriptAttribute(String.valueOf(tickler.getId()))%>')"
-                           title="Add Encounter Note">
-                            <span class="glyphicon glyphicon-comment"></span>
-                        </a>
-                    </td>
-                    <td><%=tickler.getId()%>
-                    </td>
-                </tr>
-                <% List<TicklerCommentDTO> tcomments = tickler.getComments();
-                    for (TicklerCommentDTO tc : tcomments) {
-                        String formattedName = tc.getProviderFormattedName();
-                %>
-
-
-                <tr class="followup-comment-<%=tickler.getId()%> comment-row no-sort">
-                    <td></td>
-                    <td></td>
-                    <td><%=Encode.forHtmlContent(tickler.getDemographicLastName())%>,<%=Encode.forHtmlContent(tickler.getDemographicFirstName())%>
-                    </td>
-                    <td class="no-sort"><%=Encode.forHtmlContent(formattedName)%>
-                    </td>
-                    <td><%=dateOnlyFormat.format(tickler.getServiceDate())%>
-                    </td>
-
-                    <td class="no-sort">
-                        <% if (tc.isUpdateDateToday()) { %>
-                        <%=timeOnlyFormat.format(tc.getUpdateDate())%>
-                        <% } else { %>
-                        <%=datetimeFormat.format(tc.getUpdateDate())%>
-                        <% } %>
-                    </td>
-
-                    <td><%=tickler.getPriority()%>
-                    </td>
-                    <td></td>
-                    <td></td>
-                    <td class="no-sort" style="white-space:pre-wrap"><%=Encode.forHtmlContent(tc.getMessage())%>
-                    </td>
-                    <td></td>
-                    <td><%=tickler.getId()%>
-                    </td>
-                </tr>
-                <% }
-                }
-                %>
                 </tbody>
             </table>
 

--- a/src/main/webapp/tickler/ticklerMain.jsp
+++ b/src/main/webapp/tickler/ticklerMain.jsp
@@ -306,7 +306,7 @@
                 //     }
                 // });
                 let groupColumn = 11;
-                let warningColumn = 12;
+                let rowTypeColumn = 12;
                 ticklerResultsTable = jQuery("#ticklerResults").dataTable({
                     "searching": false,
                     "aLengthMenu": [[25, 50, 75, -1], [25, 50, 75, "All"]],
@@ -341,7 +341,7 @@
                     ],
                     "columnDefs": [
                         {visible: false, targets: groupColumn},
-                        {visible: false, targets: warningColumn}
+                        {visible: false, targets: rowTypeColumn}
                     ],
                     "createdRow": function (row, data, dataIndex) {
                         if (data.warning === true) {
@@ -366,7 +366,7 @@
                                 }
                             });
                     },
-                    "order": JSON.parse(localStorage.getItem('ticklerSortOrder')) || [[4, 'desc']]
+                    "order": (function() { try { return JSON.parse(localStorage.getItem('ticklerSortOrder')) || [[4, 'desc']]; } catch(e) { return [[4, 'desc']]; } })()
                 })
 
                 ticklerResultsTable.api().on('length.dt', function (e, settings, len) {

--- a/src/main/webapp/tickler/ticklerMain.jsp
+++ b/src/main/webapp/tickler/ticklerMain.jsp
@@ -216,12 +216,10 @@
             }
 
             function renderCheckbox(data, type, row) {
-                if (row.rowType === 'comment') return '';
                 return '<input type="checkbox" name="checkbox" value="' + row.id + '" class="noprint">';
             }
 
             function renderEditIcon(data, type, row) {
-                if (row.rowType === 'comment') return '';
                 return '<a href="javascript:void(0)" title="Edit Tickler" ' +
                     'onClick="window.open(\'' + ctx + '/tickler/ticklerEdit.jsp?tickler_no=' + row.id +
                     '\', \'edit_tickler\', \'width=800, height=650\')">' +
@@ -230,7 +228,6 @@
 
             function renderDemoName(data, type, row) {
                 var name = escapeHtml(row.demoLastName) + ',' + escapeHtml(row.demoFirstName);
-                if (row.rowType === 'comment') return name;
                 return '<a href="javascript:void(0)" ' +
                     'onClick="popupPage(600,800,\'' + ctx +
                     '/demographic/demographiccontrol.jsp?demographic_no=' +
@@ -244,7 +241,7 @@
 
             function renderMessage(data, type, row) {
                 var html = '<span style="white-space:pre-wrap">' + escapeHtml(row.message) + '</span>';
-                if (row.rowType === 'tickler' && row.links) {
+                if (row.links) {
                     for (var i = 0; i < row.links.length; i++) {
                         html += buildAttachmentLink(row.links[i].tableName, row.links[i].tableId);
                     }
@@ -253,7 +250,6 @@
             }
 
             function renderNoteIcon(data, type, row) {
-                if (row.rowType === 'comment') return '';
                 return '<a href="javascript:void(0)" class="noteDialogLink noprint" ' +
                     'onClick="openNoteDialog(\'' + row.demoNo + '\',\'' + row.id + '\')" ' +
                     'title="Add Encounter Note">' +
@@ -305,8 +301,8 @@
                 //
                 //     }
                 // });
-                let groupColumn = 11;
-                let rowTypeColumn = 12;
+                let idColumn = 11;
+                let lastComments = {};
                 ticklerResultsTable = jQuery("#ticklerResults").dataTable({
                     "searching": false,
                     "aLengthMenu": [[25, 50, 75, -1], [25, 50, 75, "All"]],
@@ -322,6 +318,10 @@
                             d.xml_vdate = jQuery("#xml_vdate").val() || "";
                             d.xml_appointment_date = jQuery("#xml_appointment_date").val() || "";
                             d.demographic_no = jQuery("input[name='demoview']").val() || "0";
+                        },
+                        "dataSrc": function (json) {
+                            lastComments = json.comments || {};
+                            return json.data;
                         }
                     },
                     "columns": [
@@ -336,33 +336,42 @@
                         {data: "status", orderable: false, render: renderText},
                         {data: null, orderable: false, render: renderMessage},
                         {data: null, orderable: false, render: renderNoteIcon},
-                        {data: "id", orderable: false},
-                        {data: "rowType", orderable: false}
+                        {data: "id", orderable: false}
                     ],
                     "columnDefs": [
-                        {visible: false, targets: groupColumn},
-                        {visible: false, targets: rowTypeColumn}
+                        {visible: false, targets: idColumn}
                     ],
                     "createdRow": function (row, data, dataIndex) {
                         if (data.warning === true) {
                             jQuery(row).addClass('error');
-                        } else if (data.rowType === 'comment') {
-                            jQuery(row).addClass('followup-comment-' + data.id + ' comment-row no-sort');
                         }
                     },
                     "drawCallback": function (settings) {
                         let api = this.api();
                         let rows = api.rows({page: 'current'}).nodes();
-                        let last = null;
+                        let numCols = jQuery('#ticklerResults thead th').length;
 
-                        api.column(groupColumn, {page: 'current'})
+                        api.column(idColumn, {page: 'current'})
                             .data()
-                            .each(function (group, i) {
-                                if (last !== group) {
-                                    jQuery(rows)
-                                        .eq(i)
-                                        .after(jQuery(".followup-comment-" + group))
-                                    last = group;
+                            .each(function (ticklerId, i) {
+                                let comments = lastComments[String(ticklerId)];
+                                if (comments) {
+                                    for (var c = comments.length - 1; c >= 0; c--) {
+                                        var tc = comments[c];
+                                        var commentTr = jQuery('<tr class="comment-row no-sort"></tr>');
+                                        commentTr.append('<td></td>');
+                                        commentTr.append('<td></td>');
+                                        commentTr.append('<td>' + escapeHtml(api.row(i).data().demoLastName) + ',' + escapeHtml(api.row(i).data().demoFirstName) + '</td>');
+                                        commentTr.append('<td>' + escapeHtml(tc.creator) + '</td>');
+                                        commentTr.append('<td>' + escapeHtml(api.row(i).data().serviceDate) + '</td>');
+                                        commentTr.append('<td>' + escapeHtml(tc.createDate) + '</td>');
+                                        commentTr.append('<td>' + escapeHtml(api.row(i).data().priority) + '</td>');
+                                        commentTr.append('<td></td>');
+                                        commentTr.append('<td></td>');
+                                        commentTr.append('<td style="white-space:pre-wrap">' + escapeHtml(tc.message) + '</td>');
+                                        commentTr.append('<td></td>');
+                                        jQuery(rows).eq(i).after(commentTr);
+                                    }
                                 }
                             });
                     },
@@ -870,7 +879,6 @@
                     <th>
                         <fmt:setBundle basename="oscarResources"/><fmt:message key="tickler.ticklerMain.msgMessage"/>
                     </th>
-                    <th></th>
                     <th></th>
                     <th></th>
                 </tr>

--- a/src/main/webapp/tickler/ticklerMain.jsp
+++ b/src/main/webapp/tickler/ticklerMain.jsp
@@ -307,16 +307,9 @@
                 let groupColumn = 11;
                 let warningColumn = 12;
                 ticklerResultsTable = jQuery("#ticklerResults").dataTable({
-                    "bStateSave": true,
-                    "fnStateSave": function (oSettings, oData) {
-                        localStorage.setItem('ticklerDataTable', JSON.stringify(oData));
-                    },
-                    "fnStateLoad": function () {
-                        return JSON.parse(localStorage.getItem('ticklerDataTable'));
-                    },
                     "searching": false,
                     "aLengthMenu": [[25, 50, 75, -1], [25, 50, 75, "All"]],
-                    "iDisplayLength": 50,
+                    "iDisplayLength": parseInt(localStorage.getItem('ticklerPageLength')) || 50,
                     "serverSide": true,
                     "ajax": {
                         "url": ctx + "/tickler/ListTicklers.do",
@@ -335,7 +328,7 @@
                         {data: null, orderable: false, render: renderEditIcon},
                         {data: null, orderable: false, render: renderDemoName},
                         {data: "creator", orderable: false, render: renderText},
-                        {data: "serviceDate", orderable: false},
+                        {data: "serviceDate"},
                         {data: "createDate", orderable: false},
                         {data: "priority", orderable: false},
                         {data: "assignee", orderable: false, render: renderText},
@@ -372,8 +365,16 @@
                                 }
                             });
                     },
-                    "order": [[4, 'desc']]
+                    "order": JSON.parse(localStorage.getItem('ticklerSortOrder')) || [[4, 'desc']]
                 })
+
+                ticklerResultsTable.api().on('length.dt', function (e, settings, len) {
+                    localStorage.setItem('ticklerPageLength', len);
+                });
+
+                ticklerResultsTable.api().on('order.dt', function () {
+                    localStorage.setItem('ticklerSortOrder', JSON.stringify(ticklerResultsTable.api().order()));
+                });
 
                 /*
                  * Reload the search results when the Tickler status is changed.

--- a/src/test-modern/java/ca/openosp/openo/tickler/web/TicklerList2ActionTest.java
+++ b/src/test-modern/java/ca/openosp/openo/tickler/web/TicklerList2ActionTest.java
@@ -1,20 +1,3 @@
-/**
- * Copyright (c) 2026. Magenta Health. All Rights Reserved.
- * This software is published under the GPL GNU General Public License.
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
- * <p>
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- * <p>
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
- */
 package ca.openosp.openo.tickler.web;
 
 import ca.openosp.openo.commn.model.CustomFilter;

--- a/src/test-modern/java/ca/openosp/openo/tickler/web/TicklerList2ActionTest.java
+++ b/src/test-modern/java/ca/openosp/openo/tickler/web/TicklerList2ActionTest.java
@@ -1,0 +1,500 @@
+/**
+ * Copyright (c) 2026. Magenta Health. All Rights Reserved.
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
+package ca.openosp.openo.tickler.web;
+
+import ca.openosp.openo.commn.model.CustomFilter;
+import ca.openosp.openo.commn.model.Tickler;
+import ca.openosp.openo.managers.SecurityInfoManager;
+import ca.openosp.openo.managers.TicklerManager;
+import ca.openosp.openo.test.base.OpenOWebTestBase;
+import ca.openosp.openo.tickler.dto.TicklerCommentDTO;
+import ca.openosp.openo.tickler.dto.TicklerLinkDTO;
+import ca.openosp.openo.tickler.dto.TicklerListDTO;
+import ca.openosp.openo.tickler.pageUtil.TicklerList2Action;
+import ca.openosp.openo.utility.LoggedInInfo;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.*;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+
+/**
+ * Web layer tests for {@link TicklerList2Action}.
+ *
+ * <p>Validates the DataTables server-side JSON endpoint including privilege
+ * enforcement, paging inputs, filter parameters, and JSON response shape.
+ *
+ * @since 2026-02-06
+ */
+@DisplayName("TicklerList2Action Web Layer Tests")
+@Tag("web")
+class TicklerList2ActionTest extends OpenOWebTestBase {
+
+    @Mock
+    private TicklerManager mockTicklerManager;
+
+    private TicklerList2Action action;
+
+    private static final ObjectMapper mapper = new ObjectMapper();
+    private static final String TEST_PROVIDER = "999998";
+
+    @BeforeEach
+    void setUp() throws Exception {
+        MockitoAnnotations.openMocks(this);
+
+        replaceSpringUtilsBean(TicklerManager.class, mockTicklerManager);
+        replaceSpringUtilsBean(SecurityInfoManager.class, mockSecurityInfoManager);
+
+        when(mockLoggedInInfo.getLoggedInProviderNo()).thenReturn(TEST_PROVIDER);
+        setSessionAttribute("user", TEST_PROVIDER);
+        String loggedInInfoKey = LoggedInInfo.class.getName() + ".LOGGED_IN_INFO_KEY";
+        setSessionAttribute(loggedInInfoKey, mockLoggedInInfo);
+
+        // Default: return empty results
+        when(mockTicklerManager.getNumTicklers(any(LoggedInInfo.class), any(CustomFilter.class)))
+                .thenReturn(0);
+        when(mockTicklerManager.getTicklerDTOs(any(LoggedInInfo.class), any(CustomFilter.class), anyInt(), anyInt()))
+                .thenReturn(Collections.emptyList());
+        when(mockTicklerManager.getTicklerDTOs(any(LoggedInInfo.class), any(CustomFilter.class)))
+                .thenReturn(Collections.emptyList());
+
+        action = new TicklerList2Action();
+        injectField("ticklerManager", mockTicklerManager);
+        injectField("securityInfoManager", mockSecurityInfoManager);
+    }
+
+    // ── Privilege Enforcement ──────────────────────────────────────────
+
+    @Test
+    @DisplayName("Should return 403 JSON error when _tickler read privilege denied")
+    void shouldReturn403_whenPrivilegeDenied() throws Exception {
+        denyPrivilege("_tickler", "r");
+
+        executeAction(action);
+
+        assertThat(getMockResponse().getStatus()).isEqualTo(403);
+        JsonNode json = parseResponse();
+        assertThat(json.get("error").asText()).isEqualTo("Access denied");
+        verifySecurityCheck("_tickler", "r");
+    }
+
+    @Test
+    @DisplayName("Should return JSON when _tickler read privilege allowed")
+    void shouldReturnJson_whenPrivilegeAllowed() throws Exception {
+        allowPrivilege("_tickler", "r");
+
+        executeAction(action);
+
+        assertThat(getMockResponse().getContentType()).contains("application/json");
+    }
+
+    // ── JSON Response Shape ────────────────────────────────────────────
+
+    @Test
+    @DisplayName("Should return correct top-level JSON structure")
+    void shouldReturnCorrectJsonStructure_whenEmptyResults() throws Exception {
+        allowPrivilege("_tickler", "r");
+        addRequestParameter("draw", "3");
+
+        executeAction(action);
+
+        JsonNode json = parseResponse();
+        assertThat(json.get("draw").asInt()).isEqualTo(3);
+        assertThat(json.get("recordsTotal").asInt()).isEqualTo(0);
+        assertThat(json.get("recordsFiltered").asInt()).isEqualTo(0);
+        assertThat(json.get("data").isArray()).isTrue();
+        assertThat(json.get("data").size()).isZero();
+        assertThat(json.has("comments")).isTrue();
+    }
+
+    @Test
+    @DisplayName("Should include all required fields in data rows")
+    void shouldIncludeAllFields_whenTicklerReturned() throws Exception {
+        allowPrivilege("_tickler", "r");
+
+        TicklerListDTO dto = createTestTickler(1, "Follow up on labs");
+        stubPaginatedResults(1, List.of(dto));
+
+        executeAction(action);
+
+        JsonNode row = parseResponse().get("data").get(0);
+        assertThat(row.get("id").asInt()).isEqualTo(1);
+        assertThat(row.get("demoNo").asInt()).isEqualTo(1001);
+        assertThat(row.get("demoLastName").asText()).isEqualTo("Smith");
+        assertThat(row.get("demoFirstName").asText()).isEqualTo("John");
+        assertThat(row.get("creator").asText()).isEqualTo("Doctor, Jane");
+        assertThat(row.get("serviceDate").asText()).isNotEmpty();
+        assertThat(row.get("createDate").asText()).isNotEmpty();
+        assertThat(row.get("priority").asText()).isEqualTo("Normal");
+        assertThat(row.get("assignee").asText()).isEqualTo("Nurse, Bob");
+        assertThat(row.get("status").asText()).isNotEmpty();
+        assertThat(row.get("message").asText()).isEqualTo("Follow up on labs");
+        assertThat(row.has("warning")).isTrue();
+        assertThat(row.get("links").isArray()).isTrue();
+    }
+
+    @Test
+    @DisplayName("Should set recordsTotal and recordsFiltered to total count")
+    void shouldSetRecordCounts_whenResultsExist() throws Exception {
+        allowPrivilege("_tickler", "r");
+
+        stubPaginatedResults(42, List.of(createTestTickler(1, "test")));
+        addRequestParameter("draw", "5");
+
+        executeAction(action);
+
+        JsonNode json = parseResponse();
+        assertThat(json.get("recordsTotal").asInt()).isEqualTo(42);
+        assertThat(json.get("recordsFiltered").asInt()).isEqualTo(42);
+        assertThat(json.get("draw").asInt()).isEqualTo(5);
+    }
+
+    // ── Comments in Response ───────────────────────────────────────────
+
+    @Test
+    @DisplayName("Should include comments as separate map keyed by tickler ID")
+    void shouldIncludeCommentsMap_whenTicklerHasComments() throws Exception {
+        allowPrivilege("_tickler", "r");
+
+        TicklerListDTO dto = createTestTickler(10, "Needs review");
+        TicklerCommentDTO comment = new TicklerCommentDTO(
+                100, 10, "Reviewed by specialist", new Date(1700000000000L), "Specialist", "Alice");
+        dto.setComments(List.of(comment));
+        stubPaginatedResults(1, List.of(dto));
+
+        executeAction(action);
+
+        JsonNode json = parseResponse();
+        JsonNode comments = json.get("comments");
+        assertThat(comments.has("10")).isTrue();
+
+        JsonNode commentArray = comments.get("10");
+        assertThat(commentArray.isArray()).isTrue();
+        assertThat(commentArray.size()).isEqualTo(1);
+        assertThat(commentArray.get(0).get("creator").asText()).isEqualTo("Specialist, Alice");
+        assertThat(commentArray.get(0).get("message").asText()).isEqualTo("Reviewed by specialist");
+        assertThat(commentArray.get(0).has("createDate")).isTrue();
+    }
+
+    @Test
+    @DisplayName("Should omit tickler from comments map when it has no comments")
+    void shouldOmitFromCommentsMap_whenNoComments() throws Exception {
+        allowPrivilege("_tickler", "r");
+
+        TicklerListDTO dto = createTestTickler(20, "No comments here");
+        dto.setComments(Collections.emptyList());
+        stubPaginatedResults(1, List.of(dto));
+
+        executeAction(action);
+
+        JsonNode comments = parseResponse().get("comments");
+        assertThat(comments.has("20")).isFalse();
+    }
+
+    // ── Links in Response ──────────────────────────────────────────────
+
+    @Test
+    @DisplayName("Should include links array in data rows")
+    void shouldIncludeLinks_whenTicklerHasLinks() throws Exception {
+        allowPrivilege("_tickler", "r");
+
+        TicklerListDTO dto = createTestTickler(5, "Lab attached");
+        dto.setLinks(List.of(new TicklerLinkDTO(1, 5, "HL7", 999L)));
+        stubPaginatedResults(1, List.of(dto));
+
+        executeAction(action);
+
+        JsonNode links = parseResponse().get("data").get(0).get("links");
+        assertThat(links.size()).isEqualTo(1);
+        assertThat(links.get(0).get("tableName").asText()).isEqualTo("HL7");
+        assertThat(links.get(0).get("tableId").asLong()).isEqualTo(999L);
+    }
+
+    // ── Paging Parameters ──────────────────────────────────────────────
+
+    @Test
+    @DisplayName("Should pass start and length to TicklerManager for pagination")
+    void shouldPassPagingParams_whenProvided() throws Exception {
+        allowPrivilege("_tickler", "r");
+
+        addRequestParameter("start", "25");
+        addRequestParameter("length", "50");
+
+        executeAction(action);
+
+        verify(mockTicklerManager).getTicklerDTOs(
+                any(LoggedInInfo.class), any(CustomFilter.class), eq(25), eq(50));
+    }
+
+    @Test
+    @DisplayName("Should default to start=0 and length=50")
+    void shouldUseDefaults_whenPagingParamsMissing() throws Exception {
+        allowPrivilege("_tickler", "r");
+
+        executeAction(action);
+
+        verify(mockTicklerManager).getTicklerDTOs(
+                any(LoggedInInfo.class), any(CustomFilter.class), eq(0), eq(50));
+    }
+
+    @Test
+    @DisplayName("Should clamp negative start to zero")
+    void shouldClampStart_whenNegative() throws Exception {
+        allowPrivilege("_tickler", "r");
+
+        addRequestParameter("start", "-10");
+
+        executeAction(action);
+
+        verify(mockTicklerManager).getTicklerDTOs(
+                any(LoggedInInfo.class), any(CustomFilter.class), eq(0), anyInt());
+    }
+
+    @Test
+    @DisplayName("Should cap length at 500")
+    void shouldCapLength_whenExceedsMax() throws Exception {
+        allowPrivilege("_tickler", "r");
+
+        addRequestParameter("length", "1000");
+
+        executeAction(action);
+
+        verify(mockTicklerManager).getTicklerDTOs(
+                any(LoggedInInfo.class), any(CustomFilter.class), anyInt(), eq(500));
+    }
+
+    @Test
+    @DisplayName("Should use paginated overload with totalRecords as limit when length is -1")
+    void shouldShowAll_whenLengthIsNegative() throws Exception {
+        allowPrivilege("_tickler", "r");
+
+        when(mockTicklerManager.getNumTicklers(any(LoggedInInfo.class), any(CustomFilter.class)))
+                .thenReturn(150);
+        addRequestParameter("length", "-1");
+
+        executeAction(action);
+
+        verify(mockTicklerManager).getTicklerDTOs(
+                any(LoggedInInfo.class), any(CustomFilter.class), eq(0), eq(150));
+    }
+
+    @Test
+    @DisplayName("Should default draw to 1 when not provided")
+    void shouldDefaultDraw_whenMissing() throws Exception {
+        allowPrivilege("_tickler", "r");
+
+        executeAction(action);
+
+        JsonNode json = parseResponse();
+        assertThat(json.get("draw").asInt()).isEqualTo(1);
+    }
+
+    // ── Filter Parameters ──────────────────────────────────────────────
+
+    @Test
+    @DisplayName("Should pass ticklerview status to filter")
+    void shouldPassStatus_whenTicklerviewProvided() throws Exception {
+        allowPrivilege("_tickler", "r");
+
+        addRequestParameter("ticklerview", "C");
+
+        executeAction(action);
+
+        ArgumentCaptor<CustomFilter> captor = ArgumentCaptor.forClass(CustomFilter.class);
+        verify(mockTicklerManager).getNumTicklers(any(LoggedInInfo.class), captor.capture());
+        assertThat(captor.getValue().getStatus()).isEqualTo("C");
+    }
+
+    @Test
+    @DisplayName("Should default ticklerview to Active")
+    void shouldDefaultToActive_whenTicklerviewMissing() throws Exception {
+        allowPrivilege("_tickler", "r");
+
+        executeAction(action);
+
+        ArgumentCaptor<CustomFilter> captor = ArgumentCaptor.forClass(CustomFilter.class);
+        verify(mockTicklerManager).getNumTicklers(any(LoggedInInfo.class), captor.capture());
+        assertThat(captor.getValue().getStatus()).isEqualTo("A");
+    }
+
+    @ParameterizedTest
+    @DisplayName("Should pass sort direction to filter")
+    @CsvSource({"asc, asc", "desc, desc", "invalid, desc", "'', desc"})
+    void shouldPassSortDirection_whenOrderDirProvided(String input, String expected) throws Exception {
+        allowPrivilege("_tickler", "r");
+
+        if (input != null && !input.isEmpty()) {
+            addRequestParameter("order[0][dir]", input);
+        }
+
+        executeAction(action);
+
+        ArgumentCaptor<CustomFilter> captor = ArgumentCaptor.forClass(CustomFilter.class);
+        verify(mockTicklerManager).getNumTicklers(any(LoggedInInfo.class), captor.capture());
+        assertThat(captor.getValue().getSort_order()).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("Should clear provider filters when demographic_no is set")
+    void shouldClearProviderFilters_whenDemographicSpecified() throws Exception {
+        allowPrivilege("_tickler", "r");
+
+        addRequestParameter("demographic_no", "1001");
+        addRequestParameter("providerview", "999998");
+        addRequestParameter("assignedTo", "999999");
+        addRequestParameter("mrpview", "999997");
+
+        executeAction(action);
+
+        ArgumentCaptor<CustomFilter> captor = ArgumentCaptor.forClass(CustomFilter.class);
+        verify(mockTicklerManager).getNumTicklers(any(LoggedInInfo.class), captor.capture());
+        CustomFilter filter = captor.getValue();
+        assertThat(filter.getDemographicNo()).isEqualTo("1001");
+        assertThat(filter.getMrp()).isNull();
+    }
+
+    @Test
+    @DisplayName("Should handle non-numeric parameter values gracefully")
+    void shouldHandleGracefully_whenParamsAreNonNumeric() throws Exception {
+        allowPrivilege("_tickler", "r");
+
+        addRequestParameter("draw", "abc");
+        addRequestParameter("start", "xyz");
+        addRequestParameter("length", "!!!");
+
+        executeAction(action);
+
+        JsonNode json = parseResponse();
+        // Should fall back to defaults: draw=1, start=0, length=50
+        assertThat(json.get("draw").asInt()).isEqualTo(1);
+        verify(mockTicklerManager).getTicklerDTOs(
+                any(LoggedInInfo.class), any(CustomFilter.class), eq(0), eq(50));
+    }
+
+    // ── Invalid Date Handling ─────────────────────────────────────────
+
+    @Test
+    @DisplayName("Should return 400 JSON error when date format is invalid")
+    void shouldReturn400_whenDateFormatInvalid() throws Exception {
+        allowPrivilege("_tickler", "r");
+
+        addRequestParameter("xml_vdate", "not-a-date");
+
+        executeAction(action);
+
+        assertThat(getMockResponse().getStatus()).isEqualTo(400);
+        JsonNode json = parseResponse();
+        assertThat(json.get("error").asText()).contains("date");
+    }
+
+    // ── Warning Flag ───────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("Should set warning=false when service date is in the future")
+    void shouldNotWarn_whenServiceDateIsFuture() throws Exception {
+        allowPrivilege("_tickler", "r");
+
+        TicklerListDTO dto = createTestTickler(1, "future tickler");
+        // Service date far in the future — no warn period can trigger
+        dto.setServiceDate(new Date(System.currentTimeMillis() + 365L * 24 * 60 * 60 * 1000));
+        stubPaginatedResults(1, List.of(dto));
+
+        executeAction(action);
+
+        JsonNode row = parseResponse().get("data").get(0);
+        assertThat(row.get("warning").asBoolean()).isFalse();
+    }
+
+    // ── Null/Empty Dates ───────────────────────────────────────────────
+
+    @Test
+    @DisplayName("Should handle null serviceDate and createDate gracefully")
+    void shouldReturnEmptyStrings_whenDatesAreNull() throws Exception {
+        allowPrivilege("_tickler", "r");
+
+        TicklerListDTO dto = createTestTickler(1, "no dates");
+        dto.setServiceDate(null);
+        dto.setCreateDate(null);
+        stubPaginatedResults(1, List.of(dto));
+
+        executeAction(action);
+
+        JsonNode row = parseResponse().get("data").get(0);
+        assertThat(row.get("serviceDate").asText()).isEmpty();
+        assertThat(row.get("createDate").asText()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Should handle null comment updateDate")
+    void shouldReturnEmptyCreateDate_whenCommentUpdateDateIsNull() throws Exception {
+        allowPrivilege("_tickler", "r");
+
+        TicklerListDTO dto = createTestTickler(1, "test");
+        TicklerCommentDTO comment = new TicklerCommentDTO(1, 1, "comment", null, "Last", "First");
+        dto.setComments(List.of(comment));
+        stubPaginatedResults(1, List.of(dto));
+
+        executeAction(action);
+
+        JsonNode commentNode = parseResponse().get("comments").get("1").get(0);
+        assertThat(commentNode.get("createDate").asText()).isEmpty();
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────
+
+    private TicklerListDTO createTestTickler(int id, String message) {
+        return new TicklerListDTO(
+                id, message, new Date(), new Date(),
+                Tickler.STATUS.A, Tickler.PRIORITY.Normal,
+                1001, "Smith", "John",
+                "Doctor", "Jane",
+                "Nurse", "Bob");
+    }
+
+    private void stubPaginatedResults(int total, List<TicklerListDTO> ticklers) {
+        when(mockTicklerManager.getNumTicklers(any(LoggedInInfo.class), any(CustomFilter.class)))
+                .thenReturn(total);
+        when(mockTicklerManager.getTicklerDTOs(any(LoggedInInfo.class), any(CustomFilter.class), anyInt(), anyInt()))
+                .thenReturn(ticklers);
+        when(mockTicklerManager.getTicklerDTOs(any(LoggedInInfo.class), any(CustomFilter.class)))
+                .thenReturn(ticklers);
+    }
+
+    private JsonNode parseResponse() throws Exception {
+        return mapper.readTree(getMockResponse().getContentAsString());
+    }
+
+    private void injectField(String fieldName, Object value) throws Exception {
+        java.lang.reflect.Field field = TicklerList2Action.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(action, value);
+    }
+}


### PR DESCRIPTION
## In this PR, I have:
- Fixed tickler pagination, so that it is done in the back end rather than the front end 
     -  This used to load up to a maximum of 5000 ticklers without accounting for pagination until after all of the ticklers were processed, this meant that pagination was only a UI change, and didn't help with scaling higher datasets to be more manageable by limits
     - Due to this, the front end JSP conditional code has been mostly moved to the back end now
     - As a side note with these changes, the tickler count is now based on the tickler entries and NOT the tickler entries + tickler comments, this means that ticklers are grouped with their respective comments in the same page instead of potentially being on different pages, which also means the count overall will be show a lower value then before, this can be changed but is in my opinion an enhancement overall

## Other side fixes for issues with ticklers include:
- Increased XSS security using OWASP encoding on the tickler page
- Added value setter for the "From" search date option
     - This means that when you search with a "From" date, the value will persist through searches, before it did not do that
- Wrapped secondary filter dropdown to only appear in demographic searches
     - This is because the secondary filter does nothing on the tickler main page if you are using the main tab, so it was redundant and confusing, it only works when viewing the page through a demographic
-  Fixed conflicting pagination data with storing the page on load when closing and re-opening the tickler main page
     - This caused issues with the pagination as if you were to select a page that didn't have any data for the assigned provider, it would show blank instead of the actual data starting at the first page

## I have tested this by:
- Comparing functionality on this branch with the hotfix branch (accounting for the side fixes as explained above)

## Summary by Sourcery

Implement server-side pagination and filtering for the tickler list and expose it via a new JSON-backed Struts action used by the main tickler page.

New Features:
- Expose a new TicklerList JSON endpoint that serves paginated tickler and comment data for DataTables server-side processing.

Bug Fixes:
- Correct tickler pagination so that page navigation and provider/assignee filters always return valid data sets instead of blank pages.
- Ensure the tickler date range "From" field and other search parameters persist correctly across searches.

Enhancements:
- Refactor the tickler main JSP to delegate row rendering and pagination to DataTables with client-side column renderers using backend-sourced data.
- Improve XSS protection on the tickler page by encoding dynamic values in form fields, options, and JavaScript-generated content.
- Persist tickler table page size and sort order in local storage to maintain user preferences between views.
- Hide the secondary tickler status filter unless viewing ticklers for a specific demographic to reduce confusion in the main view.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved tickler pagination and filtering to the backend via a new server-side DataTables endpoint, fixing UI-only paging and speeding up large tickler lists. Strengthened XSS protections and added JSON error handling; supports “All” without truncation and caps per-page size at 500.

- **New Features**
  - Added `tickler/ListTicklers.do` (`TicklerList2Action`) returning paginated JSON for DataTables server-side mode (max page size 500; “All” shows all).
  - Moved sorting/filtering (status, provider/MRP/assignee, date range, demographic) to the backend; comments are returned separately and counts exclude comments.
  - Updated `ticklerMain.jsp` to server-side mode and persisted page length and sort order in localStorage.

- **Bug Fixes**
  - Backend-enforced pagination prevents blank pages and works with provider/assignee filters.
  - Returns JSON errors for access denied (403) and invalid dates (400).
  - “From” date now persists; secondary filter only shows on demographic views; fixed MDS attachment links to include the context path.

<sup>Written for commit d210c1c1aba47e79a22d2a58ce26307c5bd0949e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



## Summary by Sourcery

Move tickler list pagination and filtering to a new server-side JSON endpoint consumed by the tickler main page, improving performance, correctness, and security.

New Features:
- Introduce a TicklerList2Action Struts endpoint that returns paginated tickler and comment data as JSON for DataTables server-side processing.

Bug Fixes:
- Ensure tickler pagination uses backend limits and filters so navigating pages and applying provider or assignee filters no longer produces blank or inconsistent result sets.
- Persist the tickler date range "From" and "To" values across searches so the selected range is retained.

Enhancements:
- Refactor ticklerMain.jsp to use server-side DataTables with client-side renderers instead of rendering all tickler rows directly in JSP.
- Add OWASP encoding to tickler filters, provider lists, and date inputs to harden the tickler page against XSS.
- Hide the secondary tickler status filter on the main tickler page unless viewing ticklers for a specific demographic to avoid redundant UI.
- Persist tickler table page length and sort order in local storage to remember user view preferences.

## Summary by Sourcery

Move tickler list pagination and filtering to a new server-side JSON endpoint consumed by the main tickler page to improve performance, correctness, and security.

New Features:
- Expose a TicklerList JSON Struts action that returns paginated tickler data and comments for DataTables server-side processing.

Bug Fixes:
- Ensure tickler pagination and provider/assignee filters are enforced on the backend so navigation no longer produces blank or inconsistent pages.
- Persist the tickler date range "From" value and other search parameters across reloads so filters remain applied.

Enhancements:
- Refactor the tickler main JSP to delegate row rendering and pagination to DataTables using backend-sourced JSON instead of server-side row generation.
- Improve XSS protection on the tickler page by encoding dynamic values in date inputs, provider lists, site selectors, and JavaScript-generated options.
- Hide the secondary tickler status filter unless viewing ticklers for a specific demographic to simplify the main tickler view.
- Remember tickler table page length and sort order via local storage to maintain user preferences between sessions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tickler list now uses server-side data processing for improved performance with large datasets.

* **Security**
  * Enhanced HTML escaping throughout tickler page to prevent XSS vulnerabilities.

* **Refactor**
  * Modernized tickler interface with dynamic client-side rendering and persistent user preferences for sort order and page length.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->