### PR TITLE
Enhancement: Removed recently updated prototype usage in documentsInQueue.jsp for fetch, and jQuery to append data

### DIFF
--- a/src/main/webapp/oscarMDS/documentsInQueues.jsp
+++ b/src/main/webapp/oscarMDS/documentsInQueues.jsp
@@ -892,6 +892,10 @@
 
             var placeholder = document.getElementById('docPlaceholder_' + docNo);
             var div = placeholder || document.getElementById(childId);
+            if (!div) {
+                console.error('showDocLab: target element not found for docNo=' + docNo);
+                return;
+            }
             var url = '';
             if (type == 'DOC')
                 url = "<%= request.getContextPath() %>/documentManager/showDocument.jsp";
@@ -904,15 +908,20 @@
             else
                 url = "";
 
-            var data = "segmentID=" + docNo + "&providerNo=" + providerNo + "&searchProviderNo=" + searchProviderNo + "&status=" + status + "&demoName=" + demoName;
+            var data = "segmentID=" + encodeURIComponent(docNo)
+                + "&providerNo=" + encodeURIComponent(providerNo)
+                + "&searchProviderNo=" + encodeURIComponent(searchProviderNo)
+                + "&status=" + encodeURIComponent(status)
+                + "&demoName=" + encodeURIComponent(demoName);
             if (inQueue) {
-                data += "&inQueue=" + inQueue;
+                data += "&inQueue=" + encodeURIComponent(inQueue);
             }
 
             fetch(url, {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/x-www-form-urlencoded',
+                    'X-Requested-With': 'XMLHttpRequest',
                     '<csrf:tokenname/>': '<csrf:tokenvalue/>'
                 },
                 credentials: 'same-origin',

--- a/src/main/webapp/oscarMDS/documentsInQueues.jsp
+++ b/src/main/webapp/oscarMDS/documentsInQueues.jsp
@@ -41,6 +41,7 @@
 
 <%@page import="org.apache.commons.text.StringEscapeUtils" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
+<%@ taglib prefix="csrf" uri="http://www.owasp.org/index.php/Category:OWASP_CSRFGuard_Project/Owasp.CsrfGuard.tld" %>
 <%@ page import="java.util.*, ca.openosp.openo.util.*, ca.openosp.OscarProperties" %>
 <!DOCTYPE HTML >
 
@@ -889,8 +890,8 @@
             docNo = docNo.replace(' ', '');//trim
             var type = checkType(docNo);
 
-            var placeholder = $('docPlaceholder_' + docNo);
-            var div = placeholder || $(childId);
+            var placeholder = document.getElementById('docPlaceholder_' + docNo);
+            var div = placeholder || document.getElementById(childId);
             var url = '';
             if (type == 'DOC')
                 url = "<%= request.getContextPath() %>/documentManager/showDocument.jsp";
@@ -904,20 +905,34 @@
                 url = "";
 
             var data = "segmentID=" + docNo + "&providerNo=" + providerNo + "&searchProviderNo=" + searchProviderNo + "&status=" + status + "&demoName=" + demoName;
-            if (inQueue)
+            if (inQueue) {
                 data += "&inQueue=" + inQueue;
-            var ajaxOptions = {
-                method: 'get',
-                parameters: data,
-                evalScripts: true,
-                onSuccess: function (transport) {
-                    focusFirstDocLab();
-                }
-            };
-            if (!placeholder) {
-                ajaxOptions.insertion = Insertion.Bottom;
             }
-            new Ajax.Updater(div, url, ajaxOptions);
+
+            fetch(url, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/x-www-form-urlencoded',
+                    '<csrf:tokenname/>': '<csrf:tokenvalue/>'
+                },
+                credentials: 'same-origin',
+                body: data
+            })
+            .then(function (response) {
+                if (!response.ok) { throw new Error('Failed to load document'); }
+                return response.text();
+            })
+            .then(function (html) {
+                if (placeholder) {
+                    jQuery(div).html(html);
+                } else {
+                    jQuery(div).append(html);
+                }
+                focusFirstDocLab();
+            })
+            .catch(function (err) {
+                console.error('Error loading document/lab:', err);
+            });
 
         }
 


### PR DESCRIPTION
## Summary

  Replace deprecated Prototype.js Ajax.Updater with modern fetch API in documentsInQueues.jsp showDocLab() function, switching from GET to POST and adding CSRF protection.

This PR was created to address this review comment: https://github.com/openo-beta/Open-O/pull/2305#pullrequestreview-3918299650

##  Problem

  The showDocLab() function in documentsInQueues.jsp used Prototype.js's Ajax.Updater and Insertion.Bottom — deprecated libraries that should be phased out. It also used a GET request to load document/lab content, passing
  patient-related parameters (segmentID, providerNo, demoName) in the query string.

##  Solution

  - Replaced Ajax.Updater with fetch API (vanilla JS) for the HTTP request
  - Changed GET to POST so parameters are sent in the request body instead of the query string
  - Added CSRF token via the OWASP CSRFGuard taglib (<csrf:tokenname/>/<csrf:tokenvalue/>) in request headers
  - Replaced Prototype $() with document.getElementById() for DOM element lookup
  - Used jQuery .html() and .append() for DOM insertion to preserve script execution from the server-rendered JSP fragments (showDocument.jsp, labDisplayAjax.jsp), which contain inline scripts required for PDF rendering, autocomplete, and popup functions
  - Added error handling with response.ok check and .catch() for network failures

## Summary by Sourcery

Modernize document/lab loading in documentsInQueues.jsp by replacing Prototype.js Ajax.Updater with a fetch-based POST request secured with CSRF headers and safer DOM handling.

Enhancements:
- Switch document/lab loading from Prototype.js Ajax.Updater GET requests to a vanilla fetch-based POST that sends parameters in the request body.
- Encode all request parameters and add a guard for missing target elements to make dynamic loading more robust.
- Use jQuery-based DOM insertion to preserve script execution when rendering server-generated JSP fragments.
- Integrate OWASP CSRFGuard taglib to add CSRF protection headers on the AJAX request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced `Prototype.js` Ajax.Updater in documentsInQueues.jsp with a fetch-based POST that includes CSRF headers. Uses `jQuery` for DOM insertion and adds param encoding and a target element check to make loading safer.

- **Refactors**
  - Switched to fetch POST with `application/x-www-form-urlencoded`, `same-origin` credentials, and headers `X-Requested-With` and CSRF via the `OWASP CSRFGuard` taglib.
  - Moved params from the query string to the request body; replaced `$()` with `document.getElementById`.
  - Inserted HTML via `jQuery` `.html()`/`.append()` and added `response.ok` checks with error logging.

- **Bug Fixes**
  - Encode all request params with `encodeURIComponent` to handle special characters.
  - Guard against a missing target element and bail with a clear console error.

<sup>Written for commit 2ad6bd2525b0ac00de5bceee9d19f45a8e181e0a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Strengthened CSRF token validation and protection mechanisms in document queue operations

* **Refactor**
  * Modernized request handling from legacy framework to current web standards for improved reliability and performance
  * Enhanced error handling with comprehensive logging to facilitate better troubleshooting and system stability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->