### PR TITLE
Fix: preventions not being included in flowsheet printing

### DIFF
--- a/src/main/webapp/oscarEncounter/oscarMeasurements/TemplateFlowSheetPrint.jsp
+++ b/src/main/webapp/oscarEncounter/oscarMeasurements/TemplateFlowSheetPrint.jsp
@@ -23,6 +23,26 @@
     Ontario, Canada
 
 --%>
+<%--
+    Custom Print view for flowsheet templates (e.g. Diabetes, Prenatal).
+
+    Allows clinicians to select which measurements, preventions, and drugs
+    to include in a printed flowsheet summary. Supports three print modes:
+    All entries, Last Only, and Out of Range. Individual items can be refined
+    by count or date range via per-item dropdowns (measurements only).
+
+    Flow: Initial load shows checkboxes for selection -> "Preview" submits
+    selections via POST -> page re-renders with only selected items visible
+    -> browser print dialog.
+
+    @param demographic_no patient demographic number (required)
+    @param template flowsheet template identifier, e.g. "diab2" (required)
+    @param printView if present, renders in print-preview mode
+    @param printHP[] selected item identifiers to include in printout
+    @param show optional view filter: "lastOnly" or "outOfRange"
+
+    @since 2006-02-14
+--%>
 <!DOCTYPE html>
 <%@page import="ca.openosp.openo.utility.SpringUtils" %>
 <% long startTime = System.currentTimeMillis(); %>


### PR DESCRIPTION
## In this PR, I have fixed:
- Preventions not being included in flowsheet printing due to missing fallback logic when no printstyle dropdown option exists, which is the current behaviour of preventions

## I have tested this by:
- Printing a flowsheet, ensuring that preventions show in the print page as well

## Summary by Sourcery

Bug Fixes:
- Include preventions and other measurements without a print style selection in flowsheet printouts by applying an 'all entries' fallback.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes flowsheet printing to include Preventions and other items without a printStyle dropdown by defaulting them to print all entries, with an explicit null check to ensure consistent fallback. Adds a JSP comment block that documents the flowsheet print view and its parameters.

<sup>Written for commit 60db89ab336fe6871daaa01757e65b22fb61d459. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed printing default behavior to display all entries when no specific print style is configured, ensuring more consistent output when printing flowsheets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->