### PR TITLE
Fix: shift arrow not working in the note browser

### DIFF
--- a/src/main/webapp/casemgmt/noteBrowser.jsp
+++ b/src/main/webapp/casemgmt/noteBrowser.jsp
@@ -245,29 +245,29 @@
         }
 
         function showEncounter(encList) {
-            var url2 = '<%=request.getContextPath()%>' + '/CaseManagementEntry.do?method=displayNotes&demographicNo=<%=demographicID%>' + encList + '&printCPP=false&printRx=false';
+            const url2 = '<%=request.getContextPath()%>' + '/CaseManagementEntry.do?method=displayNotes&demographicNo=<%=demographicID%>' + encList + '&printCPP=false&printRx=false';
 
             // Use an iframe instead of an <object> tag to display encounter notes.
             // An <object type="text/html"> steals focus from the select list when it
             // loads, which breaks shift+arrow keyboard selection after the 2nd keypress.
             let iframe = document.createElement('iframe');
             iframe.title = 'Encounter notes';
-            iframe.src = url2;
             iframe.width = getWidth() - 40;
             iframe.height = getHeight() - 300;
             iframe.style.border = 'none';
-
-            var docdisp = document.getElementById('docdisp');
-            docdisp.innerHTML = '';
-            docdisp.appendChild(iframe);
 
             // Restore focus to the encounter list only if the iframe stole it,
             // so that shift+arrow selection can continue uninterrupted without
             // overriding focus if the user has intentionally moved elsewhere.
             iframe.addEventListener('load', function() {
-                var el = document.getElementById('encounterlist');
+                const el = document.getElementById('encounterlist');
                 if (el && (document.activeElement === iframe || document.activeElement === document.body)) el.focus();
             });
+
+            iframe.src = url2;
+            const docdisp = document.getElementById('docdisp');
+            docdisp.innerHTML = '';
+            docdisp.appendChild(iframe);
 
             document.getElementById('docinfo').innerHTML = '';
             document.getElementById('docextrainfo').innerHTML = '';


### PR DESCRIPTION
## In this PR, I have:
- Fixed shift arrow not working in the note browser
- Replaced deprecated document.all("id") for document ID selection with document.getElementById("id")
- Added output encoding to outputted error message

## I have tested this by:
- Using the shift + arrow in the note browser, ensuring that the issue does not happen

This PR closes issue: https://github.com/openo-beta/Open-O/issues/2277

## Summary by Sourcery

Resolve keyboard selection issues in the note browser and modernize DOM element access in the note viewer UI.

Bug Fixes:
- Restore continuous shift+arrow selection in the note browser encounter list by preventing the note viewer from stealing focus.

Enhancements:
- Replace the HTML object-based note viewer with an iframe-based implementation that preserves focus behavior.
- Update deprecated document.all element lookups to use document.getElementById for note browser action buttons.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores shift+arrow selection in the note browser by keeping focus on the encounter list when previewing notes. Also hardens the UI by modernizing DOM access and HTML-encoding error output.

- **Bug Fixes**
  - Switched the preview from an object to an iframe with a title and a load handler (bound before setting src) that only refocuses the encounter list if the iframe stole focus, keeping shift+arrow working.
  - Replaced document.all(...) with document.getElementById(...) for docbuttons/refilebutton visibility.
  - HTML-encoded error messages using OWASP Encode.forHtml to prevent unsafe output.

<sup>Written for commit 9240bf6cc33a676101623ba17e699985db029356. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



## Summary by Sourcery

Fix keyboard-based multi-selection in the note browser and modernize DOM usage for note action controls.

Bug Fixes:
- Restore continuous shift+arrow selection in the note browser by preventing the note preview from stealing focus.

Enhancements:
- Switch the note preview from an HTML object to an iframe that preserves focus behavior.
- Replace deprecated document.all lookups with document.getElementById for note action and refile button visibility handling.

## Summary by Sourcery

Fix keyboard-based multi-selection in the note browser by preventing the note preview from stealing focus and improving safety and reliability of the UI.

Bug Fixes:
- Restore continuous shift+arrow selection in the note browser encounter list by switching the note preview to an iframe that preserves list focus and refocusing when needed.
- HTML-encode note browser error messages before rendering to avoid unsafe output.

Enhancements:
- Replace deprecated document.all element access with document.getElementById for note browser action and refile button visibility handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved encounter notes display rendering for enhanced compatibility.
  * Restored keyboard navigation functionality (shift+arrow keys) in the encounter list after notes are loaded, ensuring consistent navigation experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->