### PR TITLE
Fix: MMR and MMRV incorrect prevention recommendations

### DIFF
--- a/src/main/resources/oscar/oscarPrevention/prevention.drl
+++ b/src/main/resources/oscar/oscarPrevention/prevention.drl
@@ -376,8 +376,9 @@
         </parameter>
         <java:condition>prev.getAgeInMonths() &gt;= 48</java:condition>
         <java:condition>prev.getAgeInYears() &lt; 10</java:condition>
-        <java:condition>prev.getNumberOfPreventionType("MMR") == 1</java:condition>                                        
-        <java:consequence>              
+        <java:condition>prev.getNumberOfPreventionType("MMR") == 1</java:condition>
+        <java:condition>prev.getNumberOfPreventionType("MMRV") == 0</java:condition>
+        <java:consequence>
               prev.log("MMR 2");
               prev.addWarning("MMR", "Needs Second MMR or MMRV");
         </java:consequence>
@@ -390,7 +391,8 @@
         </parameter>
         <java:condition>prev.getAgeInMonths() &gt;= 48</java:condition>
         <java:condition>prev.getAgeInYears() &lt; 10</java:condition>
-        <java:condition>prev.getNumberOfPreventionType("MMRV") == 1</java:condition>  
+        <java:condition>prev.getNumberOfPreventionType("MMRV") == 1</java:condition>
+        <java:condition>prev.getNumberOfPreventionType("MMR") == 0</java:condition>
         <java:consequence>
               prev.log("MMRV 1");
               prev.addWarning("MMRV", "Needs Second MMR or MMRV");


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                   
   
Fixes incorrect prevention recommendations for MMR and MMRV vaccines where patients who received one dose of each were incorrectly warned to get a second dose of both.                                                                   
                                 
Fixes #2283

## Problem

  When a patient receives 1 MMR dose (at ~12 months) and 1 MMRV dose (at ages 4-6), the system should recognize this as a complete 2-dose series. Instead, two erroneous warnings appear: "Needs Second MMR or MMRV".

  The root cause is in prevention.drl:

  - Rule "MMR 2" only checked MMR == 1 before warning — it did not check whether an MMRV dose had also been given
  - Rule "MMRV 1" only checked MMRV == 1 before warning — it did not check whether an MMR dose had also been given

  Note that Rule "MMR 1" (first dose) already had the correct cross-check pattern (MMR == 0 AND MMRV == 0), but this was not carried forward to the second-dose rules.

## Solution

  Added cross-type vaccine checks to both second-dose rules in prevention.drl:

  - **MMR 2**: Added `prev.getNumberOfPreventionType("MMRV") == 0` — only warns if no MMRV dose exists
  - **MMRV 1**: Added `prev.getNumberOfPreventionType("MMR") == 0` — only warns if no MMR dose exists

  This ensures any combination totaling 2 doses across MMR/MMRV (1+1, 2+0, 0+2) correctly suppresses the warning.

  Test plan

  - Add 1 MMR + 1 MMRV to a patient aged 4-6 → no warnings should appear
  - Add only 1 MMR to a patient aged 4-6 → "Needs Second MMR or MMRV" warning appears
  - Add only 1 MMRV to a patient aged 4-6 → "Needs Second MMR or MMRV" warning appears
  - Add 0 MMR + 0 MMRV to a patient aged 12+ months → "Needs First MMR or MMRV" warning appears

## Summary by Sourcery

Correct prevention rules so mixed MMR and MMRV doses are treated as a complete series and no duplicate second-dose warnings are shown.

Bug Fixes:
- Ensure patients with one MMR and one MMRV dose are not incorrectly warned to receive second doses of both vaccines.
- Tighten MMR and MMRV second-dose prevention rules to account for doses of the other vaccine type when generating warnings.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed incorrect prevention recommendations for MMR/MMRV so a patient with 1 MMR + 1 MMRV is treated as a complete 2-dose series and no second-dose warnings appear. Updated second-dose rules in prevention.drl to cross-check the other vaccine type before warning.

- **Bug Fixes**
  - MMR 2: warn only when MMR == 1 and MMRV == 0 (ages 4–9).
  - MMRV 1: warn only when MMRV == 1 and MMR == 0 (ages 4–9).

<sup>Written for commit a0c3e703a83cc58c640b7d2baac5262a58508a8a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced vaccine prevention tracking for MMR and MMRV vaccinations, eliminating conflicts between the two vaccine types and improving alert accuracy in the prevention tracking system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->