### PR TITLE
Feature: Make the HCV Validation button available from the "regular" demographic view, not just the "Edit" view

### DIFF
--- a/src/main/resources/oscarResources_en.properties
+++ b/src/main/resources/oscarResources_en.properties
@@ -6072,6 +6072,7 @@ demographic.demographiceditdemographic.msgBillPatient = bill a patient
 demographic.demographiceditdemographic.msgCreateInvoice = Create Invoice
 demographic.demographiceditdemographic.msgInvoiceList = Invoice List
 demographic.demographiceditdemographic.msgBillHistory = Billing History
+demographic.demographiceditdemographic.msgValidateOHIP = Validate OHIP
 demographic.demographiceditdemographic.msgWaitList = Waiting List
 demographic.demographiceditdemographic.msgAppt = Appointment
 demographic.demographiceditdemographic.msgNextAppt = Next Appointment

--- a/src/main/resources/oscarResources_es.properties
+++ b/src/main/resources/oscarResources_es.properties
@@ -4982,6 +4982,7 @@ demographic.demographiceditdemographic.msgBillPatient = Facturar paciente
 demographic.demographiceditdemographic.msgCreateInvoice = Crear factura
 demographic.demographiceditdemographic.msgInvoiceList = Lista de facturas
 demographic.demographiceditdemographic.msgBillHistory = Historial facturacion
+demographic.demographiceditdemographic.msgValidateOHIP = Validar OHIP
 demographic.demographiceditdemographic.msgWaitList = Lista espera
 demographic.demographiceditdemographic.msgAppt = Turno
 demographic.demographiceditdemographic.msgNextAppt = Proximo turno

--- a/src/main/resources/oscarResources_fr.properties
+++ b/src/main/resources/oscarResources_fr.properties
@@ -4405,6 +4405,7 @@ demographic.demographiceditdemographic.msgBillPatient=Facturer un patient
 demographic.demographiceditdemographic.msgCreateInvoice=Cr\u00e9er une facture
 demographic.demographiceditdemographic.msgInvoiceList=Liste des factures
 demographic.demographiceditdemographic.msgBillHistory=Historique de facturation
+demographic.demographiceditdemographic.msgValidateOHIP=Valider OHIP
 demographic.demographiceditdemographic.msgWaitList=Ajouter le patient \u00e0 la liste d'attente
 demographic.demographiceditdemographic.msgAppt=Rendez-vous
 demographic.demographiceditdemographic.msgNextAppt=Prochain rendez-vous

--- a/src/main/resources/oscarResources_pl.properties
+++ b/src/main/resources/oscarResources_pl.properties
@@ -4408,6 +4408,7 @@ demographic.demographiceditdemographic.msgBillPatient=Bill pacjenta
 demographic.demographiceditdemographic.msgCreateInvoice=Utw&#X0f3;rz faktur&#X119;
 demographic.demographiceditdemographic.msgInvoiceList=Lista faktury
 demographic.demographiceditdemographic.msgBillHistory=Historia p&#X142;atno&#X15b;ci
+demographic.demographiceditdemographic.msgValidateOHIP=Zatwierd\u017a OHIP
 demographic.demographiceditdemographic.msgWaitList=Waiting List
 demographic.demographiceditdemographic.msgAppt=Powo&#X142;anie
 demographic.demographiceditdemographic.msgNextAppt=Dalej Powo&#X142;anie

--- a/src/main/resources/oscarResources_pt_BR.properties
+++ b/src/main/resources/oscarResources_pt_BR.properties
@@ -5886,6 +5886,7 @@ demographic.demographiceditdemographic.msgBillPatient = faturar um paciente
 demographic.demographiceditdemographic.msgCreateInvoice = Criar recibo
 demographic.demographiceditdemographic.msgInvoiceList = Lista de faturas
 demographic.demographiceditdemographic.msgBillHistory = Hist\u00F3rico de cobran\u00E7a
+demographic.demographiceditdemographic.msgValidateOHIP = Validar OHIP
 demographic.demographiceditdemographic.msgWaitList = Lista de espera
 demographic.demographiceditdemographic.msgAppt = Consulta
 demographic.demographiceditdemographic.msgNextAppt =  Pr\u00F3xima consulta

--- a/src/main/webapp/demographic/demographiceditdemographic.jsp
+++ b/src/main/webapp/demographic/demographiceditdemographic.jsp
@@ -1068,7 +1068,7 @@
                                     <br/>
                                     <a href="javascript:void(0);"
                                        onclick="validateHC(); return false;">
-                                       Validate OHIP</a>
+                                       <fmt:setBundle basename="oscarResources"/><fmt:message key="demographic.demographiceditdemographic.msgValidateOHIP"/></a>
                                     <% } %>
                                     <%
                                     } else {


### PR DESCRIPTION
## Summary
                                                                                                                                                                                                                                            
  Adds a "Validate OHIP" link to the demographic sidebar for Ontario users, mirroring BC's existing "Check Eligibility" link.

  Fixes #2289

 ## Problem

  The health card validation (HCV) button was only available inside the edit form next to the HIN input field. Users had to open the edit view and scroll to the HIN field to validate a patient's OHIP coverage. BC already had a
  convenient "Check Eligibility" link in the sidebar billing section, but Ontario had no equivalent.


 ## Solution

  - Added a "Validate OHIP" link in the ON billing sidebar section, gated by hcv.type=online (same condition as the existing inline button)
  - Reuses the existing validateHC() JavaScript function — no new logic
  - Kept the original inline Validate button in the edit form as well
  - Added localized msgValidateOHIP resource keys for all 5 supported languages (en, fr, es, pt_BR, pl)


## Summary by Sourcery

Expose OHIP validation from the demographic view alongside billing history when online HCV is enabled and localize the new action label.

New Features:
- Add a Validate OHIP action link to the demographic view under Billing History, conditioned on online HCV being enabled.

Enhancements:
- Add translated resource strings for the Validate OHIP label in English, Spanish, French, Polish, and Brazilian Portuguese.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a "Validate OHIP" link in the demographic view (under Billing History) so users can validate without opening Edit; it only appears when online HCV is enabled. Added translations for the link label (en, es, fr, pl, pt_BR) and kept the existing Edit-page button.

<sup>Written for commit 079e8fdc1910704d735755d797f903c5668be681. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced OHIP validation interface by introducing conditional display logic that shows a validation link only when the appropriate configuration is active, replacing the previous always-visible button for improved usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->