### PR TITLE
Fix: disabled resizing on all eForm textarea elements

### DIFF
--- a/src/main/webapp/eform/eformFloatingToolbar/eform_floating_toolbar.js
+++ b/src/main/webapp/eform/eformFloatingToolbar/eform_floating_toolbar.js
@@ -841,7 +841,12 @@ function HideSpin() {
 	 * truncated during PDF generation.
 	 */
 	function disableTextareaResize() {
+		if (document.getElementById("eform-disable-textarea-resize")) {
+			return;
+		}
+
 		const style = document.createElement("style");
+		style.id = "eform-disable-textarea-resize";
 		style.textContent = "textarea { resize: none !important; }";
 		document.head.appendChild(style);
 	}


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                   
  Disable textarea resizing in eForms to prevent content truncation during PDF generation.


Fixes #2292 
                                                                                                                                                                                                                                            
##  Problem
  Bootstrap's CSS applies resize: vertical to all textareas. This allows users to expand textarea fields beyond their intended dimensions in eForms. When the form is converted to PDF via "Add to Documents," any content outside the original textarea boundaries is truncated, resulting in data loss.

 ## Solution
  Inject a CSS rule (textarea { resize: none !important; }) via the eForm floating toolbar JavaScript on page load. This prevents users from resizing textareas, ensuring the visible content matches what appears in the generated PDF. The fix is idempotent and applies to all textareas on the eForm page, including any added dynamically.



## Summary by Sourcery

Disable resizing for all eForm textarea elements to avoid content truncation in generated PDFs by injecting a global style on page load.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disables resizing on all eForm textarea fields to prevent text from being cut off in generated PDFs. Injects a single global style on load, guarded by an ID check, that sets textarea resize to none with !important.

<sup>Written for commit 36d1b3059461e83078d9b670a6726d76160a73ff. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Bug Fixes:
- Prevent textarea content from being truncated in generated PDFs by disabling resize on all eForm textareas via a global style rule injected on page load.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Text areas are no longer resizable, ensuring a consistent form layout across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->