### PR TITLE
fix: restore epoch serialization for billing dates to fix Ocean sync error

### DIFF
--- a/src/main/java/ca/openosp/openo/webserv/rest/to/model/BillingDetailTo1.java
+++ b/src/main/java/ca/openosp/openo/webserv/rest/to/model/BillingDetailTo1.java
@@ -26,6 +26,8 @@ package ca.openosp.openo.webserv.rest.to.model;
 
 import ca.openosp.openo.commn.model.BillingONItem;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+
 import java.io.Serializable;
 import java.math.BigDecimal;
 import java.util.Date;
@@ -45,7 +47,9 @@ public class BillingDetailTo1 implements Serializable {
     private String providerNo;
     private Integer appointmentNo;
     private String province;
+    @JsonFormat(shape = JsonFormat.Shape.NUMBER)
     private Date billingDate;
+    @JsonFormat(shape = JsonFormat.Shape.NUMBER)
     private Date billingTime;
     private BigDecimal total;
     private BigDecimal paid;


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                        
  - Adds `@JsonFormat(shape = JsonFormat.Shape.NUMBER)` to `billingDate` and `billingTime` in `BillingDetailTo1`                                                                                                                                    
  - Forces both fields to serialize as epoch milliseconds (e.g. `1709510400000`) regardless of their value                                                                                                                                          
  - Restores the REST API response format that was in place before the Jackson dependency upgrade                                                                                                                                                   
                  
  ## Root Cause
  After the Jackson dependency upgrade, the serialization behaviour for billing date and time fields changed - these fields were previously returned as epoch numbers but began returning string-formatted values instead, breaking the Ocean integration sync.

  ## Impact
  Restoring epoch serialization for these fields is critical not only to fix the confirmed Ocean sync error, but also to prevent potential breakage in other third-party integrations that depend on the Oscar REST API. Any external system consuming these fields as numeric timestamps before the upgrade would silently break with the new string format.

## Summary by Sourcery

Restore numeric epoch-millisecond serialization for billing date and time fields to maintain compatibility with existing API consumers.

Bug Fixes:
- Fix Ocean integration sync failures caused by billing date and time being serialized as strings instead of numeric timestamps.

Enhancements:
- Explicitly configure billing date and time fields to serialize as epoch-millisecond numbers to preserve backward-compatible REST API behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore epoch millisecond serialization for billingDate and billingTime in BillingDetailTo1 to fix Ocean sync failures after the Jackson upgrade. Ensures the REST API returns numeric timestamps instead of date strings.

- **Bug Fixes**
  - Annotate billingDate and billingTime with @JsonFormat(shape = JsonFormat.Shape.NUMBER) to force epoch milliseconds.
  - Match pre-upgrade API behavior to avoid breaking Ocean and other consumers expecting numbers.

<sup>Written for commit aba67623b1f4bbe89855a52816c419985bd209fd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed date and time field serialization in API responses for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->