### PR TITLE
Fix: Update instructions/label for Asthma Action Plan measurement

### DIFF
--- a/database/mysql/oscardata.sql
+++ b/database/mysql/oscardata.sql
@@ -987,7 +987,7 @@ INSERT INTO `measurementType` (`type`, `typeDisplayName`, `typeDescription`, `me
 ( '24UR', '24-hr Urine cr clearance & albuminuria', 'Renal 24-hr Urine cr clearance & albuminuria', 'q 6-12 months, unit mg', '3', '2013-02-01 00:00:00'),
 ( '5DAA', '5 Day Adherence if on ART', '5 Day Adherence if on ART', 'number', '4', '2013-02-01 00:00:00'),
 ( 'A1C', 'A1C', 'A1C', 'Range:0.040-0.200', '3', '2013-02-01 00:00:00'),
-( 'AACP', 'Asthma Action Plan ', 'Asthma Action Plan ', 'Yes/No', '7', '2013-02-01 00:00:00'),
+( 'AACP', 'Asthma Action Plan ', 'Asthma Action Plan ', 'Provided/Revised/Reviewed', '18', '2013-02-01 00:00:00'),
 ( 'ABO', 'Blood Group', 'ABO RhD blood type group', 'Blood Type', '11', '2014-05-09 00:00:00'),
 ( 'ACOS', 'Asthma Coping Strategies', 'Asthma Coping Strategies', 'Yes/No', '7', '2013-02-01 00:00:00'),
 ( 'ACR', 'Alb creat ratio', 'ACR', 'in mg/mmol', '5', '2013-02-01 00:00:00'),
@@ -1455,7 +1455,8 @@ INSERT INTO `validations` (`id`, `name`, `regularExp`, `maxValue1`, `minValue`, 
 (14,'Numeric Value greater than or equal to 0',NULL,0,0,0,0,1,NULL,0),
 (15, 'Yes/No/Maybe', 'YES|yes|Yes|Y|NO|no|No|N|MAYBE|maybe|Maybe', NULL, NULL, NULL, NULL, NULL, NULL, NULL),
 (16, 'Review', 'REVIEWED|reviewed|Reviewed', NULL, NULL, NULL, NULL, NULL, NULL, NULL),
-(17,'pos or neg', 'pos|neg|positive|negative', NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+(17,'pos or neg', 'pos|neg|positive|negative', NULL, NULL, NULL, NULL, NULL, NULL, NULL),
+(18,'Provided/Revised/Reviewed', 'Provided|Revised|Reviewed', NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 
 insert into `secRole` values(1, 'receptionist', 'receptionist');

--- a/database/mysql/oscardata.sql
+++ b/database/mysql/oscardata.sql
@@ -987,7 +987,7 @@ INSERT INTO `measurementType` (`type`, `typeDisplayName`, `typeDescription`, `me
 ( '24UR', '24-hr Urine cr clearance & albuminuria', 'Renal 24-hr Urine cr clearance & albuminuria', 'q 6-12 months, unit mg', '3', '2013-02-01 00:00:00'),
 ( '5DAA', '5 Day Adherence if on ART', '5 Day Adherence if on ART', 'number', '4', '2013-02-01 00:00:00'),
 ( 'A1C', 'A1C', 'A1C', 'Range:0.040-0.200', '3', '2013-02-01 00:00:00'),
-( 'AACP', 'Asthma Action Plan ', 'Asthma Action Plan ', 'Plan', '18', '2013-02-01 00:00:00'),
+( 'AACP', 'Asthma Action Plan ', 'Asthma Action Plan ', 'Provided/Revised/Reviewed', '18', '2013-02-01 00:00:00'),
 ( 'ABO', 'Blood Group', 'ABO RhD blood type group', 'Blood Type', '11', '2014-05-09 00:00:00'),
 ( 'ACOS', 'Asthma Coping Strategies', 'Asthma Coping Strategies', 'Yes/No', '7', '2013-02-01 00:00:00'),
 ( 'ACR', 'Alb creat ratio', 'ACR', 'in mg/mmol', '5', '2013-02-01 00:00:00'),

--- a/database/mysql/oscardata.sql
+++ b/database/mysql/oscardata.sql
@@ -987,7 +987,7 @@ INSERT INTO `measurementType` (`type`, `typeDisplayName`, `typeDescription`, `me
 ( '24UR', '24-hr Urine cr clearance & albuminuria', 'Renal 24-hr Urine cr clearance & albuminuria', 'q 6-12 months, unit mg', '3', '2013-02-01 00:00:00'),
 ( '5DAA', '5 Day Adherence if on ART', '5 Day Adherence if on ART', 'number', '4', '2013-02-01 00:00:00'),
 ( 'A1C', 'A1C', 'A1C', 'Range:0.040-0.200', '3', '2013-02-01 00:00:00'),
-( 'AACP', 'Asthma Action Plan ', 'Asthma Action Plan ', 'Provided/Revised/Reviewed', '18', '2013-02-01 00:00:00'),
+( 'AACP', 'Asthma Action Plan ', 'Asthma Action Plan ', 'Plan', '18', '2013-02-01 00:00:00'),
 ( 'ABO', 'Blood Group', 'ABO RhD blood type group', 'Blood Type', '11', '2014-05-09 00:00:00'),
 ( 'ACOS', 'Asthma Coping Strategies', 'Asthma Coping Strategies', 'Yes/No', '7', '2013-02-01 00:00:00'),
 ( 'ACR', 'Alb creat ratio', 'ACR', 'in mg/mmol', '5', '2013-02-01 00:00:00'),

--- a/database/mysql/updates/update-2026-03-09-aacp-validation.sql
+++ b/database/mysql/updates/update-2026-03-09-aacp-validation.sql
@@ -11,5 +11,5 @@ WHERE NOT EXISTS (
 
 -- Point AACP to the Provided/Revised/Reviewed validation instead of the generic Yes/No/NA
 UPDATE measurementType
-SET validation = (SELECT id FROM validations WHERE name = 'Provided/Revised/Reviewed' LIMIT 1)
+SET validation = (SELECT id FROM validations WHERE name = 'Provided/Revised/Reviewed' ORDER BY id LIMIT 1)
 WHERE type = 'AACP';

--- a/database/mysql/updates/update-2026-03-09-aacp-validation.sql
+++ b/database/mysql/updates/update-2026-03-09-aacp-validation.sql
@@ -6,10 +6,10 @@
 INSERT INTO validations (name, regularExp)
 SELECT 'Provided/Revised/Reviewed', 'Provided|Revised|Reviewed'
 WHERE NOT EXISTS (
-    SELECT 1 FROM validations WHERE name = 'Provided/Revised/Reviewed'
+    SELECT 1 FROM validations WHERE name = 'Provided/Revised/Reviewed' AND regularExp = 'Provided|Revised|Reviewed'
 );
 
 -- Point AACP to the Provided/Revised/Reviewed validation instead of the generic Yes/No/NA
 UPDATE measurementType
-SET validation = (SELECT id FROM validations WHERE name = 'Provided/Revised/Reviewed' ORDER BY id LIMIT 1)
+SET validation = (SELECT id FROM validations WHERE name = 'Provided/Revised/Reviewed' AND regularExp = 'Provided|Revised|Reviewed' ORDER BY id LIMIT 1)
 WHERE type = 'AACP';

--- a/database/mysql/updates/update-2026-03-09-aacp-validation.sql
+++ b/database/mysql/updates/update-2026-03-09-aacp-validation.sql
@@ -1,0 +1,15 @@
+-- Update Asthma Action Plan (AACP) dropdown options
+-- Changes from generic Yes/No/NA to Provided/Revised/Reviewed per OMD DE16.098 conformance
+-- Issue: https://github.com/openo-beta/Open-O/issues/2319
+
+-- Create the Provided/Revised/Reviewed validation row if it doesn't already exist
+INSERT INTO validations (name, regularExp)
+SELECT 'Provided/Revised/Reviewed', 'Provided|Revised|Reviewed'
+WHERE NOT EXISTS (
+    SELECT 1 FROM validations WHERE name = 'Provided/Revised/Reviewed'
+);
+
+-- Point AACP to the Provided/Revised/Reviewed validation instead of the generic Yes/No/NA
+UPDATE measurementType
+SET validation = (SELECT id FROM validations WHERE name = 'Provided/Revised/Reviewed' LIMIT 1)
+WHERE type = 'AACP';

--- a/src/main/resources/oscar/oscarEncounter/oscarMeasurements/flowsheets/omdAsthmaFlowsheet.xml
+++ b/src/main/resources/oscar/oscarEncounter/oscarMeasurements/flowsheets/omdAsthmaFlowsheet.xml
@@ -109,7 +109,7 @@
 			</rule>
 		</ruleset>
 	</item>	
-	<item measurement_type="AACP" display_name="Action Plan" guideline="" graphable="yes" value_name="Provided/Revised/Reviewed" />
+	<item measurement_type="AACP" display_name="Action Plan" guideline="" graphable="yes" value_name="Plan" />
 	<item measurement_type="ARMA" display_name="Medication Adherence" guideline="" graphable="yes" value_name="Reviewed" />
 	<item measurement_type="SMCS" display_name="Smoking Cessation" guideline="" graphable="yes" value_name="Reviewed" />
 	<item measurement_type="ARDT" display_name="Device Technique Optimal" guideline="" graphable="no" value_name="Reviewed" />

--- a/src/main/webapp/oscarEncounter/oscarMeasurements/AddMeasurementData.jsp
+++ b/src/main/webapp/oscarEncounter/oscarMeasurements/AddMeasurementData.jsp
@@ -488,7 +488,7 @@
                                     <% String[] opts = validations.getName().contains("/") ? validations.getName().split("/") : validations.getRegularExp().split("\\|");
                                         boolean valFoundInOpts = false;
                                         for (String opt : opts) {
-                                            if (opt.equals(val)) valFoundInOpts = true;%>
+                                            if (val != null && opt.equals(val)) valFoundInOpts = true;%>
                                     <option value="<%=Encode.forHtmlAttribute(opt)%>"  <%=sel(opt, val)%>><%=Encode.forHtmlContent(opt)%>
                                     </option>
                                     <% }

--- a/src/main/webapp/oscarEncounter/oscarMeasurements/AddMeasurementData.jsp
+++ b/src/main/webapp/oscarEncounter/oscarMeasurements/AddMeasurementData.jsp
@@ -489,7 +489,7 @@
                                         boolean valFoundInOpts = false;
                                         for (String opt : opts) {
                                             if (opt.equals(val)) valFoundInOpts = true;%>
-                                    <option value="<%=opt%>"  <%=sel(opt, val)%>><%=opt%>
+                                    <option value="<%=Encode.forHtmlAttribute(opt)%>"  <%=sel(opt, val)%>><%=Encode.forHtmlContent(opt)%>
                                     </option>
                                     <% }
                                         if (val != null && !val.isEmpty() && !valFoundInOpts) { %>

--- a/src/main/webapp/oscarEncounter/oscarMeasurements/AddMeasurementData.jsp
+++ b/src/main/webapp/oscarEncounter/oscarMeasurements/AddMeasurementData.jsp
@@ -486,10 +486,16 @@
                                         name="<%= "inputValue-" + ctr %>">
                                     <option value=""></option>
                                     <% String[] opts = validations.getName().contains("/") ? validations.getName().split("/") : validations.getRegularExp().split("\\|");
-                                        for (String opt : opts) {%>
+                                        boolean valFoundInOpts = false;
+                                        for (String opt : opts) {
+                                            if (opt.equals(val)) valFoundInOpts = true;%>
                                     <option value="<%=opt%>"  <%=sel(opt, val)%>><%=opt%>
                                     </option>
-                                    <% }%>
+                                    <% }
+                                        if (val != null && !val.isEmpty() && !valFoundInOpts) { %>
+                                    <option value="<%=Encode.forHtmlAttribute(val)%>" selected disabled><%=Encode.forHtmlContent(val)%>
+                                    </option>
+                                    <% } %>
                                 </select>
                                 <%} else if (validations != null && validations.getName().startsWith("Integer")) { %>
                                 <select id="<%= "inputValue-" + ctr %>"


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                             
Updates the Asthma Action Plan (AACP) flowsheet dropdown from Yes/No/NA to Provided/Revised/Reviewed per OMD DE16.098 conformance requirements.

### See the "Manual Steps" section for required manual updates for these fixes on an already setup DB

Fixes #2319 
                                                                                                                                                                                                                                            
##  Problem         
                                                                                                                                                                                                                                            
  The AACP measurement type in the measurementType table pointed to a shared validations row (Yes/No/NA) used by 160+ other measurement types. The flowsheet XML already defined the correct Provided|Revised|Reviewed validation, but it was never applied because the ImportMeasurementTypes logic skips measurement types that already exist in the database.
                                                                                                                                                                                                                                            This meant the dropdown only offered Yes/No/NA options, which don't clarify whether the action plan was provided, revised, or reviewed.  

<img width="536" height="174" alt="image" src="https://github.com/user-attachments/assets/b8ae831a-e4ee-4be6-9238-d432d7659faa" />
                                                                                                 
   
##  Solution                                                                                                                                                                                                                                  
                  
- DB migration: Points the AACP measurementType row to the existing Provided/Revised/Reviewed validation row (inserts one if it doesn't exist)                                                                                            
- Flowsheet XML: Updates value_name from "Provided/Revised/Reviewed" to "Plan" to set the dropdown label
- Legacy data handling: When viewing an existing measurement entry whose stored value doesn't match the current dropdown options, the old value is shown as a disabled selected option so historical data remains visible                 
                                    
<img width="510" height="210" alt="image" src="https://github.com/user-attachments/assets/24ac8ed6-3b03-449c-9a35-20e6b5a7c3e4" />

                                                                                                                                                                                                       
## Manual Steps 
                                                                                                                                                                                                                                                                                                                                                                                                                                                                        
Run the database migration script before deploying:                                                                                                                                                                                      
                  
database/mysql/updates/update-2026-03-09-aacp-validation.sql

## Summary by Sourcery

Align the Asthma Action Plan (AACP) measurement with the correct Provided/Revised/Reviewed options and label while preserving visibility of historical data.

Bug Fixes:
- Ensure the AACP dropdown uses Provided/Revised/Reviewed options instead of the generic Yes/No/NA validation.
- Display legacy AACP measurement values that no longer match current options as a disabled, selected option so historical entries remain visible.

Enhancements:
- HTML-encode dropdown option labels and values in the measurement entry UI for safer rendering.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the Asthma Action Plan (AACP) dropdown from Yes/No/NA to Provided/Revised/Reviewed and sets the flowsheet label to "Plan" per OMD DE16.098. Preserves legacy entries, HTML-encodes options, and updates seed data and `.devcontainer` dev script to include these changes. Fixes #2319.

- **Bug Fixes**
  - DB: Point `AACP` to the Provided/Revised/Reviewed validation (create if missing) and select the id deterministically with ORDER BY.
  - Seed: Add the Provided/Revised/Reviewed validation, set `AACP` to use it for new installs, restore legacy `measurementInstructions`, and update `.devcontainer/db/scripts/development.sql` for devcontainer rebuilds.
  - UI: Parse options from `regularExp`, add a null-safe value match, HTML-encode, and show unmatched legacy values as a disabled selected option.

- **Migration**
  - Run `database/mysql/updates/update-2026-03-09-aacp-validation.sql` before deploy.

<sup>Written for commit 6844968ed1f1a17d3d0bf322a105356343bc48e6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of previously saved values in measurement data entry forms, preventing them from being lost when re-editing records.
  * Updated Asthma Action Plan measurement validation and option display logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->