### PR TITLE
Enhancement: sort pending documents in chronological order in document queues

### DIFF
--- a/src/main/java/ca/openosp/openo/commn/dao/QueueDocumentLinkDaoImpl.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/QueueDocumentLinkDaoImpl.java
@@ -58,7 +58,7 @@ public class QueueDocumentLinkDaoImpl extends AbstractDaoImpl<QueueDocumentLink>
 
     @Override
     public List<QueueDocumentLink> getActiveQueueDocLink() {
-        Query query = entityManager.createQuery("SELECT q from QueueDocumentLink q where q.status=?1");
+        Query query = entityManager.createQuery("SELECT q from QueueDocumentLink q where q.status=?1 ORDER BY q.docId ASC");
         query.setParameter(1, "A");
 
         @SuppressWarnings("unchecked")

--- a/src/main/java/ca/openosp/openo/commn/dao/QueueDocumentLinkDaoImpl.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/QueueDocumentLinkDaoImpl.java
@@ -58,7 +58,9 @@ public class QueueDocumentLinkDaoImpl extends AbstractDaoImpl<QueueDocumentLink>
 
     @Override
     public List<QueueDocumentLink> getActiveQueueDocLink() {
-        Query query = entityManager.createQuery("SELECT q from QueueDocumentLink q where q.status=?1 ORDER BY q.docId ASC");
+        Query query = entityManager.createNativeQuery(
+                "SELECT q.* FROM queue_document_link q JOIN document d ON q.document_id = d.document_no WHERE q.status = ?1 ORDER BY d.updatedatetime ASC",
+                QueueDocumentLink.class);
         query.setParameter(1, "A");
 
         @SuppressWarnings("unchecked")

--- a/src/main/webapp/oscarMDS/documentsInQueues.jsp
+++ b/src/main/webapp/oscarMDS/documentsInQueues.jsp
@@ -333,7 +333,7 @@
                 var docid = docs[i];
                 nowDocLabIds.push(docid);
                 var placeholder = document.createElement('div');
-                placeholder.id = 'docPlaceholder_' + docid.replace(/\s/g, '');
+                placeholder.id = 'docPlaceholder_' + docid.replace(' ', '');
                 docsContainer.appendChild(placeholder);
             }
             nowDocLabIds.reverse();

--- a/src/main/webapp/oscarMDS/documentsInQueues.jsp
+++ b/src/main/webapp/oscarMDS/documentsInQueues.jsp
@@ -333,7 +333,7 @@
                 var docid = docs[i];
                 nowDocLabIds.push(docid);
                 var placeholder = document.createElement('div');
-                placeholder.id = 'docPlaceholder_' + docid.replace(' ', '');
+                placeholder.id = 'docPlaceholder_' + docid.replace(/\s/g, '');
                 docsContainer.appendChild(placeholder);
             }
             nowDocLabIds.reverse();
@@ -906,14 +906,18 @@
             var data = "segmentID=" + docNo + "&providerNo=" + providerNo + "&searchProviderNo=" + searchProviderNo + "&status=" + status + "&demoName=" + demoName;
             if (inQueue)
                 data += "&inQueue=" + inQueue;
-            new Ajax.Updater(div, url, {
+            var ajaxOptions = {
                 method: 'get',
                 parameters: data,
                 evalScripts: true,
                 onSuccess: function (transport) {
                     focusFirstDocLab();
                 }
-            });
+            };
+            if (!placeholder) {
+                ajaxOptions.insertion = Insertion.Bottom;
+            }
+            new Ajax.Updater(div, url, ajaxOptions);
 
         }
 

