### PR TITLE
fix: missing textbox to edit signature in preferences when no signature is set on the currently logged in provider

### DIFF
--- a/src/main/webapp/provider/editSignature.jsp
+++ b/src/main/webapp/provider/editSignature.jsp
@@ -90,9 +90,9 @@
                 <%
                     if (sig.hasSignature(curUser_no)) {
                 %>
-                <fmt:setBundle basename="oscarResources"/><fmt:message key="provider.editSignature.msgEdit"/>
+                <label for="signature"><fmt:setBundle basename="oscarResources"/><fmt:message key="provider.editSignature.msgEdit"/></label>
                 <br>
-                <input type="text" name="signature" size="40" value="<%= Encode.forHtmlAttribute(sig.getSignature(curUser_no)) %>" />
+                <input type="text" name="signature" id="signature" size="40" value="<%= Encode.forHtmlAttribute(sig.getSignature(curUser_no)) %>" />
                 <br>
 
                 <!-- add by caisi -->
@@ -106,9 +106,9 @@
                 <input type="submit"
                        value="<fmt:setBundle basename="oscarResources"/><fmt:message key="provider.editSignature.btnUpdate"/>"/>
                 <% } else {%>
-                <fmt:setBundle basename="oscarResources"/><fmt:message key="provider.editSignature.msgNew"/>
+                <label for="signature"><fmt:setBundle basename="oscarResources"/><fmt:message key="provider.editSignature.msgNew"/></label>
                 <br>
-                <input type="text" name="signature" size="40" />
+                <input type="text" name="signature" id="signature" size="40" />
                 <br>
                 <!-- add by caisi -->
                 <caisi:isModuleLoad moduleName="caisi">


### PR DESCRIPTION
## In this PR, I have:
- Fixed an incorrect input type of "checkbox" when signature is first being set, should be of input type "text"
- Additionally, I added proper labels to fmt messages for accessibility

## I have tested this by:
- Creating a new signature, ensuring that I can create a new signature with a text box, and also ensure that a signature can be edited afterwards

## Summary by Sourcery

Bug Fixes:
- Replace the incorrect checkbox input with a text input for entering a new provider signature when no signature is currently set.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the signature preferences page to show a text field when no signature is set, replacing the incorrect checkbox so providers can enter an initial signature. Also adds proper labels and id attributes to the signature input in editSignature.jsp for accessibility in both new and edit states.

<sup>Written for commit 346771e4fe62002e16b8c774aa9283e2cf8b3077. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Fix provider signature preferences so a text input is used when creating or editing a signature and the field is properly labelled for accessibility.

Bug Fixes:
- Show a text input instead of a checkbox when setting a provider signature for the first time.

Enhancements:
- Add accessible label and id association to the provider signature input field for both new and existing signatures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Signature input field updated to accept free-form text instead of a checkbox toggle, allowing users to enter custom signature text directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->