### PR TITLE
feat: add sending provider name to email chart notes

### DIFF
--- a/src/main/java/ca/openosp/openo/email/util/EmailNoteUtil.java
+++ b/src/main/java/ca/openosp/openo/email/util/EmailNoteUtil.java
@@ -278,8 +278,12 @@ public class EmailNoteUtil {
 
     private void addSentByLine(StringBuilder noteBuilder) {
         String dateTime = DateUtils.format(SENT_DATE_FORMAT, emailLog.getTimestamp(), null);
-        noteBuilder.append("\n\n[Sent on ").append(dateTime)
-                .append(" by ").append(resolveProviderDisplayName()).append("]");
+        String displayName = resolveProviderDisplayName();
+        noteBuilder.append("\n\n[Sent on ").append(dateTime);
+        if (!displayName.isBlank()) {
+            noteBuilder.append(" by ").append(displayName);
+        }
+        noteBuilder.append("]");
     }
 
     /**


### PR DESCRIPTION
Appends `[Sent on DD-MMM-YYYY HH:mm by Provider Name]` to email chart notes identifying who sent the email

<img width="567" height="217" alt="image" src="https://github.com/user-attachments/assets/9c7cef39-6881-45f7-8c35-45dfe56963e4" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a [Sent on dd-MMM-yyyy H:mm by <name>] line to email chart notes to show who sent the email and when, with consistent timestamp formatting. Uses the provider’s signature (ProviderExt) if set; otherwise the provider’s full name; skips the “by” part if the provider name is missing.

<sup>Written for commit 541f81b1b83b2bae3c0aa7772635b15e78b4868a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

New Features:
- Add a sent-by annotation to email chart notes showing when the email was sent and by which provider, using a custom signature if available or the provider's full name otherwise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Email notes now include a "Sent by" line showing the sent timestamp and sender name.
  * The sender name will use a custom provider signature when available, otherwise the provider's full name.
  * The "Sent by" line is appended to the end of generated email notes for clearer sender attribution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->