### PR TITLE
fix: restore epoch serialization for date fields across REST TO models to fix Ocean sync

### DIFF
--- a/src/main/java/ca/openosp/openo/webserv/rest/to/model/AllergyTo1.java
+++ b/src/main/java/ca/openosp/openo/webserv/rest/to/model/AllergyTo1.java
@@ -68,6 +68,7 @@ public class AllergyTo1 {
 
     private int position = 0;
 
+    @JsonFormat(shape = JsonFormat.Shape.NUMBER)
     private Date lastUpdateDate;
 
     private String providerNo;

--- a/src/main/java/ca/openosp/openo/webserv/rest/to/model/AppointmentTo1.java
+++ b/src/main/java/ca/openosp/openo/webserv/rest/to/model/AppointmentTo1.java
@@ -27,6 +27,8 @@ package ca.openosp.openo.webserv.rest.to.model;
 import java.io.Serializable;
 import java.util.Date;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+
 import ca.openosp.openo.commn.model.Appointment.BookingSource;
 import ca.openosp.openo.commn.model.Demographic;
 import ca.openosp.openo.commn.model.Provider;
@@ -62,8 +64,10 @@ public class AppointmentTo1 implements Serializable {
 
     private String importedStatus;
 
+    @JsonFormat(shape = JsonFormat.Shape.NUMBER)
     private Date createDateTime = new Date();
 
+    @JsonFormat(shape = JsonFormat.Shape.NUMBER)
     private Date updateDateTime = new Date();
 
     private String creator;

--- a/src/main/java/ca/openosp/openo/webserv/rest/to/model/CaseManagementIssueTo1.java
+++ b/src/main/java/ca/openosp/openo/webserv/rest/to/model/CaseManagementIssueTo1.java
@@ -26,6 +26,8 @@ package ca.openosp.openo.webserv.rest.to.model;
 
 import java.util.Date;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+
 public class CaseManagementIssueTo1 {
 
     protected Long id;
@@ -36,7 +38,10 @@ public class CaseManagementIssueTo1 {
     protected boolean major;
     protected boolean resolved;
     protected String type;
+
+    @JsonFormat(shape = JsonFormat.Shape.NUMBER)
     protected Date update_date = new Date();
+    
     protected IssueTo1 issue;
     protected Integer program_id = null;
     private boolean unsaved;

--- a/src/main/java/ca/openosp/openo/webserv/rest/to/model/DemographicTo1.java
+++ b/src/main/java/ca/openosp/openo/webserv/rest/to/model/DemographicTo1.java
@@ -32,6 +32,8 @@ import java.util.List;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+
 @XmlRootElement
 public class DemographicTo1 implements Serializable {
 
@@ -81,7 +83,10 @@ public class DemographicTo1 implements Serializable {
     private String displayName;
     private ProviderTo1 provider;
     private String lastUpdateUser;
+
+    @JsonFormat(shape = JsonFormat.Shape.NUMBER)
     private Date lastUpdateDate;
+
     private String title;
     private String officialLanguage;
     private String countryOfOrigin;

--- a/src/main/java/ca/openosp/openo/webserv/rest/to/model/IssueTo1.java
+++ b/src/main/java/ca/openosp/openo/webserv/rest/to/model/IssueTo1.java
@@ -29,6 +29,8 @@ import java.util.Date;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+
 
 @XmlRootElement(name = "issue")
 public class IssueTo1 implements Serializable {
@@ -44,7 +46,10 @@ public class IssueTo1 implements Serializable {
     private String code;
     private String description;
     private String role;
+
+    @JsonFormat(shape = JsonFormat.Shape.NUMBER)
     private Date update_date;
+    
     private String priority;
     private String type;
     private Integer sortOrderId;

--- a/src/main/java/ca/openosp/openo/webserv/rest/to/model/MeasurementTo1.java
+++ b/src/main/java/ca/openosp/openo/webserv/rest/to/model/MeasurementTo1.java
@@ -45,6 +45,8 @@ public class MeasurementTo1 {
     private Date dateObserved;
     
     private Integer appointmentNo;
+
+    @JsonFormat(shape = JsonFormat.Shape.NUMBER)
     private Date createDate = new Date();
 
     public Integer getId() {

--- a/src/main/java/ca/openosp/openo/webserv/rest/to/model/NoteTo1.java
+++ b/src/main/java/ca/openosp/openo/webserv/rest/to/model/NoteTo1.java
@@ -34,6 +34,9 @@ import java.util.Set;
 import javax.xml.bind.annotation.XmlRootElement;
 
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
 import ca.openosp.openo.casemgmt.model.CaseManagementIssue;
 
 @XmlRootElement(name = "encounterNote")
@@ -43,9 +46,15 @@ public class NoteTo1 implements Serializable {
     private Boolean isSigned;
     private Boolean isVerified;
     private Boolean isEditable;
+
+    @JsonFormat(shape = JsonFormat.Shape.NUMBER)
     private Date observationDate;
+
     private String revision;
+
+    @JsonFormat(shape = JsonFormat.Shape.NUMBER)
     private Date updateDate;
+    
     private String providerName;
     private String providerNo;
     private String status;


### PR DESCRIPTION
## Summary
  - Adds `@JsonFormat(shape = JsonFormat.Shape.NUMBER)` to `Date` fields in multiple REST transfer object models
  - Forces date fields to serialize as epoch milliseconds regardless of their value
  - Restores the REST API response format that was in place before the Jackson dependency upgrade


  ## Root Cause
  After the Jackson dependency upgrade, date serialization behaviour changed across multiple REST TO models - fields previously returned as epoch numbers began returning string-formatted values instead, breaking the Ocean integration sync and potentially other third-party integrations.

## Summary by Sourcery

Bug Fixes:
- Ensure various REST TO date fields serialize as numeric epoch milliseconds instead of formatted strings after the Jackson upgrade.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores epoch-millisecond serialization for Date fields in REST TO1 models to fix Ocean sync and keep the previous API contract. Adds `@JsonFormat(shape = JsonFormat.Shape.NUMBER)` to ensure dates serialize as numbers, not strings.

- **Bug Fixes**
  - Force epoch millis for date fields in `AllergyTo1`, `AppointmentTo1`, `CaseManagementIssueTo1`, `DemographicTo1`, `IssueTo1`, `MeasurementTo1`, `NoteTo1`.
  - Reverts a regression from the Jackson upgrade that switched date serialization to strings and broke Ocean and other integrations.

<sup>Written for commit 779baa8f0c786ed607500d965c087024c29d2e20. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