--- a/src/main/webapp/oscarMDS/documentsInQueues.jsp
+++ b/src/main/webapp/oscarMDS/documentsInQueues.jsp
@@ -321,15 +321,22 @@
         var queueID;
 
         function showDocInQueue(qid) {
-            $('docs').innerHTML = '';
+            var docsContainer = $('docs');
+            while (docsContainer.firstChild) {
+                docsContainer.removeChild(docsContainer.firstChild);
+            }
             var docs = queueDocNos[qid];
             nowChildId = 'docs';
             nowMultiple = 1;
             nowDocLabIds = new Array();
-            for (var i = docs.length - 1; i > -1; i--) {
+            for (var i = 0; i < docs.length; i++) {
                 var docid = docs[i];
                 nowDocLabIds.push(docid);
+                var placeholder = document.createElement('div');
+                placeholder.id = 'docPlaceholder_' + docid.replace(' ', '');
+                docsContainer.appendChild(placeholder);
             }
+            nowDocLabIds.reverse();
             queueID = qid;
             showFirstTime();
         }
@@ -881,12 +888,9 @@
             //create child element in docViews
             docNo = docNo.replace(' ', '');//trim
             var type = checkType(docNo);
-            //oscarLog('type'+type);
-            //var div=childId;
 
-            //var div=window.frames[0].document.getElementById(childId);
-            var div = $(childId);
-            //alert(div);
+            var placeholder = $('docPlaceholder_' + docNo);
+            var div = placeholder || $(childId);
             var url = '';
             if (type == 'DOC')
                 url = "<%= request.getContextPath() %>/documentManager/showDocument.jsp";
@@ -899,15 +903,12 @@
             else
                 url = "";
 
-            //oscarLog('url='+url);
             var data = "segmentID=" + docNo + "&providerNo=" + providerNo + "&searchProviderNo=" + searchProviderNo + "&status=" + status + "&demoName=" + demoName;
             if (inQueue)
                 data += "&inQueue=" + inQueue;
-            // oscarLog('url='+url+'+-+ \n data='+data+"----div:"+div);
             new Ajax.Updater(div, url, {
                 method: 'get',
                 parameters: data,
-                insertion: Insertion.Bottom,
                 evalScripts: true,
                 onSuccess: function (transport) {
                     focusFirstDocLab();


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                
  Sort pending documents in the "Documents In Queues" page in ascending chronological order (oldest first, newest at the bottom).
                                                                                                                                                                                                                                            
  Fixes #2288     

  ## Problem
  Documents in the Pending Docs queue displayed in non-deterministic order. This was caused by two issues:

  1. The `getActiveQueueDocLink()` DAO query had no `ORDER BY` clause, so the database returned results without a guaranteed order.
  2. The JavaScript loaded each document via parallel AJAX calls using `Insertion.Bottom`, meaning whichever response arrived first appeared at the top, regardless of the intended order.

  ## Solution
  1. **DAO**: Added `ORDER BY q.docId ASC` to the `getActiveQueueDocLink()` query. Since `document_no` is auto-incrementing, ascending docId order matches chronological upload order.
  2. **JSP**: Pre-created placeholder divs in the correct order before firing AJAX calls. Each response now targets its specific placeholder div instead of appending to the bottom of the container, guaranteeing correct display order
  regardless of AJAX response timing.

## Summary by Sourcery

Ensure documents in pending queues display in a stable chronological order across backend retrieval and frontend rendering.

Bug Fixes:
- Order active queue document links by associated document update time so pending items are returned in chronological sequence.
- Stabilize pending document rendering by pre-creating ordered placeholders and targeting AJAX updates to them instead of relying on response order.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sort pending documents in Documents In Queues by upload date (oldest first) so the list is stable and predictable.

- **Bug Fixes**
  - DAO: Use a native query joining document, ordered by d.updatedatetime ASC.
  - UI: Pre-create ordered placeholders and target AJAX updates per doc; only append when no placeholder to avoid changes in non-queue views.
  - Consistency: Revert whitespace handling to a single-space replace for IDs to match existing behavior.

<sup>Written for commit aef0d14be643aa69f0ddbf9895e643130e1565fb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Documents in queue lists are now ordered consistently (ascending order) for better organization.
  * Enhanced document display performance with optimized loading behavior in the document queue interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->