### PR TITLE
Fix: medication X button passes wrong ID and removed flawed archival mechanism that was only used to archive re-staged medications after re-editing

### DIFF
--- a/src/main/java/ca/openosp/openo/prescript/pageUtil/RxDeleteRx2Action.java
+++ b/src/main/java/ca/openosp/openo/prescript/pageUtil/RxDeleteRx2Action.java
@@ -99,7 +99,8 @@ public final class RxDeleteRx2Action extends ActionSupport {
      * <li>Discontinue() - Discontinue prescription with reason</li>
      * </ul>
      * <p>
-     * If no method parameter is provided, performs bulk deletion using the drugList parameter.
+     * If no recognized method is provided, falls through to bulk deletion using the drugList parameter.
+     * If drugList is also absent, logs a warning and returns null.
      *
      * Expected request parameters:
      * <ul>
@@ -130,6 +131,10 @@ public final class RxDeleteRx2Action extends ActionSupport {
         RxSessionBean bean = (RxSessionBean) request.getSession().getAttribute("RxSessionBean");
         if (bean == null) {
             response.sendRedirect("error.html");
+            return null;
+        }
+        if (drugList == null || drugList.isBlank()) {
+            MiscUtils.getLogger().warn("RxDeleteRx2Action: no drugList provided for bulk deletion (parameterValue=" + method + ")");
             return null;
         }
         String ip = request.getRemoteAddr();

--- a/src/main/java/ca/openosp/openo/prescript/pageUtil/RxDeleteRx2Action.java
+++ b/src/main/java/ca/openosp/openo/prescript/pageUtil/RxDeleteRx2Action.java
@@ -94,7 +94,6 @@ public final class RxDeleteRx2Action extends ActionSupport {
      * Routes to:
      * <ul>
      * <li>Delete2() - Single prescription deletion by ID</li>
-     * <li>DeleteRxOnCloseRxBox() - Delete prescription when closing dialog</li>
      * <li>clearStash() - Clear prescription stash</li>
      * <li>clearReRxDrugList() - Clear re-prescription list</li>
      * <li>Discontinue() - Discontinue prescription with reason</li>
@@ -118,8 +117,6 @@ public final class RxDeleteRx2Action extends ActionSupport {
         String method = request.getParameter("parameterValue");
         if ("Delete2".equals(method)) {
             return Delete2();
-        } else if ("DeleteRxOnCloseRxBox".equals(method)) {
-            return DeleteRxOnCloseRxBox();
         } else if ("clearStash".equals(method)) {
             return clearStash();
         } else if ("clearReRxDrugList".equals(method)) {
@@ -214,60 +211,6 @@ public final class RxDeleteRx2Action extends ActionSupport {
             MiscUtils.getLogger().error("Error", e);
         }
         MiscUtils.getLogger().debug("===========================END Delete2 RxDeleteRx2Action========================");
-        return null;
-    }
-
-    /**
-     * Deletes a prescription when the prescription dialog box is closed.
-     * <p>
-     * Uses a random ID to look up the actual drug ID from the session's random ID mapping,
-     * then archives the prescription and returns the drug ID as JSON.
-     *
-     * Expected request parameters:
-     * <ul>
-     * <li>randomId - String random identifier mapped to the actual drug ID in the session</li>
-     * </ul>
-     *
-     * @return null (writes JSON response with drug ID directly to output stream)
-     * @throws IOException if response writing fails
-     */
-    public String DeleteRxOnCloseRxBox()
-            throws IOException {
-
-        MiscUtils.getLogger().debug("===========================DeleteRxOnCloseRxBox RxDeleteRx2Action========================");
-        checkPrivilege(request, PRIVILEGE_UPDATE);
-
-        String randomId = request.getParameter("randomId");
-
-
-        // Setup variables
-        RxSessionBean bean = (RxSessionBean) request.getSession().getAttribute("RxSessionBean");
-        if (bean == null) {
-            response.sendRedirect("error.html");
-            return null;
-        }
-        if (randomId != null) {
-            HashMap rd = bean.getRandomIdDrugIdPair();
-            Integer drugId = (Integer) rd.get(Long.parseLong(randomId));
-            MiscUtils.getLogger().debug("111drugId=" + drugId + "--randomId=" + randomId);
-            if (drugId != null) {
-                String ip = request.getRemoteAddr();
-                try {
-                    Drug drug = drugDao.find(drugId);
-                    setDrugDelete(drug);
-                    drugDao.merge(drug);
-                    LogAction.addLog((String) request.getSession().getAttribute("user"), LogConst.DELETE, LogConst.CON_PRESCRIPTION, drugId.toString(), ip, "" + bean.getDemographicNo(), drug.getAuditString());
-                } catch (Exception e) {
-                    MiscUtils.getLogger().error("Error", e);
-                }
-            }
-            HashMap hm = new HashMap();
-            hm.put("drugId", drugId);
-            ObjectNode jsonObject = objectMapper.valueToTree(hm);
-            MiscUtils.getLogger().debug("jsonObject=" + jsonObject.toString());
-            response.getOutputStream().write(jsonObject.toString().getBytes());
-        }
-        MiscUtils.getLogger().debug("===========================END DeleteRxOnCloseRxBox RxDeleteRx2Action========================");
         return null;
     }
 

--- a/src/main/java/ca/openosp/openo/prescript/pageUtil/RxDeleteRx2Action.java
+++ b/src/main/java/ca/openosp/openo/prescript/pageUtil/RxDeleteRx2Action.java
@@ -49,6 +49,7 @@ import ca.openosp.openo.commn.model.SecRole;
 import ca.openosp.openo.managers.SecurityInfoManager;
 import ca.openosp.openo.utility.LoggedInInfo;
 import ca.openosp.openo.utility.MiscUtils;
+import org.owasp.encoder.Encode;
 import ca.openosp.openo.utility.SpringUtils;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.context.support.WebApplicationContextUtils;
@@ -134,7 +135,7 @@ public final class RxDeleteRx2Action extends ActionSupport {
             return null;
         }
         if (drugList == null || drugList.isBlank()) {
-            MiscUtils.getLogger().warn("RxDeleteRx2Action: no drugList provided for bulk deletion (parameterValue=" + method + ")");
+            MiscUtils.getLogger().warn("RxDeleteRx2Action: no drugList provided for bulk deletion (parameterValue=" + Encode.forJava(String.valueOf(method)) + ")");
             return null;
         }
         String ip = request.getRemoteAddr();

--- a/src/main/webapp/oscarRx/SearchDrug3.jsp
+++ b/src/main/webapp/oscarRx/SearchDrug3.jsp
@@ -23,6 +23,27 @@
     Ontario, Canada
 
 --%>
+<%--
+    SearchDrug3.jsp - Prescription drug search and staging interface
+
+    Purpose: Primary interface for searching, staging, and managing prescription drugs.
+    Handles the full prescription workflow including drug search, staging drugs for
+    prescribing, re-prescribing (ReRx), saving prescriptions, and print preview.
+
+    Features:
+    - Drug search with auto-complete and interaction checking
+    - Prescription staging area with add/remove drug cards
+    - Re-prescribe (ReRx) checkbox workflow for existing medications
+    - Save & Print and Save Only prescription workflows
+    - Print preview modal with Edit Rx support
+    - Drug favorites management
+    - Allergy and interaction warnings
+
+    Requires:
+    - RxSessionBean in HTTP session (contains demographicNo, providerNo, stash state)
+
+    @since 2009-09-18
+--%>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
 <%@ taglib prefix="s" uri="/struts-tags" %>
 <%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar" %>
@@ -1723,7 +1744,7 @@
 
   function deletePrescribe(randomId) {
     let url = ctx + "/oscarRx/rxStashDelete.do";
-    let headers = {'Content-Type': 'application/x-www-form-urlencoded'};
+    let headers = {'Content-Type': 'application/x-www-form-urlencoded', 'X-Requested-With': 'XMLHttpRequest'};
     headers['<csrf:tokenname/>'] = document.querySelector('#drugForm input[name="<csrf:tokenname/>"]').value;
 
     fetch(url, {

--- a/src/main/webapp/oscarRx/SearchDrug3.jsp
+++ b/src/main/webapp/oscarRx/SearchDrug3.jsp
@@ -1722,15 +1722,23 @@
 
 
   function deletePrescribe(randomId) {
-    let data = "randomId=" + randomId;
-    let url = ctx + "/oscarRx/rxStashDelete.do?parameterValue=deletePrescribe";
-    new Ajax.Request(url, {
-      method: 'get', parameters: data, onSuccess: function (transport) {
-        // updateCurrentInteractions();
-        jQuery("#set_" + randomId).remove();
-        jQuery("#prescriptionMoreLessLink_" + randomId).remove();
-        jQuery("#deleteMedicationFromPrescription_" + randomId).remove();
+    let url = ctx + "/oscarRx/rxStashDelete.do";
+    let headers = {'Content-Type': 'application/x-www-form-urlencoded'};
+    headers['<csrf:tokenname/>'] = document.querySelector('#drugForm input[name="<csrf:tokenname/>"]').value;
+
+    fetch(url, {
+      method: 'POST',
+      headers: headers,
+      body: new URLSearchParams({parameterValue: 'deletePrescribe', randomId: randomId})
+    }).then(function (response) {
+      if (!response.ok) {
+        console.error('Failed to remove drug from stash (HTTP ' + response.status + ')');
       }
+      document.getElementById("set_" + randomId)?.remove();
+      document.getElementById("prescriptionMoreLessLink_" + randomId)?.remove();
+      document.getElementById("deleteMedicationFromPrescription_" + randomId)?.remove();
+    }).catch(function (error) {
+      console.error('deletePrescribe error:', error);
     });
   }
 
@@ -2630,8 +2638,7 @@
 
     /**
      * Unchecks the "re-prescribe" checkbox for an existing prescribed drug and removes its ID from the re-prescribe list.
-     * @param uiRefId The UI reference ID for the drug.
-     * @param drugId The ID of the drug.
+     * @param drugId The database ID of the prescribed drug.
      */
     function uncheckReRxForExistingPrescribedDrug(drugId) {
       const checkbox = this.getReRxCheckboxByUiRefId(drugId);

--- a/src/main/webapp/oscarRx/SearchDrug3.jsp
+++ b/src/main/webapp/oscarRx/SearchDrug3.jsp
@@ -1015,7 +1015,6 @@
                         <div id="rxText"></div>
                         <%-- Prescriptions are staged here via the prescribe.jsp widget --%>
 
-                        <input type="hidden" id="deleteOnCloseRxBox" value="false"/>
                         <input type="hidden" property="demographicNo" value="<%=patient.getDemographicNo()%>"/>
 
                       </div>
@@ -1728,10 +1727,6 @@
     new Ajax.Request(url, {
       method: 'get', parameters: data, onSuccess: function (transport) {
         // updateCurrentInteractions();
-        if ($('deleteOnCloseRxBox').value == 'true') {
-          deleteRxOnCloseRxBox(randomId);
-        }
-
         jQuery("#set_" + randomId).remove();
         jQuery("#prescriptionMoreLessLink_" + randomId).remove();
         jQuery("#deleteMedicationFromPrescription_" + randomId).remove();
@@ -1739,31 +1734,6 @@
     });
   }
 
-  function deleteRxOnCloseRxBox(randomId) {
-
-    let data = "randomId=" + randomId;
-    let url = ctx + "/oscarRx/deleteRx.do?parameterValue=DeleteRxOnCloseRxBox";
-    new Ajax.Request(url, {
-      method: 'get', parameters: data, onSuccess: function (transport) {
-        let json = transport.responseText.evalJSON();
-        if (json != null) {
-          let id = json.drugId;
-          let rxDate = "rxDate_" + id;
-          let reRx = "reRx_" + id;
-          let del = "del_" + id;
-          let discont = "discont_" + id;
-          let prescrip = "prescrip_" + id;
-          $(rxDate).style.textDecoration = 'line-through';
-          $(reRx).style.textDecoration = 'line-through';
-          $(del).style.textDecoration = 'line-through';
-          $(discont).style.textDecoration = 'line-through';
-          $(prescrip).style.textDecoration = 'line-through';
-          // updateCurrentInteractions();
-        }
-      }
-    });
-
-  }
 
   skipParseInstr = false;
 
@@ -2047,10 +2017,6 @@
     });
   }
 
-  function updateDeleteOnCloseRxBox() {
-    $('deleteOnCloseRxBox').value = 'true';
-  }
-
   function popForm2(scriptId) {
       try {
         const modalElement = document.getElementById('rxPreviewBootstrapModal');
@@ -2097,7 +2063,6 @@
         editRxButton = newEditRxButton;
 
         editRxButton.onclick = function () {
-          updateDeleteOnCloseRxBox();
           const modalInstance = bootstrap.Modal.getInstance(modalElement);
           if (modalInstance) {
             modalInstance.hide();
@@ -2641,18 +2606,17 @@
      */
     function removePrescribingDrug(cardId, drugId) {
       const uiRefId = cardId.id.split('_')[1];
-      this.deletePrescribingDrugFromUI(uiRefId, drugId);
+      this.deletePrescribingDrugFromUI(uiRefId);
       this.uncheckReRxForExistingPrescribedDrug(drugId)
     }
 
     /**
      * Deletes a prescribing drug from UI and calls deletePrescribe.
      * @param uiRefId The unique id for referencing the UI element.
-     * @param drugId The id of the drug to delete.
      */
-    function deletePrescribingDrugFromUI(uiRefId, drugId) {
+    function deletePrescribingDrugFromUI(uiRefId) {
       this.removeElementFromUI(this.getPrescribingDrugCardByUiRefId(uiRefId));
-      this.deletePrescribe(drugId);
+      this.deletePrescribe(uiRefId);
     }
 
     /**


### PR DESCRIPTION
## Summary
  Fixes two interdependent bugs in the prescription staging UI where the X button on drug cards failed to remove drugs from the server stash, and a hidden flag caused unintended permanent archival of medications from the database.

  Fixes #2339
  Fixes #2341 

> **Note:** These bug numbers are based on a google document listing medication issues found, not other issues tracked in GitHub.

  ## Problem
  **Bug `#5` (Regression):** `deletePrescribingDrugFromUI()` passed `drugId`
  (DrugReferenceId) to `deletePrescribe()` instead of `uiRefId` (randomId).
  The server looks up stash items by randomId, so the lookup always failed silently
  — the X button removed the drug from the UI but left it in the server stash.

  **Bug `#6` (Pre-existing, masked by Bug `#5`):** The `deleteOnCloseRxBox` hidden
  field was set to `'true'` when "Edit Rx" was clicked but never reset. This caused
  `deletePrescribe()` to also call `deleteRxOnCloseRxBox()`, which permanently
  archived drugs from the database without user confirmation. Because Bug `#5`
  prevented `deletePrescribe()` from reaching that code path, this bug was masked.

  ## Solution
  **Bug `#5`:** Pass `uiRefId` (the randomId) instead of `drugId` to
  `deletePrescribe()`. Remove the now-unused `drugId` parameter from
  `deletePrescribingDrugFromUI()`.

**Bug `#6`:** Remove the entire `deleteOnCloseRxBox` mechanism — a flawed 2010-era
  feature (commit 75940c0, SourceForge Bug: https://sourceforge.net/p/oscarmcmaster/bugs/1336/) that silently changed the X button from
  "remove from staging" to "permanently archive from database" based on hidden
  state, with no visual indication or confirmation. This is unsafe behavior for a
  healthcare system. Removed: the hidden input, flag setter, conditional check in
  `deletePrescribe()`, the `deleteRxOnCloseRxBox()` function, and the
  server-side `DeleteRxOnCloseRxBox()` method in `RxDeleteRx2Action.java`.

**Bug `#7`:** Removed the underlying functionality, this is no longer applicable, resolved in this PR

  ## Additional improvements
  - **CSRF protection:** `deletePrescribe()` changed from GET to POST with CSRF
    token header, so it is now covered by CSRFGuard's protected methods
    (`POST,PUT,DELETE`)
  - **Prototype.js removal:** Replaced `Ajax.Request` with `fetch` and
    Prototype `$()` calls with `document.getElementById()`
  - **jQuery removal:** Replaced `jQuery("#...").remove()` with vanilla
    `document.getElementById()?.remove()`
  - **Error handling:** Added error logging for failed stash removal requests
  - **JSDoc fix:** Corrected misleading `@param` documentation on
    `uncheckReRxForExistingPrescribedDrug()`
- **Additional javadoc fixes and additions**

## Summary by Sourcery

Fix prescription staging UI deletion so it targets the correct server-side item and remove the legacy hidden-flag mechanism that could silently archive medications.

Bug Fixes:
- Ensure the prescription card X button deletes the correct staged medication on the server by using the UI reference ID instead of the drug ID.
- Eliminate the deleteOnCloseRxBox-based archival flow, including its hidden field, updater, and delete-on-close handler, to prevent unintended permanent archival of medications.

Enhancements:
- Simplify the prescription deletion codepath by removing unused parameters and dead archival-related logic from the staging UI.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the prescription staging X button so it deletes the correct staged item on the server and removes the legacy archival path that could silently archive medications. Also hardens deletion with CSRF-protected POST, safer logging, and better server-side handling.

- **Bug Fixes**
  - Pass `uiRefId` to `deletePrescribe()` instead of `drugId`; remove `drugId` from `deletePrescribingDrugFromUI()` and update the caller.
  - Remove the `deleteOnCloseRxBox` mechanism across client and server, including the client function and the server `DeleteRxOnCloseRxBox` action.

- **Refactors**
  - Switch stash deletion to `fetch` with CSRF and `X-Requested-With` header.
  - Add a null/empty check for `drugList` in bulk deletion and warn instead of proceeding; update Javadoc/JSDoc and add a header comment to `SearchDrug3.jsp`.
  - Encode logged method parameters with `org.owasp.encoder.Encode` to avoid unsafe log output.

<sup>Written for commit 71a7a86e8f6c00f8a7c6b279776c1c5cd6d4726b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Fix prescription staging deletion to target the correct staged medication and remove the legacy delete-on-close archival path, while modernizing the client-side request and security for stash deletion.

Bug Fixes:
- Ensure the X button on prescription cards deletes the correct staged medication on the server by using the UI reference ID.
- Remove the deleteOnCloseRxBox-based delete-on-close mechanism that could silently archive prescriptions.

Enhancements:
- Switch prescription stash deletion to a CSRF-protected POST request using fetch and vanilla DOM APIs.
- Simplify prescription deletion logic by removing unused parameters, dead archival code paths, and correcting related JSDoc.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Switched deletion requests to a safer POST flow with CSRF protection and better HTTP error handling.
  * Simplified UI deletion logic so items remove reliably using a single stable identifier.
  * Safer DOM updates with helper routines to prevent UI errors.

* **Bug Fixes**
  * Added handling for bulk-deletion paths and a guard for missing input to avoid failed deletions and log warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->