### PR TITLE
Fix: prevention reports restricted to enrolled patients

### DIFF
--- a/src/main/java/ca/openosp/openo/prevention/pageUtil/PreventionReport2Action.java
+++ b/src/main/java/ca/openosp/openo/prevention/pageUtil/PreventionReport2Action.java
@@ -93,8 +93,7 @@ public class PreventionReport2Action extends ActionSupport {
         // Use the overload without asofRosterDate so results are based on the demographic query and
         // asofDate only. The overload that accepts an asofRosterDate may additionally apply a post-query
         // rostering filter (skipping non-rostered patients) when an as-of roster date is provided and at
-        // least one provider filter is specified, which is only appropriate for CMS4 export billing bonus
-        // calculations.
+        // least one provider filter is specified.
         ArrayList<ArrayList<String>> list = demoQ.buildQuery(loggedInInfo, frm);
 
         log.debug("set size " + list.size());

--- a/src/main/java/ca/openosp/openo/report/data/RptDemographicQueryBuilder.java
+++ b/src/main/java/ca/openosp/openo/report/data/RptDemographicQueryBuilder.java
@@ -85,8 +85,7 @@ public class RptDemographicQueryBuilder {
     /**
      * Builds a demographic query with optional post-query rostering filtering.
      * When {@code asofRosterDate} is provided, results are filtered to only include patients
-     * who were rostered to the selected provider on that date. This is used by CMS4 export
-     * for billing bonus calculations.
+     * who were rostered to the selected provider on that date.
      *
      * @param loggedInInfo LoggedInInfo the logged-in user session
      * @param frm RptDemographicReport2Form the demographic query form with search criteria


### PR DESCRIPTION
## In this PR, I have:
- FIxed prevention reporting skipping some non-enrolled patients 
     - Particularly noticeable through Lebron's patients
- Added javadoc and notes to related methods/method call to explain code changes and current code state for future reference 
     
## I have tested this by:
- Using the Ontario Prevention Reporting functionality, ensuring that previously missing non-rostered patients show up with expected demographic queries (and excluded when specifically looking for rostered patients set in the query)

## Summary by Sourcery

Bug Fixes:
- Correct prevention report demographic query so non-rostered patients are included unless a roster-only filter is explicitly required.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Ontario Prevention Report excluding non-rostered patients. The report now includes all patients matching demographic filters; roster-only queries still work when explicitly selected.

- **Bug Fixes**
  - PreventionReport2Action now calls buildQuery(loggedInInfo, frm) so results use demographic filters and the as-of date only, avoiding roster-date filtering.
  - RptDemographicQueryBuilder adds a no-rostering overload; the 3-arg method remains for optional roster filtering/CMS4 exports. Javadoc added and misleading comments removed.

<sup>Written for commit a3bf54f3b0b9b9903783e2c927d1d99c1fde83b5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Adjust demographic query usage so prevention reports include eligible non-rostered patients while preserving roster-based filtering for CMS4 exports.

Bug Fixes:
- Fix Ontario prevention reports excluding non-rostered patients by using a demographic query path without roster-date filtering.

Enhancements:
- Add an overload of the demographic query builder to support optional rostering filters for different reporting contexts.
- Document demographic query builder behavior and rostering filter usage with Javadoc and code comments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevention report results now use demographic criteria and the selected as-of date only, ensuring eligible non-rostered patients are included.
  * Removed a rostering filter that previously excluded some patients from the report.

* **Refactor**
  * Streamlined query construction to support the updated report behavior without altering user workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->