### PR TITLE
fix: prevent duplicate inbox documents caused by non-deterministic pagination sort

### DIFF
--- a/src/main/java/ca/openosp/openo/commn/dao/InboxResultsDaoImpl.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/InboxResultsDaoImpl.java
@@ -275,7 +275,7 @@ public class InboxResultsDaoImpl implements InboxResultsDao {
                         + isDocAbnormalSql
                         + dateSql
                         + " GROUP BY doc.document_no"
-                        + " ORDER BY " + (dateSearchType.equals("receivedCreated") ? "doc.contentdatetime DESC," : "doc.observationdate DESC,") + " doc.document_no DESC "
+                        + " ORDER BY " + (dateSearchType.equals("receivedCreated") ? "doc.contentdatetime DESC" : "doc.observationdate DESC") + ", doc.document_no DESC "
                         + (isPaged ? "	LIMIT " + (page * pageSize) + "," + pageSize : "");
 
                 } else if (demographicNo != null && !"".equals(demographicNo)) {
@@ -316,7 +316,7 @@ public class InboxResultsDaoImpl implements InboxResultsDao {
                         + isDocAbnormalSql
                         + dateSql
                         + " GROUP BY doc.document_no"
-                        + " ORDER BY " + (dateSearchType.equals("receivedCreated") ? "doc.contentdatetime DESC," : "doc.observationdate DESC,") + " doc.document_no DESC "
+                        + " ORDER BY " + (dateSearchType.equals("receivedCreated") ? "doc.contentdatetime DESC" : "doc.observationdate DESC") + ", doc.document_no DESC "
                         + (isPaged ? "	LIMIT " + (page * pageSize) + "," + pageSize : "");
                 } else if (patientSearch) { // N arg
                     docNoLoc = 1;
@@ -361,7 +361,7 @@ public class InboxResultsDaoImpl implements InboxResultsDao {
                         + isDocAbnormalSql
                         + dateSql
                         + " GROUP BY doc.document_no"
-                        + " ORDER BY " + (dateSearchType.equals("receivedCreated") ? "doc.contentdatetime DESC," : "doc.observationdate DESC,") + " doc.document_no DESC "
+                        + " ORDER BY " + (dateSearchType.equals("receivedCreated") ? "doc.contentdatetime DESC" : "doc.observationdate DESC") + ", doc.document_no DESC "
                         + (isPaged ? "	LIMIT " + (page * pageSize) + "," + pageSize : "");
 
                 } else {
@@ -390,7 +390,7 @@ public class InboxResultsDaoImpl implements InboxResultsDao {
                         + isDocAbnormalSql
                         + dateSql
                         + " GROUP BY doc.document_no "
-                        + " ORDER BY " + (dateSearchType.equals("receivedCreated") ? "doc.contentdatetime DESC," : "doc.observationdate DESC,") + " doc.document_no DESC"
+                        + " ORDER BY " + (dateSearchType.equals("receivedCreated") ? "doc.contentdatetime DESC" : "doc.observationdate DESC") + ", doc.document_no DESC"
                         + (isPaged ? " LIMIT " + (page * pageSize) + "," + pageSize : "");
                 }
             } else { // Don't mix labs and docs.
@@ -418,7 +418,7 @@ public class InboxResultsDaoImpl implements InboxResultsDao {
                         + isDocAbnormalSql
                         + dateSql
                         + " GROUP BY doc.document_no"
-                        + " ORDER BY " + (dateSearchType.equals("receivedCreated") ? "doc.contentdatetime DESC," : "doc.observationdate DESC,") + " doc.document_no DESC"
+                        + " ORDER BY " + (dateSearchType.equals("receivedCreated") ? "doc.contentdatetime DESC" : "doc.observationdate DESC") + ", doc.document_no DESC"
                         + (isPaged ? "	LIMIT " + (page * pageSize) + "," + pageSize : "");
                 } else if (demographicNo != null && !"".equals(demographicNo)) {
                     docNoLoc = 1;
@@ -445,7 +445,7 @@ public class InboxResultsDaoImpl implements InboxResultsDao {
                         + isDocAbnormalSql
                         + dateSql
                         + " GROUP BY doc.document_no"
-                        + " ORDER BY " + (dateSearchType.equals("receivedCreated") ? "doc.contentdatetime DESC," : "doc.observationdate DESC,") + " doc.document_no DESC"
+                        + " ORDER BY " + (dateSearchType.equals("receivedCreated") ? "doc.contentdatetime DESC" : "doc.observationdate DESC") + ", doc.document_no DESC"
                         + (isPaged ? "	LIMIT " + (page * pageSize) + "," + pageSize : "");
                 } else if (patientSearch) {
                     docNoLoc = 1;
@@ -472,7 +472,7 @@ public class InboxResultsDaoImpl implements InboxResultsDao {
                         + isDocAbnormalSql
                         + dateSql
                         + " GROUP BY doc.document_no"
-                        + " ORDER BY " + (dateSearchType.equals("receivedCreated") ? "doc.contentdatetime DESC," : "doc.observationdate DESC,") + " doc.document_no DESC"
+                        + " ORDER BY " + (dateSearchType.equals("receivedCreated") ? "doc.contentdatetime DESC" : "doc.observationdate DESC") + ", doc.document_no DESC"
                         + (isPaged ? "	LIMIT " + (page * pageSize) + "," + pageSize : "");
                 } else {
                     docNoLoc = 1;
@@ -515,7 +515,7 @@ public class InboxResultsDaoImpl implements InboxResultsDao {
                         + " ON d.demographic_no = -1"
                         + ") AS X "
                         + " GROUP BY document_no"
-                        + " ORDER BY " + (dateSearchType.equals("receivedCreated") ? "contentdatetime DESC," : "observationdate DESC,") + " document_no DESC"
+                        + " ORDER BY " + (dateSearchType.equals("receivedCreated") ? "contentdatetime DESC" : "observationdate DESC") + ", document_no DESC"
                         + (isPaged ? "	LIMIT " + (page * pageSize) + "," + pageSize : "");
                 }
             }


### PR DESCRIPTION
## Problem
Documents appeared duplicated in the inbox when paginating through results.                                                                                                                                                                       
                                                                                                                                                                                                                                                    
The inbox loads results page by page via AJAX - page 1 fetches `LIMIT 0,20`, page 2 fetches `LIMIT 20,20`, and so on, appending each batch to the table until all results are loaded. When multiple documents share the same `observationdate`, MariaDB has no stable way to order those tied rows. The database is free to return them in any order it chooses, and that order is not guaranteed to be the same between two separate query executions.

This means the "boundary" between pages shifts. A document near the end of page 1 can slide into the start of page 2 on the next request. From the user's perspective, the same document simply appears twice in the list with no obvious reason why.

The problem is more likely to surface in busy inboxes where many documents are uploaded or received on the same day, as those documents all share an identical `observationdate` and form a large pool of tied rows that MariaDB can freely reorder.

This is confirmed expected behaviour in MySQL/MariaDB - it is not a database bug. The responsibility is on the query to provide a deterministic sort order.

## Root Cause
Ordering by date only, with no tie-breaker:
```sql
  ORDER BY doc.observationdate DESC
  LIMIT 20, 20
```

## Fix
Added doc.document_no DESC (or document_no DESC for the UNION path) as a secondary sort to query paths in InboxResultsDaoImpl.java.
```sql
  ORDER BY doc.observationdate DESC, doc.document_no DESC
  LIMIT 20, 20
```

## References

  - [MySQL Bug #69732](https://bugs.mysql.com/bug.php?id=69732) — closed "Not a Bug"; MySQL team states: *"make sure you ORDER BY on something guaranteed to be UNIQUE"*
  - [MySQL duplicates when sorting in descending order](https://oliverlundquist.com/2018/03/05/mysql-duplicates-when-sorting-in-descending-order.html) — same real-world scenario with `created_at DESC` pagination producing duplicates across pages
  - [MySQL Paging Sorting with Data Duplication — Priority Queue](https://www.sobyte.net/post/2021-09/mysql-paging-sorting-data-duplicates/) — explains the MySQL 5.6+ priority queue optimisation that makes tied-row ordering unstable between queries

## Summary by Sourcery

Bug Fixes:
- Prevent duplicate inbox documents across paginated results by adding document_no as a secondary descending sort key to date-based ordering in document queries.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents duplicate documents in the inbox by making pagination sorting deterministic.

- **Bug Fixes**
  - Added document_no DESC as a secondary sort after observationdate/contentdatetime in all inbox document queries (including the UNION path). Also moved the comma outside the ternary in ORDER BY for clearer SQL and consistent ordering.
  - Stabilizes LIMIT/OFFSET pagination so documents with the same date don’t shift between pages.

<sup>Written for commit 08319066382b0dedd3d5ac460d618e8db5054163. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced inbox results ordering to ensure more consistent and predictable display when documents share the same date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->