### PR TITLE
Performance: slow edit specialists page

### DIFF
--- a/src/main/java/ca/openosp/openo/commn/dao/ProfessionalSpecialistDao.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/ProfessionalSpecialistDao.java
@@ -29,10 +29,20 @@ package ca.openosp.openo.commn.dao;
 import java.util.List;
 
 import ca.openosp.openo.commn.model.ProfessionalSpecialist;
+import ca.openosp.openo.consultation.dto.SpecialistListDTO;
 
 public interface ProfessionalSpecialistDao extends AbstractDao<ProfessionalSpecialist> {
 
     List<ProfessionalSpecialist> findAll();
+
+    /**
+     * Returns lightweight projections of all specialists for list display,
+     * fetching only the columns needed (id, name, letters, address, phone, fax).
+     * Avoids full entity hydration of heavy text fields.
+     *
+     * @return List&lt;SpecialistListDTO&gt; specialists ordered by last name, first name
+     */
+    List<SpecialistListDTO> findAllListDTOs();
 
     List<ProfessionalSpecialist> findByEDataUrlNotNull();
 

--- a/src/main/java/ca/openosp/openo/commn/dao/ProfessionalSpecialistDaoImpl.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/ProfessionalSpecialistDaoImpl.java
@@ -36,6 +36,7 @@ import javax.persistence.Query;
 
 import org.apache.commons.lang3.StringUtils;
 import ca.openosp.openo.commn.model.ProfessionalSpecialist;
+import ca.openosp.openo.consultation.dto.SpecialistListDTO;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -53,6 +54,22 @@ public class ProfessionalSpecialistDaoImpl extends AbstractDaoImpl<ProfessionalS
         List<ProfessionalSpecialist> results = query.getResultList();
 
         return (results);
+    }
+
+    @Override
+    public List<SpecialistListDTO> findAllListDTOs() {
+        Query query = entityManager.createQuery(
+                "SELECT NEW ca.openosp.openo.consultation.dto.SpecialistListDTO("
+                        + "x.id, x.firstName, x.lastName, x.professionalLetters, "
+                        + "x.streetAddress, x.phoneNumber, x.faxNumber) "
+                        + "FROM ProfessionalSpecialist x "
+                        + "ORDER BY x.lastName, x.firstName"
+        );
+
+        @SuppressWarnings("unchecked")
+        List<SpecialistListDTO> results = query.getResultList();
+
+        return results;
     }
 
     /**

--- a/src/main/java/ca/openosp/openo/commn/dao/ProfessionalSpecialistDaoImpl.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/ProfessionalSpecialistDaoImpl.java
@@ -33,6 +33,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.persistence.Query;
+import javax.persistence.TypedQuery;
 
 import org.apache.commons.lang3.StringUtils;
 import ca.openosp.openo.commn.model.ProfessionalSpecialist;
@@ -58,18 +59,16 @@ public class ProfessionalSpecialistDaoImpl extends AbstractDaoImpl<ProfessionalS
 
     @Override
     public List<SpecialistListDTO> findAllListDTOs() {
-        Query query = entityManager.createQuery(
+        TypedQuery<SpecialistListDTO> query = entityManager.createQuery(
                 "SELECT NEW ca.openosp.openo.consultation.dto.SpecialistListDTO("
                         + "x.id, x.firstName, x.lastName, x.professionalLetters, "
                         + "x.streetAddress, x.phoneNumber, x.faxNumber) "
                         + "FROM ProfessionalSpecialist x "
-                        + "ORDER BY x.lastName, x.firstName"
+                        + "ORDER BY x.lastName, x.firstName",
+                SpecialistListDTO.class
         );
 
-        @SuppressWarnings("unchecked")
-        List<SpecialistListDTO> results = query.getResultList();
-
-        return results;
+        return query.getResultList();
     }
 
     /**

--- a/src/main/java/ca/openosp/openo/consultation/dto/SpecialistListDTO.java
+++ b/src/main/java/ca/openosp/openo/consultation/dto/SpecialistListDTO.java
@@ -1,0 +1,58 @@
+package ca.openosp.openo.consultation.dto;
+
+import java.io.Serializable;
+
+/**
+ * Lightweight DTO for specialist list views (Edit Specialists, Display Service).
+ * <p>
+ * Uses JPQL constructor projection to fetch only the columns needed for list display,
+ * avoiding full {@code ProfessionalSpecialist} entity hydration which includes heavy
+ * text fields ({@code eDataOscarKey}, {@code eDataServiceKey}, {@code annotation}).
+ * With 10k+ specialist records, this eliminates significant unnecessary data transfer.
+ * </p>
+ *
+ * @since 2026-03-09
+ */
+public class SpecialistListDTO implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final Integer id;
+    private final String firstName;
+    private final String lastName;
+    private final String professionalLetters;
+    private final String streetAddress;
+    private final String phoneNumber;
+    private final String faxNumber;
+
+    /**
+     * JPQL constructor projection target.
+     *
+     * @param id Integer the specialist ID (maps to {@code specId} column)
+     * @param firstName String the specialist's first name
+     * @param lastName String the specialist's last name
+     * @param professionalLetters String professional designation letters (e.g. "MD, FRCPC")
+     * @param streetAddress String the specialist's street address
+     * @param phoneNumber String the specialist's phone number
+     * @param faxNumber String the specialist's fax number
+     */
+    public SpecialistListDTO(Integer id, String firstName, String lastName,
+                             String professionalLetters, String streetAddress,
+                             String phoneNumber, String faxNumber) {
+        this.id = id;
+        this.firstName = firstName;
+        this.lastName = lastName;
+        this.professionalLetters = professionalLetters;
+        this.streetAddress = streetAddress;
+        this.phoneNumber = phoneNumber;
+        this.faxNumber = faxNumber;
+    }
+
+    public Integer getId() { return id; }
+    public String getFirstName() { return firstName; }
+    public String getLastName() { return lastName; }
+    public String getProfessionalLetters() { return professionalLetters; }
+    public String getStreetAddress() { return streetAddress; }
+    public String getPhoneNumber() { return phoneNumber; }
+    public String getFaxNumber() { return faxNumber; }
+}

--- a/src/main/java/ca/openosp/openo/consultation/dto/SpecialistListDTO.java
+++ b/src/main/java/ca/openosp/openo/consultation/dto/SpecialistListDTO.java
@@ -48,11 +48,24 @@ public class SpecialistListDTO implements Serializable {
         this.faxNumber = faxNumber;
     }
 
+    /** @return Integer the specialist ID (maps to {@code specId} column) */
     public Integer getId() { return id; }
+
+    /** @return String the specialist's first name */
     public String getFirstName() { return firstName; }
+
+    /** @return String the specialist's last name */
     public String getLastName() { return lastName; }
+
+    /** @return String professional designation letters (e.g. "MD, FRCPC"), may be null */
     public String getProfessionalLetters() { return professionalLetters; }
+
+    /** @return String the specialist's street address, may be null */
     public String getStreetAddress() { return streetAddress; }
+
+    /** @return String the specialist's phone number, may be null */
     public String getPhoneNumber() { return phoneNumber; }
+
+    /** @return String the specialist's fax number, may be null */
     public String getFaxNumber() { return faxNumber; }
 }

--- a/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/config/pageUtil/EctConDisplayServiceUtil.java
+++ b/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/config/pageUtil/EctConDisplayServiceUtil.java
@@ -26,6 +26,7 @@
 
 package ca.openosp.openo.encounter.oscarConsultationRequest.config.pageUtil;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Vector;
 
