### PR TITLE
Fix: billings can no longer be future dated

### DIFF
--- a/src/main/webapp/billing/CA/ON/billingON.jsp
+++ b/src/main/webapp/billing/CA/ON/billingON.jsp
@@ -787,15 +787,11 @@
             var mm = str_date.substring(eval(str_date.indexOf("-") + 1), str_date.lastIndexOf("-"));
             var dd = str_date.substring(eval(str_date.lastIndexOf("-") + 1));
             var bWrongDate = false;
-            sMsg = "";
             if (yyyy > varYear) {
-                sMsg = "year";
                 bWrongDate = true;
             } else if (yyyy == varYear && mm > varMonth) {
-                sMsg = "month";
                 bWrongDate = true;
             } else if (yyyy == varYear && mm == varMonth && dd > varDate) {
-                sMsg = "date";
                 bWrongDate = true;
             }
             if (bWrongDate) {


### PR DESCRIPTION
## Summary

Restores the ability to create future-dated billing invoices in ON billing, which was broken by a previous refactor.

## Problem

A previous PR changed the checkServiceDate() function in billingON.jsp from a confirm() dialog to an alert() + return false. This made it impossible to submit future-dated billings — the form is now blocked with no way to proceed. Previously, users received a warning but could click OK to continue, which is needed for legitimate workflows like pre-rosters.

## Solution

Replace the blocking alert() + return false with the original confirm() dialog, restoring the warn-but-allow behavior for future service dates

removed now unused message variable, which was used in the update that has been reverted

## Summary by Sourcery

Bug Fixes:
- Allow future-dated ON billing invoices to be submitted again by changing the date validation from a blocking alert to a confirm dialog that lets users proceed after acknowledging the warning.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores future-dated ON billing invoices by replacing the blocking alert with a confirm dialog so users can proceed after a warning. Also removes an unused message variable.

<sup>Written for commit d9d385f4be003bb61a9c72d714bb0dd47433e692. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Bug Fixes:
- Fix ON billing form validation that incorrectly blocked submission when a future service or admission date was entered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved date validation for billing: When a future date is entered, users now receive a confirmation prompt allowing them to proceed or edit, instead of automatic rejection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->