@@ -42,15 +43,18 @@ import ca.openosp.openo.util.ConversionUtils;
 public class EctConDisplayServiceUtil {
     private ConsultationServiceDao consultationServiceDao = (ConsultationServiceDao) SpringUtils.getBean(ConsultationServiceDao.class);
 
-    public Vector<String> fNameVec;
-    public Vector<String> lNameVec;
-    public Vector<String> proLettersVec;
-    public Vector<String> addressVec;
-    public Vector<String> phoneVec;
-    public Vector<String> faxVec;
-    public Vector<String> specIdVec;
+    private List<SpecialistListDTO> specialists = Collections.emptyList();
     public Vector<String> serviceName;
     public Vector<String> serviceId;
+
+    /**
+     * Returns the lightweight specialist list loaded by {@link #loadSpecialists()}.
+     *
+     * @return List&lt;SpecialistListDTO&gt; specialists ordered by last name, first name
+     */
+    public List<SpecialistListDTO> getSpecialists() {
+        return specialists;
+    }
 
     public String getServiceDesc(String serId) {
         String retval = new String();
@@ -64,28 +68,19 @@ public class EctConDisplayServiceUtil {
     }
 
     public void estSpecialist() {
-        estSpecialistVector();
+        loadSpecialists();
     }
 
     public void estSpecialistVector() {
-        fNameVec = new Vector<String>();
-        lNameVec = new Vector<String>();
-        proLettersVec = new Vector<String>();
-        addressVec = new Vector<String>();
-        phoneVec = new Vector<String>();
-        faxVec = new Vector<String>();
-        specIdVec = new Vector<String>();
+        loadSpecialists();
+    }
 
+    /**
+     * Loads all specialists as lightweight DTO projections for list display.
+     */
+    public void loadSpecialists() {
         ProfessionalSpecialistDao dao = SpringUtils.getBean(ProfessionalSpecialistDao.class);
-        for (SpecialistListDTO dto : dao.findAllListDTOs()) {
-            fNameVec.add(dto.getFirstName());
-            lNameVec.add(dto.getLastName());
-            proLettersVec.add(dto.getProfessionalLetters());
-            addressVec.add(dto.getStreetAddress());
-            phoneVec.add(dto.getPhoneNumber());
-            faxVec.add(dto.getFaxNumber());
-            specIdVec.add(dto.getId().toString());
-        }
+        specialists = dao.findAllListDTOs();
     }
 
     public Vector<String> getSpecialistInField(String serviceId) {

--- a/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/config/pageUtil/EctConDisplayServiceUtil.java
+++ b/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/config/pageUtil/EctConDisplayServiceUtil.java
@@ -26,7 +26,6 @@
 
 package ca.openosp.openo.encounter.oscarConsultationRequest.config.pageUtil;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Vector;
 
@@ -34,8 +33,8 @@ import ca.openosp.openo.commn.dao.ConsultationServiceDao;
 import ca.openosp.openo.commn.dao.ProfessionalSpecialistDao;
 import ca.openosp.openo.commn.dao.ServiceSpecialistsDao;
 import ca.openosp.openo.commn.model.ConsultationServices;
-import ca.openosp.openo.commn.model.ProfessionalSpecialist;
 import ca.openosp.openo.commn.model.ServiceSpecialists;
+import ca.openosp.openo.consultation.dto.SpecialistListDTO;
 import ca.openosp.openo.utility.SpringUtils;
 
 import ca.openosp.openo.util.ConversionUtils;
@@ -49,13 +48,9 @@ public class EctConDisplayServiceUtil {
     public Vector<String> addressVec;
     public Vector<String> phoneVec;
     public Vector<String> faxVec;
-    public Vector<String> websiteVec;
-    public Vector<String> emailVec;
-    public Vector<String> specTypeVec;
     public Vector<String> specIdVec;
     public Vector<String> serviceName;
     public Vector<String> serviceId;
-    public ArrayList<String> referralNoVec;
 
     public String getServiceDesc(String serId) {
         String retval = new String();
@@ -79,24 +74,17 @@ public class EctConDisplayServiceUtil {
         addressVec = new Vector<String>();
         phoneVec = new Vector<String>();
         faxVec = new Vector<String>();
-        websiteVec = new Vector<String>();
-        emailVec = new Vector<String>();
-        specTypeVec = new Vector<String>();
         specIdVec = new Vector<String>();
-        referralNoVec = new ArrayList<String>();
 
         ProfessionalSpecialistDao dao = SpringUtils.getBean(ProfessionalSpecialistDao.class);
-        for (ProfessionalSpecialist ps : dao.findAll()) {
-            fNameVec.add(ps.getFirstName());
-            lNameVec.add(ps.getLastName());
-            proLettersVec.add(ps.getProfessionalLetters());
-            addressVec.add(ps.getStreetAddress());
-            phoneVec.add(ps.getPhoneNumber());
-            faxVec.add(ps.getFaxNumber());
-            websiteVec.add(ps.getWebSite());
-            emailVec.add(ps.getEmailAddress());
-            specTypeVec.add(ps.getSpecialtyType());
-            specIdVec.add(ps.getId().toString());
+        for (SpecialistListDTO dto : dao.findAllListDTOs()) {
+            fNameVec.add(dto.getFirstName());
+            lNameVec.add(dto.getLastName());
+            proLettersVec.add(dto.getProfessionalLetters());
+            addressVec.add(dto.getStreetAddress());
+            phoneVec.add(dto.getPhoneNumber());
+            faxVec.add(dto.getFaxNumber());
+            specIdVec.add(dto.getId().toString());
         }
     }
 

--- a/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/config/pageUtil/EctConDisplayServiceUtil.java
+++ b/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/config/pageUtil/EctConDisplayServiceUtil.java
@@ -26,35 +26,18 @@
 
 package ca.openosp.openo.encounter.oscarConsultationRequest.config.pageUtil;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Vector;
 
 import ca.openosp.openo.commn.dao.ConsultationServiceDao;
-import ca.openosp.openo.commn.dao.ProfessionalSpecialistDao;
-import ca.openosp.openo.commn.dao.ServiceSpecialistsDao;
 import ca.openosp.openo.commn.model.ConsultationServices;
-import ca.openosp.openo.commn.model.ServiceSpecialists;
-import ca.openosp.openo.consultation.dto.SpecialistListDTO;
 import ca.openosp.openo.utility.SpringUtils;
-
-import ca.openosp.openo.util.ConversionUtils;
 
 public class EctConDisplayServiceUtil {
     private ConsultationServiceDao consultationServiceDao = (ConsultationServiceDao) SpringUtils.getBean(ConsultationServiceDao.class);
 
-    private List<SpecialistListDTO> specialists = Collections.emptyList();
     public Vector<String> serviceName;
     public Vector<String> serviceId;
-
-    /**
-     * Returns the lightweight specialist list loaded by {@link #loadSpecialists()}.
-     *
-     * @return List&lt;SpecialistListDTO&gt; specialists ordered by last name, first name
-     */
-    public List<SpecialistListDTO> getSpecialists() {
-        return specialists;
-    }
 
     public String getServiceDesc(String serId) {
         String retval = new String();
@@ -65,32 +48,6 @@ public class EctConDisplayServiceUtil {
         }
 
         return retval;
-    }
-
-    public void estSpecialist() {
-        loadSpecialists();
-    }
-
-    public void estSpecialistVector() {
-        loadSpecialists();
-    }
-
-    /**
-     * Loads all specialists as lightweight DTO projections for list display.
-     */
-    public void loadSpecialists() {
-        ProfessionalSpecialistDao dao = SpringUtils.getBean(ProfessionalSpecialistDao.class);
-        specialists = dao.findAllListDTOs();
-    }
-
-    public Vector<String> getSpecialistInField(String serviceId) {
-        Vector<String> vector = new Vector<String>();
-        ServiceSpecialistsDao dao = SpringUtils.getBean(ServiceSpecialistsDao.class);
-
-        for (ServiceSpecialists ss : dao.findByServiceId(ConversionUtils.fromIntString(serviceId))) {
-            vector.add("" + ss.getId().getSpecId());
-        }
-        return vector;
     }
 
     public void estServicesVectors() {

--- a/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/config/pageUtil/SpecialistList2Action.java
+++ b/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/config/pageUtil/SpecialistList2Action.java
@@ -60,6 +60,15 @@ public class SpecialistList2Action extends ActionSupport {
      */
     @Override
     public String execute() {
+        if (!"POST".equals(request.getMethod())) {
+            try {
+                response.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED, "POST required");
+            } catch (IOException e) {
+                MiscUtils.getLogger().error("Error sending 405 response", e);
+            }
+            return null;
+        }
+
         if (!securityInfoManager.hasPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), "_con", "r", null)) {
             throw new SecurityException("missing required security object (_con)");
         }
@@ -90,21 +99,8 @@ public class SpecialistList2Action extends ActionSupport {
     private String getSpecialists() {
         try {
             List<SpecialistListDTO> specialists = professionalSpecialistDao.findAllListDTOs();
-
-            ArrayNode array = MAPPER.createArrayNode();
-            for (SpecialistListDTO dto : specialists) {
-                ArrayNode row = MAPPER.createArrayNode();
-                row.add(dto.getId());
-                row.add(buildDisplayName(dto));
-                row.add(StringUtils.defaultString(dto.getStreetAddress()));
-                row.add(StringUtils.defaultString(dto.getPhoneNumber()));
-                row.add(StringUtils.defaultString(dto.getFaxNumber()));
-                array.add(row);
-            }
-
-            writeJsonResponse(array);
+            writeSpecialistRows(specialists, null);
             return null;
-
         } catch (Exception e) {
             return handleServerError("Error loading specialist list", e);
         }
@@ -131,25 +127,47 @@ public class SpecialistList2Action extends ActionSupport {
 
             List<SpecialistListDTO> specialists = professionalSpecialistDao.findAllListDTOs();
             Set<String> assignedIds = loadAssignedSpecialistIds(serviceId);
-
-            ArrayNode array = MAPPER.createArrayNode();
-            for (SpecialistListDTO dto : specialists) {
-                ArrayNode row = MAPPER.createArrayNode();
-                row.add(dto.getId());
-                row.add(buildDisplayName(dto));
-                row.add(StringUtils.defaultString(dto.getStreetAddress()));
-                row.add(StringUtils.defaultString(dto.getPhoneNumber()));
-                row.add(StringUtils.defaultString(dto.getFaxNumber()));
-                row.add(assignedIds.contains(dto.getId().toString()));
-                array.add(row);
-            }
-
-            writeJsonResponse(array);
+            writeSpecialistRows(specialists, assignedIds);
             return null;
-
         } catch (Exception e) {
             return handleServerError("Error loading specialist list for service", e);
         }
+    }
+
+    /**
+     * Builds a JSON row for a single specialist DTO.
+     *
+     * @param dto SpecialistListDTO the specialist data
+     * @return ArrayNode row: {@code [id, "name", "address", "phone", "fax"]}
+     */
+    private static ArrayNode buildRow(SpecialistListDTO dto) {
+        ArrayNode row = MAPPER.createArrayNode();
+        row.add(dto.getId());
+        row.add(buildDisplayName(dto));
+        row.add(StringUtils.defaultString(dto.getStreetAddress()));
+        row.add(StringUtils.defaultString(dto.getPhoneNumber()));
+        row.add(StringUtils.defaultString(dto.getFaxNumber()));
+        return row;
+    }
+
+    /**
+     * Writes a JSON array of specialist rows to the response.
+     *
+     * @param specialists List&lt;SpecialistListDTO&gt; the specialist data
+     * @param assignedIds Set&lt;String&gt; specialist IDs assigned to a service, or null if not applicable
+     * @throws IOException if writing to response fails
+     */
+    private void writeSpecialistRows(List<SpecialistListDTO> specialists,
+                                     Set<String> assignedIds) throws IOException {
+        ArrayNode array = MAPPER.createArrayNode();
+        for (SpecialistListDTO dto : specialists) {
+            ArrayNode row = buildRow(dto);
+            if (assignedIds != null) {
+                row.add(assignedIds.contains(dto.getId().toString()));
+            }
+            array.add(row);
+        }
+        writeJsonResponse(array);
     }
 
     /**

--- a/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/config/pageUtil/SpecialistList2Action.java
+++ b/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/config/pageUtil/SpecialistList2Action.java
@@ -72,7 +72,6 @@ public class SpecialistList2Action extends ActionSupport {
             return getSpecialistsForService();
         }
 
-        MiscUtils.getLogger().warn("SpecialistList2Action: invalid method parameter: " + method);
         try {
             response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid or missing method parameter");
         } catch (IOException e) {

--- a/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/config/pageUtil/SpecialistList2Action.java
+++ b/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/config/pageUtil/SpecialistList2Action.java
@@ -33,7 +33,7 @@ import ca.openosp.openo.utility.SpringUtils;
  * shell first, then fetch data via {@code fetch()} POST. This decouples the page shell
  * from the data payload, reducing perceived load time and keeping the HTML response small.</p>
  *
- * <p>Endpoints (all POST):</p>
+ * <p>Endpoints (all POST, CSRF-protected via CsrfGuard token header):</p>
  * <ul>
  *   <li>{@code method=getSpecialists} - Returns all specialists for the EditSpecialists page.
  *       Each row: {@code [id, "name", "address", "phone", "fax"]}</li>
@@ -73,7 +73,12 @@ public class SpecialistList2Action extends ActionSupport {
         }
 
         MiscUtils.getLogger().warn("SpecialistList2Action: invalid method parameter: " + method);
-        return NONE;
+        try {
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid or missing method parameter");
+        } catch (IOException e) {
+            MiscUtils.getLogger().error("Error sending 400 response", e);
+        }
+        return null;
     }
 
     /**
@@ -173,7 +178,12 @@ public class SpecialistList2Action extends ActionSupport {
         String lName = StringUtils.defaultString(dto.getLastName());
         String fName = StringUtils.defaultString(dto.getFirstName());
         String proLetters = dto.getProfessionalLetters();
-        return lName + " " + fName + (proLetters == null ? "" : " " + proLetters);
+        StringBuilder name = new StringBuilder();
+        name.append(lName).append(" ").append(fName);
+        if (StringUtils.isNotBlank(proLetters)) {
+            name.append(" ").append(proLetters);
+        }
+        return name.toString();
     }
 
     /**

--- a/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/config/pageUtil/SpecialistList2Action.java
+++ b/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/config/pageUtil/SpecialistList2Action.java
@@ -1,0 +1,207 @@
+//CHECKSTYLE:OFF
+package ca.openosp.openo.encounter.oscarConsultationRequest.config.pageUtil;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.struts2.ServletActionContext;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.opensymphony.xwork2.ActionSupport;
+
+import ca.openosp.openo.commn.dao.ProfessionalSpecialistDao;
+import ca.openosp.openo.commn.dao.ServiceSpecialistsDao;
+import ca.openosp.openo.commn.model.ServiceSpecialists;
+import ca.openosp.openo.consultation.dto.SpecialistListDTO;
+import ca.openosp.openo.managers.SecurityInfoManager;
+import ca.openosp.openo.util.ConversionUtils;
+import ca.openosp.openo.utility.LoggedInInfo;
+import ca.openosp.openo.utility.MiscUtils;
+import ca.openosp.openo.utility.SpringUtils;
+
+/**
+ * Struts2 action providing JSON endpoints for specialist list data.
+ *
+ * <p>Serves specialist data as a separate AJAX endpoint so JSP pages load a lightweight
+ * shell first, then fetch data via {@code fetch()} POST. This decouples the page shell
+ * from the data payload, reducing perceived load time and keeping the HTML response small.</p>
+ *
+ * <p>Endpoints (all POST):</p>
+ * <ul>
+ *   <li>{@code method=getSpecialists} - Returns all specialists for the EditSpecialists page.
+ *       Each row: {@code [id, "name", "address", "phone", "fax"]}</li>
+ *   <li>{@code method=getSpecialistsForService} - Returns all specialists with checked state
+ *       for the DisplayService page. Each row: {@code [id, "name", "address", "phone", "fax", checked]}</li>
+ * </ul>
+ *
+ * @since 2026-03-10
+ */
+public class SpecialistList2Action extends ActionSupport {
+
+    private HttpServletRequest request = ServletActionContext.getRequest();
+    private HttpServletResponse response = ServletActionContext.getResponse();
+
+    private SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
+    private ProfessionalSpecialistDao professionalSpecialistDao = SpringUtils.getBean(ProfessionalSpecialistDao.class);
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    /**
+     * Main dispatcher that routes to the appropriate method based on 'method' parameter.
+     *
+     * @return String action result (null when response is written directly)
+     */
+    @Override
+    public String execute() {
+        if (!securityInfoManager.hasPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), "_con", "r", null)) {
+            throw new SecurityException("missing required security object (_con)");
+        }
+
+        String method = request.getParameter("method");
+
+        if ("getSpecialists".equals(method)) {
+            return getSpecialists();
+        } else if ("getSpecialistsForService".equals(method)) {
+            return getSpecialistsForService();
+        }
+
+        MiscUtils.getLogger().warn("SpecialistList2Action: invalid method parameter: " + method);
+        return NONE;
+    }
+
+    /**
+     * Returns all specialists as a JSON array for the EditSpecialists page.
+     *
+     * <p>Each row is {@code [id, "name", "address", "phone", "fax"]}.</p>
+     *
+     * @return null (response written directly to output stream)
+     */
+    private String getSpecialists() {
+        try {
+            List<SpecialistListDTO> specialists = professionalSpecialistDao.findAllListDTOs();
+
+            ArrayNode array = MAPPER.createArrayNode();
+            for (SpecialistListDTO dto : specialists) {
+                ArrayNode row = MAPPER.createArrayNode();
+                row.add(dto.getId());
+                row.add(buildDisplayName(dto));
+                row.add(StringUtils.defaultString(dto.getStreetAddress()));
+                row.add(StringUtils.defaultString(dto.getPhoneNumber()));
+                row.add(StringUtils.defaultString(dto.getFaxNumber()));
+                array.add(row);
+            }
+
+            writeJsonResponse(array);
+            return null;
+
+        } catch (Exception e) {
+            return handleServerError("Error loading specialist list", e);
+        }
+    }
+
+    /**
+     * Returns all specialists with checked state for the DisplayService page.
+     *
+     * <p>Each row is {@code [id, "name", "address", "phone", "fax", checked]}.
+     * The {@code checked} boolean indicates whether the specialist is assigned to
+     * the given service.</p>
+     *
+     * @return null (response written directly to output stream)
+     */
+    private String getSpecialistsForService() {
+        try {
+            String serviceIdParam = request.getParameter("serviceId");
+            Integer serviceId = ConversionUtils.fromIntString(serviceIdParam);
+
+            if (serviceId == null) {
+                response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Missing or invalid serviceId parameter");
+                return null;
+            }
+
+            List<SpecialistListDTO> specialists = professionalSpecialistDao.findAllListDTOs();
+            Set<String> assignedIds = loadAssignedSpecialistIds(serviceId);
+
+            ArrayNode array = MAPPER.createArrayNode();
+            for (SpecialistListDTO dto : specialists) {
+                ArrayNode row = MAPPER.createArrayNode();
+                row.add(dto.getId());
+                row.add(buildDisplayName(dto));
+                row.add(StringUtils.defaultString(dto.getStreetAddress()));
+                row.add(StringUtils.defaultString(dto.getPhoneNumber()));
+                row.add(StringUtils.defaultString(dto.getFaxNumber()));
+                row.add(assignedIds.contains(dto.getId().toString()));
+                array.add(row);
+            }
+
+            writeJsonResponse(array);
+            return null;
+
+        } catch (Exception e) {
+            return handleServerError("Error loading specialist list for service", e);
+        }
+    }
+
+    /**
+     * Loads the set of specialist IDs assigned to a given service.
+     *
+     * @param serviceId Integer the consultation service ID
+     * @return Set&lt;String&gt; specialist IDs assigned to the service
+     */
+    private Set<String> loadAssignedSpecialistIds(Integer serviceId) {
+        ServiceSpecialistsDao dao = SpringUtils.getBean(ServiceSpecialistsDao.class);
+        Set<String> ids = new HashSet<>();
+        for (ServiceSpecialists ss : dao.findByServiceId(serviceId)) {
+            ids.add(String.valueOf(ss.getId().getSpecId()));
+        }
+        return ids;
+    }
+
+    /**
+     * Formats a specialist name for display: "LastName FirstName ProLetters".
+     *
+     * @param dto SpecialistListDTO the specialist data
+     * @return String the formatted display name
+     */
+    private static String buildDisplayName(SpecialistListDTO dto) {
+        String lName = StringUtils.defaultString(dto.getLastName());
+        String fName = StringUtils.defaultString(dto.getFirstName());
+        String proLetters = dto.getProfessionalLetters();
+        return lName + " " + fName + (proLetters == null ? "" : " " + proLetters);
+    }
+
+    /**
+     * Writes a JSON response to the output stream.
+     *
+     * @param data ArrayNode the JSON data to write
+     * @throws IOException if writing to response fails
+     */
+    private void writeJsonResponse(ArrayNode data) throws IOException {
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        MAPPER.writeValue(response.getWriter(), data);
+    }
+
+    /**
+     * Handles server errors by logging and sending an HTTP 500 response.
+     *
+     * @param logMessage String message to log
+     * @param e Exception that occurred
+     * @return null (response written directly)
+     */
+    private String handleServerError(String logMessage, Exception e) {
+        MiscUtils.getLogger().error(logMessage, e);
+        try {
+            response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "An error occurred loading specialist data");
+        } catch (IOException ioException) {
+            MiscUtils.getLogger().error("Error sending error response", ioException);
+        }
+        return null;
+    }
+}

--- a/src/main/webapp/WEB-INF/classes/struts.xml
+++ b/src/main/webapp/WEB-INF/classes/struts.xml
@@ -981,6 +981,7 @@
             <result name="success">/oscarEncounter/oscarConsultationRequest/config/EnableRequestResponse.jsp</result>
         </action>
         <action name="oscarEncounter/ConsultationLookup2Action" class="ca.openosp.openo.encounter.oscarConsultationRequest.config.pageUtil.ConsultationLookup2Action"/>
+        <action name="oscarEncounter/SpecialistList" class="ca.openosp.openo.encounter.oscarConsultationRequest.config.pageUtil.SpecialistList2Action"/>
         <action name="oscarEncounter/AddService" class="ca.openosp.openo.encounter.oscarConsultationRequest.config.pageUtil.EctConAddService2Action">
             <result name="success">/oscarEncounter/oscarConsultationRequest/config/AddService.jsp</result>
         </action>

--- a/src/main/webapp/js/specialistListRenderer.js
+++ b/src/main/webapp/js/specialistListRenderer.js
@@ -1,0 +1,64 @@
+/**
+ * Shared batch renderer for specialist list pages (EditSpecialists, DisplayService).
+ *
+ * Fetches specialist JSON from SpecialistList2Action via POST and renders rows
+ * in batches using requestAnimationFrame for non-blocking DOM updates.
+ * Includes OWASP CsrfGuard token in the request header for CSRF protection.
+ *
+ * @param {Object} options
+ * @param {string} options.url - The fetch URL for the specialist data endpoint
+ * @param {string} options.tbodyId - The ID of the tbody element to render into
+ * @param {Function} options.buildRow - Function that receives a data row array and returns a tr element
+ * @param {string} options.csrfTokenName - The CSRF token header name from CsrfGuard
+ * @param {string} options.csrfTokenValue - The CSRF token value from CsrfGuard
+ * @since 2026-03-10
+ */
+function renderSpecialistList(options) {
+    var BATCH_SIZE = 1000;
+    var tbody = document.getElementById(options.tbodyId);
+    var firstBatchRendered = false;
+
+    function renderBatch(data, idx) {
+        var end = Math.min(idx + BATCH_SIZE, data.length);
+        var fragment = document.createDocumentFragment();
+        for (; idx < end; idx++) {
+            fragment.appendChild(options.buildRow(data[idx]));
+        }
+        tbody.appendChild(fragment);
+        if (!firstBatchRendered) {
+            firstBatchRendered = true;
+            HideSpin();
+        }
+        if (idx < data.length) {
+            requestAnimationFrame(function() { renderBatch(data, idx); });
+        }
+    }
+
+    var headers = {};
+    if (options.csrfTokenName) {
+        headers[options.csrfTokenName] = options.csrfTokenValue;
+    }
+
+    fetch(options.url, {
+        method: "POST",
+        headers: headers,
+        credentials: "same-origin"
+    })
+    .then(function(resp) {
+        if (!resp.ok) {
+            throw new Error("HTTP " + resp.status);
+        }
+        return resp.json();
+    })
+    .then(function(data) {
+        if (data.length === 0) {
+            HideSpin();
+        } else {
+            renderBatch(data, 0);
+        }
+    })
+    .catch(function(err) {
+        HideSpin();
+        console.error("Error loading specialists:", err);
+    });
+}

--- a/src/main/webapp/oscarEncounter/oscarConsultationRequest/ConsultationFormRequest.jsp
+++ b/src/main/webapp/oscarEncounter/oscarConsultationRequest/ConsultationFormRequest.jsp
@@ -104,8 +104,6 @@
     <%
         LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
         DemographicManager demographicManager = SpringUtils.getBean(DemographicManager.class);
-        displayServiceUtil.estSpecialist();
-
         //multi-site support
         String appNo = request.getParameter("appNo");
         appNo = (appNo == null ? "" : appNo);

--- a/src/main/webapp/oscarEncounter/oscarConsultationRequest/config/DisplayService.jsp
+++ b/src/main/webapp/oscarEncounter/oscarConsultationRequest/config/DisplayService.jsp
@@ -40,8 +40,6 @@
 %>
 
 <%@ page import="java.util.ResourceBundle" %>
-<%@ page import="org.owasp.encoder.Encode" %>
-<%@ page import="ca.openosp.openo.consultation.dto.SpecialistListDTO" %>
 <%@ page import="ca.openosp.openo.encounter.oscarConsultationRequest.config.pageUtil.EctConTitlebar" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
@@ -53,7 +51,6 @@
     <jsp:useBean id="displayServiceUtil" scope="request"
                  class="ca.openosp.openo.encounter.oscarConsultationRequest.config.pageUtil.EctConDisplayServiceUtil"/>
     <%
-        displayServiceUtil.loadSpecialists();
         String serviceId = (String) request.getAttribute("serviceId");
         String serviceDesc = displayServiceUtil.getServiceDesc(serviceId);
     %>
@@ -74,15 +71,8 @@
     </head>
     <body class="BodyStyle" vlink="#0000FF">
     <jsp:include page="/images/spinner.jsp" flush="true"/>
-    <script>
-        ShowSpin(true);
-        document.onreadystatechange = function () {
-            if (document.readyState === "interactive") {
-                HideSpin();
-            }
-        }
-    </script>
-    <% 
+    <script>ShowSpin(true);</script>
+    <%
     java.util.List<String> actionErrors = (java.util.List<String>) request.getAttribute("actionErrors");
     if (actionErrors != null && !actionErrors.isEmpty()) {
 %>
@@ -144,37 +134,7 @@
                                         </th>
 
                                     </tr>
-                                    <%
-                                        java.util.Vector specialistInField = displayServiceUtil.getSpecialistInField(serviceId);
-                                        for (SpecialistListDTO dto : displayServiceUtil.getSpecialists()) {
-                                            String specId = dto.getId().toString();
-                                            String fName = dto.getFirstName();
-                                            String lName = dto.getLastName();
-                                            String proLetters = dto.getProfessionalLetters();
-                                            String address = dto.getStreetAddress();
-                                            String phone = dto.getPhoneNumber();
-                                            String fax = dto.getFaxNumber();
-                                    %>
-                                    <tr>
-                                        <td>
-                                            <%if (specialistInField.contains(specId)) { %> <input type=checkbox
-                                                                                                  name="specialists"
-                                                                                                  value=<%=specId%> checked> <%} else {%>
-                                            <input type=checkbox name="specialists" value=<%=specId%>>
-                                            <%}%>
-                                        </td>
-                                        <td>
-                                            <%=Encode.forHtmlContent(lName + " " + fName + (proLetters == null ? "" : " " + proLetters))%>
-                                        </td>
-                                        <td><%=Encode.forHtmlContent(address) %>
-                                        </td>
-                                        <td><%=Encode.forHtmlContent(phone)%>
-                                        </td>
-                                        <td><%=Encode.forHtmlContent(fax)%>
-                                        </td>
-                                    </tr>
-                                    <%}%>
-
+                                    <tbody id="specialistBody"></tbody>
                                 </table>
 
                             </form></td>
@@ -188,5 +148,65 @@
             </tr>
         </table>
     </div>
+    <script>
+        (function() {
+            var BATCH_SIZE = 1000;
+            var tbody = document.getElementById("specialistBody");
+
+            function createCell(text) {
+                var td = document.createElement("td");
+                td.textContent = text;
+                return td;
+            }
+
+            function renderBatch(data, idx) {
+                var end = Math.min(idx + BATCH_SIZE, data.length);
+                var fragment = document.createDocumentFragment();
+                for (; idx < end; idx++) {
+                    var s = data[idx];
+                    var tr = document.createElement("tr");
+
+                    var cbTd = document.createElement("td");
+                    var cb = document.createElement("input");
+                    cb.type = "checkbox";
+                    cb.name = "specialists";
+                    cb.value = s[0];
+                    if (s[5]) cb.checked = true;
+                    cbTd.appendChild(cb);
+                    tr.appendChild(cbTd);
+
+                    tr.appendChild(createCell(s[1]));
+                    tr.appendChild(createCell(s[2]));
+                    tr.appendChild(createCell(s[3]));
+                    tr.appendChild(createCell(s[4]));
+
+                    fragment.appendChild(tr);
+                }
+                tbody.appendChild(fragment);
+                if (idx === Math.min(BATCH_SIZE, data.length)) {
+                    HideSpin();
+                }
+                if (idx < data.length) {
+                    requestAnimationFrame(function() { renderBatch(data, idx); });
+                }
+            }
+
+            fetch("<%= request.getContextPath() %>/oscarEncounter/SpecialistList.do?method=getSpecialistsForService&serviceId=<%=serviceId %>", {
+                method: "POST"
+            })
+            .then(function(resp) { return resp.json(); })
+            .then(function(data) {
+                if (data.length === 0) {
+                    HideSpin();
+                } else {
+                    renderBatch(data, 0);
+                }
+            })
+            .catch(function(err) {
+                HideSpin();
+                console.error("Error loading specialists:", err);
+            });
+        })();
+    </script>
     </body>
 </html>

--- a/src/main/webapp/oscarEncounter/oscarConsultationRequest/config/DisplayService.jsp
+++ b/src/main/webapp/oscarEncounter/oscarConsultationRequest/config/DisplayService.jsp
@@ -26,6 +26,7 @@
 
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
 <%@ taglib prefix="csrf" uri="http://www.owasp.org/index.php/Category:OWASP_CSRFGuard_Project/Owasp.CsrfGuard.tld" %>
+<%@ page import="org.owasp.encoder.Encode" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;
@@ -152,6 +153,9 @@
     </div>
     <script>
         (function() {
+            var ctxPath = "<%= Encode.forJavaScript(request.getContextPath()) %>";
+            var serviceId = "<%= Encode.forJavaScript(serviceId) %>";
+
             function createCell(text) {
                 var td = document.createElement("td");
                 td.textContent = text;
@@ -159,7 +163,7 @@
             }
 
             renderSpecialistList({
-                url: "<%= org.owasp.encoder.Encode.forJavaScript(request.getContextPath()) %>/oscarEncounter/SpecialistList.do?method=getSpecialistsForService&serviceId=" + encodeURIComponent("<%= org.owasp.encoder.Encode.forJavaScript(serviceId) %>"),
+                url: ctxPath + "/oscarEncounter/SpecialistList.do?method=getSpecialistsForService&serviceId=" + encodeURIComponent(serviceId),
                 tbodyId: "specialistBody",
                 csrfTokenName: "<csrf:tokenname/>",
                 csrfTokenValue: "<csrf:tokenvalue/>",

--- a/src/main/webapp/oscarEncounter/oscarConsultationRequest/config/DisplayService.jsp
+++ b/src/main/webapp/oscarEncounter/oscarConsultationRequest/config/DisplayService.jsp
@@ -41,6 +41,7 @@
 
 <%@ page import="java.util.ResourceBundle" %>
 <%@ page import="org.owasp.encoder.Encode" %>
+<%@ page import="ca.openosp.openo.consultation.dto.SpecialistListDTO" %>
 <%@ page import="ca.openosp.openo.encounter.oscarConsultationRequest.config.pageUtil.EctConTitlebar" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
@@ -52,7 +53,7 @@
     <jsp:useBean id="displayServiceUtil" scope="request"
                  class="ca.openosp.openo.encounter.oscarConsultationRequest.config.pageUtil.EctConDisplayServiceUtil"/>
     <%
-        displayServiceUtil.estSpecialistVector();
+        displayServiceUtil.loadSpecialists();
         String serviceId = (String) request.getAttribute("serviceId");
         String serviceDesc = displayServiceUtil.getServiceDesc(serviceId);
     %>
@@ -145,15 +146,14 @@
                                     </tr>
                                     <%
                                         java.util.Vector specialistInField = displayServiceUtil.getSpecialistInField(serviceId);
-                                        for (int i = 0; i < displayServiceUtil.specIdVec.size(); i++) {
-                                            String specId = displayServiceUtil.specIdVec.elementAt(i);
-                                            String fName = displayServiceUtil.fNameVec.elementAt(i);
-                                            String lName = displayServiceUtil.lNameVec.elementAt(i);
-                                            String proLetters = displayServiceUtil.proLettersVec.elementAt(i);
-                                            String address = displayServiceUtil.addressVec.elementAt(i);
-                                            String phone = displayServiceUtil.phoneVec.elementAt(i);
-                                            String fax = displayServiceUtil.faxVec.elementAt(i);
-
+                                        for (SpecialistListDTO dto : displayServiceUtil.getSpecialists()) {
+                                            String specId = dto.getId().toString();
+                                            String fName = dto.getFirstName();
+                                            String lName = dto.getLastName();
+                                            String proLetters = dto.getProfessionalLetters();
+                                            String address = dto.getStreetAddress();
+                                            String phone = dto.getPhoneNumber();
+                                            String fax = dto.getFaxNumber();
                                     %>
                                     <tr>
                                         <td>
@@ -164,8 +164,7 @@
                                             <%}%>
                                         </td>
                                         <td>
-                                            <%
-                                                out.print(Encode.forHtmlContent(lName + " " + fName + (proLetters == null ? "" : " " + proLetters))); %>
+                                            <%=Encode.forHtmlContent(lName + " " + fName + (proLetters == null ? "" : " " + proLetters))%>
                                         </td>
                                         <td><%=Encode.forHtmlContent(address) %>
                                         </td>

--- a/src/main/webapp/oscarEncounter/oscarConsultationRequest/config/DisplayService.jsp
+++ b/src/main/webapp/oscarEncounter/oscarConsultationRequest/config/DisplayService.jsp
@@ -25,6 +25,7 @@
 --%>
 
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib prefix="csrf" uri="http://www.owasp.org/index.php/Category:OWASP_CSRFGuard_Project/Owasp.CsrfGuard.tld" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;
@@ -68,6 +69,7 @@
         </script>
 
         <link rel="stylesheet" type="text/css" href="<%= request.getContextPath() %>/css/encounterStyles.css">
+        <script type="text/javascript" src="<%= request.getContextPath() %>/js/specialistListRenderer.js"></script>
     </head>
     <body class="BodyStyle" vlink="#0000FF">
     <jsp:include page="/images/spinner.jsp" flush="true"/>
@@ -150,20 +152,18 @@
     </div>
     <script>
         (function() {
-            var BATCH_SIZE = 1000;
-            var tbody = document.getElementById("specialistBody");
-
             function createCell(text) {
                 var td = document.createElement("td");
                 td.textContent = text;
                 return td;
             }
 
-            function renderBatch(data, idx) {
-                var end = Math.min(idx + BATCH_SIZE, data.length);
-                var fragment = document.createDocumentFragment();
-                for (; idx < end; idx++) {
-                    var s = data[idx];
+            renderSpecialistList({
+                url: "<%= org.owasp.encoder.Encode.forJavaScript(request.getContextPath()) %>/oscarEncounter/SpecialistList.do?method=getSpecialistsForService&serviceId=" + encodeURIComponent("<%= org.owasp.encoder.Encode.forJavaScript(serviceId) %>"),
+                tbodyId: "specialistBody",
+                csrfTokenName: "<csrf:tokenname/>",
+                csrfTokenValue: "<csrf:tokenvalue/>",
+                buildRow: function(s) {
                     var tr = document.createElement("tr");
 
                     var cbTd = document.createElement("td");
@@ -180,31 +180,8 @@
                     tr.appendChild(createCell(s[3]));
                     tr.appendChild(createCell(s[4]));
 
-                    fragment.appendChild(tr);
+                    return tr;
                 }
-                tbody.appendChild(fragment);
-                if (idx === Math.min(BATCH_SIZE, data.length)) {
-                    HideSpin();
-                }
-                if (idx < data.length) {
-                    requestAnimationFrame(function() { renderBatch(data, idx); });
-                }
-            }
-
-            fetch("<%= request.getContextPath() %>/oscarEncounter/SpecialistList.do?method=getSpecialistsForService&serviceId=<%=serviceId %>", {
-                method: "POST"
-            })
-            .then(function(resp) { return resp.json(); })
-            .then(function(data) {
-                if (data.length === 0) {
-                    HideSpin();
-                } else {
-                    renderBatch(data, 0);
-                }
-            })
-            .catch(function(err) {
-                HideSpin();
-                console.error("Error loading specialists:", err);
             });
         })();
     </script>

--- a/src/main/webapp/oscarEncounter/oscarConsultationRequest/config/EditSpecialists.jsp
+++ b/src/main/webapp/oscarEncounter/oscarConsultationRequest/config/EditSpecialists.jsp
@@ -26,6 +26,7 @@
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
 <%@ page import="java.util.List" %>
+<%@ page import="ca.openosp.openo.consultation.dto.SpecialistListDTO" %>
 <%@ page import="ca.openosp.openo.encounter.oscarConsultationRequest.config.pageUtil.EctConTitlebar" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
@@ -45,7 +46,7 @@
     <jsp:useBean id="displayServiceUtil" scope="request"
                  class="ca.openosp.openo.encounter.oscarConsultationRequest.config.pageUtil.EctConDisplayServiceUtil"/>
     <%
-        displayServiceUtil.estSpecialistVector();
+        displayServiceUtil.loadSpecialists();
     %>
     <head>
 
@@ -132,28 +133,22 @@
 
                                     </tr>
                                     <%
-
-                                        for (int i = 0; i < displayServiceUtil.specIdVec.size(); i++) {
-                                            String specId = displayServiceUtil.specIdVec.elementAt(i);
-                                            String fName = displayServiceUtil.fNameVec.elementAt(i);
-                                            String lName = displayServiceUtil.lNameVec.elementAt(i);
-                                            String proLetters = displayServiceUtil.proLettersVec.elementAt(i);
-                                            String address = displayServiceUtil.addressVec.elementAt(i);
-                                            String phone = displayServiceUtil.phoneVec.elementAt(i);
-                                            String fax = displayServiceUtil.faxVec.elementAt(i);
+                                        String contextPath = request.getContextPath();
+                                        for (SpecialistListDTO dto : displayServiceUtil.getSpecialists()) {
+                                            String specId = dto.getId().toString();
+                                            String fName = dto.getFirstName();
+                                            String lName = dto.getLastName();
+                                            String proLetters = dto.getProfessionalLetters();
+                                            String address = dto.getStreetAddress();
+                                            String phone = dto.getPhoneNumber();
+                                            String fax = dto.getFaxNumber();
                                     %>
 
                                     <tr>
                                         <td><input type="checkbox" name="specialists"
                                                    value="<%=specId%>"></td>
                                         <td>
-                                            <%
-                                                String contextPath = request.getContextPath();
-                                                String url = contextPath + "/oscarEncounter/EditSpecialists.do?specId=" + specId;
-                                                out.print("<a href=\"" + url + "\">");
-                                                out.print(Encode.forHtmlContent(lName + " " + fName + " " + (proLetters == null ? "" : proLetters)));
-                                                out.print("</a>");
-                                            %>
+                                            <a href="<%=contextPath%>/oscarEncounter/EditSpecialists.do?specId=<%=specId%>"><%=Encode.forHtmlContent(lName + " " + fName + " " + (proLetters == null ? "" : proLetters))%></a>
                                         </td>
                                         <td><%=Encode.forHtmlContent(address) %>
                                         </td>

--- a/src/main/webapp/oscarEncounter/oscarConsultationRequest/config/EditSpecialists.jsp
+++ b/src/main/webapp/oscarEncounter/oscarConsultationRequest/config/EditSpecialists.jsp
@@ -27,6 +27,7 @@
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
 <%@ taglib prefix="csrf" uri="http://www.owasp.org/index.php/Category:OWASP_CSRFGuard_Project/Owasp.CsrfGuard.tld" %>
 <%@ page import="java.util.List" %>
+<%@ page import="org.owasp.encoder.Encode" %>
 <%@ page import="ca.openosp.openo.encounter.oscarConsultationRequest.config.pageUtil.EctConTitlebar" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
@@ -140,7 +141,8 @@
     </div>
     <script>
         (function() {
-            var editUrlPrefix = "<%= org.owasp.encoder.Encode.forJavaScript(request.getContextPath()) %>/oscarEncounter/EditSpecialists.do?specId=";
+            var ctxPath = "<%= Encode.forJavaScript(request.getContextPath()) %>";
+            var editUrlPrefix = ctxPath + "/oscarEncounter/EditSpecialists.do?specId=";
 
             function createCell(text) {
                 var td = document.createElement("td");
@@ -149,7 +151,7 @@
             }
 
             renderSpecialistList({
-                url: "<%= org.owasp.encoder.Encode.forJavaScript(request.getContextPath()) %>/oscarEncounter/SpecialistList.do?method=getSpecialists",
+                url: ctxPath + "/oscarEncounter/SpecialistList.do?method=getSpecialists",
                 tbodyId: "specialistBody",
                 csrfTokenName: "<csrf:tokenname/>",
                 csrfTokenValue: "<csrf:tokenvalue/>",

--- a/src/main/webapp/oscarEncounter/oscarConsultationRequest/config/EditSpecialists.jsp
+++ b/src/main/webapp/oscarEncounter/oscarConsultationRequest/config/EditSpecialists.jsp
@@ -1,4 +1,4 @@
-<%@ page import="org.owasp.encoder.Encode" %><%--
+<%--
 
     Copyright (c) 2001-2002. Department of Family Medicine, McMaster University. All Rights Reserved.
     This software is published under the GPL GNU General Public License.
@@ -26,7 +26,6 @@
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
 <%@ page import="java.util.List" %>
-<%@ page import="ca.openosp.openo.consultation.dto.SpecialistListDTO" %>
 <%@ page import="ca.openosp.openo.encounter.oscarConsultationRequest.config.pageUtil.EctConTitlebar" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
@@ -45,9 +44,6 @@
 <html>
     <jsp:useBean id="displayServiceUtil" scope="request"
                  class="ca.openosp.openo.encounter.oscarConsultationRequest.config.pageUtil.EctConDisplayServiceUtil"/>
-    <%
-        displayServiceUtil.loadSpecialists();
-    %>
     <head>
 
         <title><fmt:setBundle basename="oscarResources"/><fmt:message key="oscarEncounter.oscarConsultationRequest.config.EditSpecialists.title"/>
@@ -65,15 +61,8 @@
 
     <body class="BodyStyle" vlink="#0000FF">
     <jsp:include page="/images/spinner.jsp" flush="true"/>
-    <script>
-        ShowSpin(true);
-        document.onreadystatechange = function () {
-            if (document.readyState === "interactive") {
-                HideSpin();
-            }
-        }
-    </script>
-    <% 
+    <script>ShowSpin(true);</script>
+    <%
     java.util.List<String> actionErrors = (java.util.List<String>) request.getAttribute("actionErrors");
     if (actionErrors != null && !actionErrors.isEmpty()) {
 %>
@@ -132,33 +121,7 @@
                                         </th>
 
                                     </tr>
-                                    <%
-                                        String contextPath = request.getContextPath();
-                                        for (SpecialistListDTO dto : displayServiceUtil.getSpecialists()) {
-                                            String specId = dto.getId().toString();
-                                            String fName = dto.getFirstName();
-                                            String lName = dto.getLastName();
-                                            String proLetters = dto.getProfessionalLetters();
-                                            String address = dto.getStreetAddress();
-                                            String phone = dto.getPhoneNumber();
-                                            String fax = dto.getFaxNumber();
-                                    %>
-
-                                    <tr>
-                                        <td><input type="checkbox" name="specialists"
-                                                   value="<%=specId%>"></td>
-                                        <td>
-                                            <a href="<%=contextPath%>/oscarEncounter/EditSpecialists.do?specId=<%=specId%>"><%=Encode.forHtmlContent(lName + " " + fName + " " + (proLetters == null ? "" : proLetters))%></a>
-                                        </td>
-                                        <td><%=Encode.forHtmlContent(address) %>
-                                        </td>
-                                        <td><%=Encode.forHtmlContent(phone)%>
-                                        </td>
-                                        <td><%=Encode.forHtmlContent(fax)%>
-                                        </td>
-                                    </tr>
-                                    <% }%>
-
+                                    <tbody id="specialistBody"></tbody>
                                 </table>
 
                             </form></td>
@@ -173,5 +136,71 @@
             </tr>
         </table>
     </div>
+    <script>
+        (function() {
+            var BATCH_SIZE = 1000;
+            var tbody = document.getElementById("specialistBody");
+            var editUrlPrefix = "<%= request.getContextPath() %>/oscarEncounter/EditSpecialists.do?specId=";
+
+            function createCell(text) {
+                var td = document.createElement("td");
+                td.textContent = text;
+                return td;
+            }
+
+            function renderBatch(data, idx) {
+                var end = Math.min(idx + BATCH_SIZE, data.length);
+                var fragment = document.createDocumentFragment();
+                for (; idx < end; idx++) {
+                    var s = data[idx];
+                    var tr = document.createElement("tr");
+
+                    var cbTd = document.createElement("td");
+                    var cb = document.createElement("input");
+                    cb.type = "checkbox";
+                    cb.name = "specialists";
+                    cb.value = s[0];
+                    cbTd.appendChild(cb);
+                    tr.appendChild(cbTd);
+
+                    var nameTd = document.createElement("td");
+                    var link = document.createElement("a");
+                    link.href = editUrlPrefix + s[0];
+                    link.textContent = s[1];
+                    nameTd.appendChild(link);
+                    tr.appendChild(nameTd);
+
+                    tr.appendChild(createCell(s[2]));
+                    tr.appendChild(createCell(s[3]));
+                    tr.appendChild(createCell(s[4]));
+
+                    fragment.appendChild(tr);
+                }
+                tbody.appendChild(fragment);
+                if (idx === Math.min(BATCH_SIZE, data.length)) {
+                    HideSpin();
+                }
+                if (idx < data.length) {
+                    requestAnimationFrame(function() { renderBatch(data, idx); });
+                }
+            }
+
+            fetch("<%= request.getContextPath() %>/oscarEncounter/SpecialistList.do?method=getSpecialists", {
+                method: "POST"
+            })
+            .then(function(resp) { return resp.json(); })
+            .then(function(data) {
+                if (data.length === 0) {
+                    HideSpin();
+                } else {
+                    renderBatch(data, 0);
+                }
+            })
+            .catch(function(err) {
+                HideSpin();
+                console.error("Error loading specialists:", err);
+            });
+        })();
+    </script>
     </body>
 </html>

--- a/src/main/webapp/oscarEncounter/oscarConsultationRequest/config/EditSpecialists.jsp
+++ b/src/main/webapp/oscarEncounter/oscarConsultationRequest/config/EditSpecialists.jsp
@@ -25,6 +25,7 @@
 --%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib prefix="csrf" uri="http://www.owasp.org/index.php/Category:OWASP_CSRFGuard_Project/Owasp.CsrfGuard.tld" %>
 <%@ page import="java.util.List" %>
 <%@ page import="ca.openosp.openo.encounter.oscarConsultationRequest.config.pageUtil.EctConTitlebar" %>
 <%
@@ -56,6 +57,7 @@
             }
         </script>
         <link rel="stylesheet" type="text/css" href="<%= request.getContextPath() %>/css/encounterStyles.css">
+        <script type="text/javascript" src="<%= request.getContextPath() %>/js/specialistListRenderer.js"></script>
 
     </head>
 
@@ -138,9 +140,7 @@
     </div>
     <script>
         (function() {
-            var BATCH_SIZE = 1000;
-            var tbody = document.getElementById("specialistBody");
-            var editUrlPrefix = "<%= request.getContextPath() %>/oscarEncounter/EditSpecialists.do?specId=";
+            var editUrlPrefix = "<%= org.owasp.encoder.Encode.forJavaScript(request.getContextPath()) %>/oscarEncounter/EditSpecialists.do?specId=";
 
             function createCell(text) {
                 var td = document.createElement("td");
@@ -148,11 +148,12 @@
                 return td;
             }
 
-            function renderBatch(data, idx) {
-                var end = Math.min(idx + BATCH_SIZE, data.length);
-                var fragment = document.createDocumentFragment();
-                for (; idx < end; idx++) {
-                    var s = data[idx];
+            renderSpecialistList({
+                url: "<%= org.owasp.encoder.Encode.forJavaScript(request.getContextPath()) %>/oscarEncounter/SpecialistList.do?method=getSpecialists",
+                tbodyId: "specialistBody",
+                csrfTokenName: "<csrf:tokenname/>",
+                csrfTokenValue: "<csrf:tokenvalue/>",
+                buildRow: function(s) {
                     var tr = document.createElement("tr");
 
                     var cbTd = document.createElement("td");
@@ -174,31 +175,8 @@
                     tr.appendChild(createCell(s[3]));
                     tr.appendChild(createCell(s[4]));
 
-                    fragment.appendChild(tr);
+                    return tr;
                 }
-                tbody.appendChild(fragment);
-                if (idx === Math.min(BATCH_SIZE, data.length)) {
-                    HideSpin();
-                }
-                if (idx < data.length) {
-                    requestAnimationFrame(function() { renderBatch(data, idx); });
-                }
-            }
-
-            fetch("<%= request.getContextPath() %>/oscarEncounter/SpecialistList.do?method=getSpecialists", {
-                method: "POST"
-            })
-            .then(function(resp) { return resp.json(); })
-            .then(function(data) {
-                if (data.length === 0) {
-                    HideSpin();
-                } else {
-                    renderBatch(data, 0);
-                }
-            })
-            .catch(function(err) {
-                HideSpin();
-                console.error("Error loading specialists:", err);
             });
         })();
     </script>

--- a/src/test-modern/java/ca/openosp/openo/consultation/dao/ProfessionalSpecialistDaoDTOIntegrationTest.java
+++ b/src/test-modern/java/ca/openosp/openo/consultation/dao/ProfessionalSpecialistDaoDTOIntegrationTest.java
@@ -1,0 +1,137 @@
+package ca.openosp.openo.consultation.dao;
+
+import ca.openosp.openo.commn.dao.ProfessionalSpecialistDao;
+import ca.openosp.openo.commn.model.ProfessionalSpecialist;
+import ca.openosp.openo.consultation.dto.SpecialistListDTO;
+import ca.openosp.openo.test.base.OpenOTestBase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link ProfessionalSpecialistDao#findAllListDTOs()}.
+ *
+ * <p>Validates the JPQL constructor projection that provides lightweight
+ * specialist data for list views, avoiding full entity hydration.</p>
+ *
+ * @since 2026-03-11
+ * @see ProfessionalSpecialistDao
+ * @see SpecialistListDTO
+ */
+@DisplayName("ProfessionalSpecialist DAO DTO Projection Integration Tests")
+@Tag("integration")
+@Tag("database")
+@Tag("dao")
+@Tag("slow")
+@Tag("read")
+@Tag("dto")
+@Transactional
+public class ProfessionalSpecialistDaoDTOIntegrationTest extends OpenOTestBase {
+
+    @Autowired
+    private ProfessionalSpecialistDao professionalSpecialistDao;
+
+    @PersistenceContext(unitName = "entityManagerFactory")
+    private EntityManager entityManager;
+
+    @BeforeEach
+    void setUp() {
+        ProfessionalSpecialist spec1 = new ProfessionalSpecialist();
+        spec1.setFirstName("Alice");
+        spec1.setLastName("Smith");
+        spec1.setProfessionalLetters("MD, FRCPC");
+        spec1.setStreetAddress("123 Main St");
+        spec1.setPhoneNumber("555-1234");
+        spec1.setFaxNumber("555-5678");
+        entityManager.persist(spec1);
+
+        ProfessionalSpecialist spec2 = new ProfessionalSpecialist();
+        spec2.setFirstName("Bob");
+        spec2.setLastName("Jones");
+        spec2.setStreetAddress("456 Oak Ave");
+        spec2.setPhoneNumber("555-9999");
+        entityManager.persist(spec2);
+
+        ProfessionalSpecialist spec3 = new ProfessionalSpecialist();
+        spec3.setFirstName("Carol");
+        spec3.setLastName("Adams");
+        entityManager.persist(spec3);
+
+        entityManager.flush();
+    }
+
+    @Test
+    @DisplayName("should return all specialists as DTOs")
+    void shouldReturnAllSpecialistsAsDTOs() {
+        List<SpecialistListDTO> results = professionalSpecialistDao.findAllListDTOs();
+
+        assertThat(results).hasSize(3);
+    }
+
+    @Test
+    @Tag("query")
+    @DisplayName("should order by lastName then firstName")
+    void shouldOrderByLastNameThenFirstName() {
+        List<SpecialistListDTO> results = professionalSpecialistDao.findAllListDTOs();
+
+        assertThat(results).extracting(SpecialistListDTO::getLastName)
+                .containsExactly("Adams", "Jones", "Smith");
+    }
+
+    @Test
+    @Tag("query")
+    @DisplayName("should populate all DTO fields correctly")
+    void shouldPopulateAllDTOFields_correctly() {
+        List<SpecialistListDTO> results = professionalSpecialistDao.findAllListDTOs();
+
+        SpecialistListDTO alice = results.stream()
+                .filter(dto -> "Smith".equals(dto.getLastName()))
+                .findFirst().orElse(null);
+
+        assertThat(alice).isNotNull();
+        assertThat(alice.getId()).isNotNull();
+        assertThat(alice.getFirstName()).isEqualTo("Alice");
+        assertThat(alice.getLastName()).isEqualTo("Smith");
+        assertThat(alice.getProfessionalLetters()).isEqualTo("MD, FRCPC");
+        assertThat(alice.getStreetAddress()).isEqualTo("123 Main St");
+        assertThat(alice.getPhoneNumber()).isEqualTo("555-1234");
+        assertThat(alice.getFaxNumber()).isEqualTo("555-5678");
+    }
+
+    @Test
+    @Tag("query")
+    @DisplayName("should handle null optional fields gracefully")
+    void shouldHandleNullOptionalFields_gracefully() {
+        List<SpecialistListDTO> results = professionalSpecialistDao.findAllListDTOs();
+
+        SpecialistListDTO carol = results.stream()
+                .filter(dto -> "Adams".equals(dto.getLastName()))
+                .findFirst().orElse(null);
+
+        assertThat(carol).isNotNull();
+        assertThat(carol.getProfessionalLetters()).isNull();
+        assertThat(carol.getStreetAddress()).isNull();
+        assertThat(carol.getPhoneNumber()).isNull();
+        assertThat(carol.getFaxNumber()).isNull();
+    }
+
+    @Test
+    @DisplayName("should return empty list when no specialists exist")
+    void shouldReturnEmptyList_whenNoSpecialistsExist() {
+        entityManager.createQuery("DELETE FROM ProfessionalSpecialist").executeUpdate();
+        entityManager.flush();
+
+        List<SpecialistListDTO> results = professionalSpecialistDao.findAllListDTOs();
+
+        assertThat(results).isEmpty();
+    }
+}

--- a/src/test-modern/resources/META-INF/persistence.xml
+++ b/src/test-modern/resources/META-INF/persistence.xml
@@ -28,6 +28,7 @@
         <class>ca.openosp.openo.commn.model.Facility</class>
         <class>ca.openosp.openo.commn.model.DemographicMerged</class>
         <class>ca.openosp.openo.PMmodule.model.ProgramQueue</class>
+        <class>ca.openosp.openo.commn.model.ProfessionalSpecialist</class>
         <!-- HBM.XML mapped entities -->
         <mapping-file>ca/openosp/openo/commn/model/Provider.hbm.xml</mapping-file>
         <mapping-file>ca/openosp/openo/commn/model/Demographic.hbm.xml</mapping-file>

--- a/src/test-modern/resources/test-context-full.xml
+++ b/src/test-modern/resources/test-context-full.xml
@@ -191,6 +191,9 @@
     <bean id="customFilterDao" class="ca.openosp.openo.commn.dao.CustomFilterDaoImpl" autowire="byName" />
     <bean id="oscarLogDao" class="ca.openosp.openo.commn.dao.OscarLogDaoImpl" autowire="byName" />
 
+    <!-- Specialist DAOs -->
+    <bean id="professionalSpecialistDao" class="ca.openosp.openo.commn.dao.ProfessionalSpecialistDaoImpl" autowire="byName" />
+
     <!-- Additional DAOs required by TicklerManager -->
     <bean id="programAccessDAO" class="ca.openosp.openo.PMmodule.dao.ProgramAccessDAOImpl" autowire="byName" />
     <bean id="ProgramAccessDAO" class="ca.openosp.openo.PMmodule.dao.ProgramAccessDAOImpl" autowire="byName" />


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                
  Decouple specialist list data from inline JSP rendering into a separate                                                                                                                                                                   
  fetch() POST endpoint with client-side batch rendering.  

Fixes #2321                                                                                                                                                                                  
                                                                                                                                                                                                                                            
  ## Problem                                                                                                                                                                                                                                
  The Edit Specialists and Display Service pages embed all specialist data                                                                                                                                                                  
  directly in the HTML response via server-side `<% for %>` loops. With                                                                                                                                                                     
  10k+ specialist records this causes:                                                                                                                                                                                                      
                                                                                                                                                                                                                                            
  - ~226MB transient memory allocation per request (DTO list + JSON string                                                                                                                                                                  
    + JSP output buffer all held simultaneously)                                                                                                                                                                                            
  - 1,705KB HTML response containing the full specialist table                                                                                                                                                                              
  - ~4 second browser (local environment) DOM parsing delay before the page becomes interactive                                                                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                            
  ## Solution                                                                                                                                                                                                                               
                                                                                                                                                                                                                                            
  **DTO Projection (server):**                                                                                                                                                                                                              
  - JPQL constructor projection (`SELECT NEW SpecialistListDTO(...)`)                                                                                                                                                                       
    fetches only the 7 columns needed for list display, avoiding full                                                                                                                                                                       
    entity hydration of heavy text fields (annotation, eDataOscarKey, etc.)                                                                                                                                                                 
                                                                                                                                                                                                                                          
  **Separate JSON endpoint (server):**                                                                                                                                                                                                      
  - New `SpecialistList2Action` serves specialist data as JSON via POST,                                                                                                                                                                    
    following the same pattern as `ConsultationLookup2Action` and                                                                                                                                                                           
    `TicklerList2Action`                                                                                                                                                                                                                    
  - Jackson ArrayNode builds the response, written directly to                                                                                                                                                                              
    `response.getWriter()` — decouples data payload from page shell                                                                                                                                                                         
                                                                                                                                                                                                                                            
  **Batch rendering (client):**                                                                                                                                                                                                             
  - JSP pages load a lightweight shell (~9KB) with spinner                                                                                                                                                                                  
  - `fetch()` POST retrieves JSON from the new endpoint                                                                                                                                                                                     
  - `requestAnimationFrame` + `document.createDocumentFragment()` renders                                                                                                                                                                   
    rows in batches of 1,000 for instant perceived load

## Summary by Sourcery

Introduce a JSON-based specialist list endpoint and client-side rendering to decouple large specialist datasets from JSP pages and improve performance on specialist configuration screens.

New Features:
- Add SpecialistList2Action JSON endpoints to serve specialist list data for Edit Specialists and Display Service pages.
- Introduce SpecialistListDTO as a lightweight projection for specialist list views.

Enhancements:
- Refactor EditSpecialists.jsp and DisplayService.jsp to fetch specialist data asynchronously and render rows client-side using a shared renderer script.
- Optimize specialist data access in ProfessionalSpecialistDao with a DTO-based query that selects only columns needed for list display.
- Simplify EctConDisplayServiceUtil by removing specialist list construction responsibilities.

Tests:
- Add integration tests verifying ProfessionalSpecialistDao DTO projection behavior, ordering, and null-handling.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move specialist data out of JSP into CSRF-protected JSON endpoints with client-side batch rendering to speed up Edit Specialists and Display Service; cuts payload and server memory for much faster interactivity. Fixes #2321.

- **Refactors**
  - Add `SpecialistList2Action` with POST-only endpoints `getSpecialists` and `getSpecialistsForService`, CsrfGuard header support, `_con` read privilege check, and 400/405 error handling; mapped in `struts.xml`.
  - Add `ProfessionalSpecialistDao#findAllListDTOs()` using JPQL constructor projection to `SpecialistListDTO` (id, names, letters, address, phone, fax); include integration tests.
  - Add `specialistListRenderer.js` for batched `requestAnimationFrame` rendering and CSRF header; update `EditSpecialists.jsp` and `DisplayService.jsp` to fetch JSON and render checkboxes/links, keeping the spinner until the first batch renders.
  - Remove specialist vector building and inline JSP loops from `EctConDisplayServiceUtil` and drop related calls (e.g., from `ConsultationFormRequest.jsp`).

<sup>Written for commit a0d1175a91b192079ab19517a1a736996866fa74. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added API endpoint for retrieving specialist information, including support for filtering specialists by service and checking assignment status.

* **Refactor**
  * Improved specialist list display performance by switching from server-side rendering to dynamic client-side loading with batched data rendering.
  * Streamlined specialist data initialization in consultation request workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->