### PR TITLE
Security: migrate file upload actions from FileUploadInterceptor to ActionFileUploadInterceptor

### DIFF
--- a/src/main/java/ca/openosp/openo/admin/traceability/GenerateTraceabilityReport2Action.java
+++ b/src/main/java/ca/openosp/openo/admin/traceability/GenerateTraceabilityReport2Action.java
@@ -60,6 +60,7 @@ public class GenerateTraceabilityReport2Action extends ActionSupport implements 
     public static int BUFFER_SIZE = 8192;
 
     private UploadedFile file;
+    private File fileOnDisk;
 
     @Override
     public String execute() throws Exception {
@@ -81,7 +82,7 @@ public class GenerateTraceabilityReport2Action extends ActionSupport implements 
             pipedOutputStream = new PipedOutputStream(pipedInputStream);
             executor = Executors.newFixedThreadPool(2);
 
-            TraceabilityReportProcessor traceabilityReportProcessor = new TraceabilityReportProcessor(pipedOutputStream, PathValidationUtils.toFile(file), request);
+            TraceabilityReportProcessor traceabilityReportProcessor = new TraceabilityReportProcessor(pipedOutputStream, fileOnDisk, request);
             TraceabilityReportConsumer traceabilityReportConsumer = new TraceabilityReportConsumer(pipedInputStream, response);
 
             futureTRP = executor.submit(traceabilityReportProcessor);
@@ -105,6 +106,7 @@ public class GenerateTraceabilityReport2Action extends ActionSupport implements 
     public void withUploadedFiles(List<UploadedFile> uploadedFiles) {
         if (!uploadedFiles.isEmpty()) {
             this.file = uploadedFiles.get(0);
+            this.fileOnDisk = PathValidationUtils.toFile(file);
         }
     }
 }

--- a/src/main/java/ca/openosp/openo/admin/traceability/GenerateTraceabilityReport2Action.java
+++ b/src/main/java/ca/openosp/openo/admin/traceability/GenerateTraceabilityReport2Action.java
@@ -77,6 +77,11 @@ public class GenerateTraceabilityReport2Action extends ActionSupport implements 
         ExecutorService executor = null;
         Future<String> futureTRP = null;
         Future<String> futureTRC = null;
+        if (fileOnDisk == null) {
+            MiscUtils.getLogger().error("No traceability file was uploaded");
+            return null;
+        }
+
         try {
             pipedInputStream = new PipedInputStream(BUFFER_SIZE);
             pipedOutputStream = new PipedOutputStream(pipedInputStream);

--- a/src/main/java/ca/openosp/openo/admin/traceability/GenerateTraceabilityReport2Action.java
+++ b/src/main/java/ca/openosp/openo/admin/traceability/GenerateTraceabilityReport2Action.java
@@ -28,6 +28,7 @@ package ca.openosp.openo.admin.traceability;
 import java.io.File;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
+import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -36,6 +37,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import ca.openosp.openo.utility.MiscUtils;
+import ca.openosp.openo.utility.PathValidationUtils;
 
 import ca.openosp.openo.log.LogAction;
 import ca.openosp.openo.log.LogConst;
@@ -49,13 +51,15 @@ import ca.openosp.openo.log.LogConst;
  */
 import org.apache.struts2.ActionSupport;
 import org.apache.struts2.ServletActionContext;
+import org.apache.struts2.action.UploadedFilesAware;
+import org.apache.struts2.dispatcher.multipart.UploadedFile;
 
-public class GenerateTraceabilityReport2Action extends ActionSupport {
+public class GenerateTraceabilityReport2Action extends ActionSupport implements UploadedFilesAware {
     HttpServletRequest request = ServletActionContext.getRequest();
     HttpServletResponse response = ServletActionContext.getResponse();
     public static int BUFFER_SIZE = 8192;
 
-    private File file;
+    private UploadedFile file;
 
     @Override
     public String execute() throws Exception {
@@ -77,7 +81,7 @@ public class GenerateTraceabilityReport2Action extends ActionSupport {
             pipedOutputStream = new PipedOutputStream(pipedInputStream);
             executor = Executors.newFixedThreadPool(2);
 
-            TraceabilityReportProcessor traceabilityReportProcessor = new TraceabilityReportProcessor(pipedOutputStream, file, request);
+            TraceabilityReportProcessor traceabilityReportProcessor = new TraceabilityReportProcessor(pipedOutputStream, PathValidationUtils.toFile(file), request);
             TraceabilityReportConsumer traceabilityReportConsumer = new TraceabilityReportConsumer(pipedInputStream, response);
 
             futureTRP = executor.submit(traceabilityReportProcessor);
@@ -97,11 +101,10 @@ public class GenerateTraceabilityReport2Action extends ActionSupport {
         return null;
     }
 
-    public File getFile() {
-        return file;
-    }
-
-    public void setFile(File file) {
-        this.file = file;
+    @Override
+    public void withUploadedFiles(List<UploadedFile> uploadedFiles) {
+        if (!uploadedFiles.isEmpty()) {
+            this.file = uploadedFiles.get(0);
+        }
     }
 }

--- a/src/main/java/ca/openosp/openo/billings/ca/on/OHIP/ScheduleOfBenefitsUpload2Action.java
+++ b/src/main/java/ca/openosp/openo/billings/ca/on/OHIP/ScheduleOfBenefitsUpload2Action.java
@@ -37,6 +37,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.apache.logging.log4j.Logger;
 import ca.openosp.openo.utility.MiscUtils;
+import ca.openosp.openo.utility.PathValidationUtils;
 
 import ca.openosp.OscarProperties;
 
@@ -46,8 +47,10 @@ import ca.openosp.OscarProperties;
  */
 import org.apache.struts2.ActionSupport;
 import org.apache.struts2.ServletActionContext;
+import org.apache.struts2.action.UploadedFilesAware;
+import org.apache.struts2.dispatcher.multipart.UploadedFile;
 
-public class ScheduleOfBenefitsUpload2Action extends ActionSupport {
+public class ScheduleOfBenefitsUpload2Action extends ActionSupport implements UploadedFilesAware {
     HttpServletRequest request = ServletActionContext.getRequest();
     HttpServletResponse response = ServletActionContext.getResponse();
 
@@ -72,7 +75,7 @@ public class ScheduleOfBenefitsUpload2Action extends ActionSupport {
         BigDecimal updateAnaesthetistFeesValue = updateAnaesthetistFees ? getBDValue(request.getParameter("updateAnaesthetistFeesValue")) : null;
         try {
 
-            InputStream is = new java.io.FileInputStream(importFile);
+            InputStream is = new java.io.FileInputStream(PathValidationUtils.toFile(importFile));
 
             ScheduleOfBenefits sob = new ScheduleOfBenefits();
             String codeChanges = request.getParameter("showChangedCodes");
@@ -156,27 +159,17 @@ public class ScheduleOfBenefitsUpload2Action extends ActionSupport {
         return isAdded;
     }
 
-    private File importFile;          // 上传的文件
-    private String importFileFileName; // 上传文件的名称
+    private UploadedFile importFile;
     private boolean updateAssistantFees;
     private boolean updateAnaesthetistFees;
     private BigDecimal updateAssistantFeesValue;
     private BigDecimal updateAnaesthetistFeesValue;
 
-    public File getImportFile() {
-        return importFile;
-    }
-
-    public void setImportFile(File importFile) {
-        this.importFile = importFile;
-    }
-
-    public String getImportFileFileName() {
-        return importFileFileName;
-    }
-
-    public void setImportFileFileName(String importFileFileName) {
-        this.importFileFileName = importFileFileName;
+    @Override
+    public void withUploadedFiles(List<UploadedFile> uploadedFiles) {
+        if (!uploadedFiles.isEmpty()) {
+            this.importFile = uploadedFiles.get(0);
+        }
     }
 
     public boolean isUpdateAssistantFees() {

--- a/src/main/java/ca/openosp/openo/billings/ca/on/OHIP/ScheduleOfBenefitsUpload2Action.java
+++ b/src/main/java/ca/openosp/openo/billings/ca/on/OHIP/ScheduleOfBenefitsUpload2Action.java
@@ -75,7 +75,7 @@ public class ScheduleOfBenefitsUpload2Action extends ActionSupport implements Up
         BigDecimal updateAnaesthetistFeesValue = updateAnaesthetistFees ? getBDValue(request.getParameter("updateAnaesthetistFeesValue")) : null;
         try {
 
-            InputStream is = new java.io.FileInputStream(PathValidationUtils.toFile(importFile));
+            InputStream is = new java.io.FileInputStream(importFileOnDisk);
 
             ScheduleOfBenefits sob = new ScheduleOfBenefits();
             String codeChanges = request.getParameter("showChangedCodes");
@@ -160,6 +160,7 @@ public class ScheduleOfBenefitsUpload2Action extends ActionSupport implements Up
     }
 
     private UploadedFile importFile;
+    private File importFileOnDisk;
     private boolean updateAssistantFees;
     private boolean updateAnaesthetistFees;
     private BigDecimal updateAssistantFeesValue;
@@ -169,6 +170,7 @@ public class ScheduleOfBenefitsUpload2Action extends ActionSupport implements Up
     public void withUploadedFiles(List<UploadedFile> uploadedFiles) {
         if (!uploadedFiles.isEmpty()) {
             this.importFile = uploadedFiles.get(0);
+            this.importFileOnDisk = PathValidationUtils.toFile(importFile);
         }
     }
 

--- a/src/main/java/ca/openosp/openo/billings/ca/on/OHIP/ScheduleOfBenefitsUpload2Action.java
+++ b/src/main/java/ca/openosp/openo/billings/ca/on/OHIP/ScheduleOfBenefitsUpload2Action.java
@@ -161,6 +161,8 @@ public class ScheduleOfBenefitsUpload2Action extends ActionSupport implements Up
 
     private UploadedFile importFile;
     private File importFileOnDisk;
+    private String importFileFileName;
+    private String importFileContentType;
     private boolean updateAssistantFees;
     private boolean updateAnaesthetistFees;
     private BigDecimal updateAssistantFeesValue;
@@ -171,6 +173,8 @@ public class ScheduleOfBenefitsUpload2Action extends ActionSupport implements Up
         if (!uploadedFiles.isEmpty()) {
             this.importFile = uploadedFiles.get(0);
             this.importFileOnDisk = PathValidationUtils.toFile(importFile);
+            this.importFileFileName = importFile.getOriginalName();
+            this.importFileContentType = importFile.getContentType();
         }
     }
 

--- a/src/main/java/ca/openosp/openo/billings/ca/on/OHIP/ScheduleOfBenefitsUpload2Action.java
+++ b/src/main/java/ca/openosp/openo/billings/ca/on/OHIP/ScheduleOfBenefitsUpload2Action.java
@@ -73,6 +73,12 @@ public class ScheduleOfBenefitsUpload2Action extends ActionSupport implements Up
         boolean updateAnaesthetistFees = checkBox(request.getParameter("updateAnaesthetistFees"));
         BigDecimal updateAssistantFeesValue = updateAssistantFees ? getBDValue(request.getParameter("updateAssistantFeesValue")) : null;
         BigDecimal updateAnaesthetistFeesValue = updateAnaesthetistFees ? getBDValue(request.getParameter("updateAnaesthetistFeesValue")) : null;
+        if (importFileOnDisk == null) {
+            request.setAttribute("outcome", "exception");
+            request.setAttribute("warnings", warnings);
+            return SUCCESS;
+        }
+
         try {
 
             InputStream is = new java.io.FileInputStream(importFileOnDisk);

--- a/src/main/java/ca/openosp/openo/billings/ca/on/pageUtil/BillingDocumentErrorReportUpload2Action.java
+++ b/src/main/java/ca/openosp/openo/billings/ca/on/pageUtil/BillingDocumentErrorReportUpload2Action.java
@@ -72,7 +72,7 @@ public class BillingDocumentErrorReportUpload2Action extends ActionSupport imple
         String filename = request.getParameter("filename");
 
         if (StringUtils.isBlank(filename)) {
-            if (!saveFile(PathValidationUtils.toFile(file1), file1FileName)) {
+            if (!saveFile(file1OnDisk, file1FileName)) {
                 addActionError(getText("errors.fileNotAdded"));
                 return ERROR;
             } else {
@@ -388,6 +388,7 @@ public class BillingDocumentErrorReportUpload2Action extends ActionSupport imple
         return hd;
     }
     private UploadedFile file1; // Uploaded file
+    private File file1OnDisk;
     private String file1FileName; // Name of the uploaded file
 
     private String filename; // Filename parameter from request
@@ -396,6 +397,7 @@ public class BillingDocumentErrorReportUpload2Action extends ActionSupport imple
     public void withUploadedFiles(List<UploadedFile> uploadedFiles) {
         if (!uploadedFiles.isEmpty()) {
             this.file1 = uploadedFiles.get(0);
+            this.file1OnDisk = PathValidationUtils.toFile(file1);
             this.file1FileName = file1.getOriginalName();
         }
     }

--- a/src/main/java/ca/openosp/openo/billings/ca/on/pageUtil/BillingDocumentErrorReportUpload2Action.java
+++ b/src/main/java/ca/openosp/openo/billings/ca/on/pageUtil/BillingDocumentErrorReportUpload2Action.java
@@ -72,7 +72,7 @@ public class BillingDocumentErrorReportUpload2Action extends ActionSupport imple
         String filename = request.getParameter("filename");
 
         if (StringUtils.isBlank(filename)) {
-            if (!saveFile(file1OnDisk, file1FileName)) {
+            if (file1OnDisk == null || file1FileName == null || file1FileName.trim().isEmpty() || !saveFile(file1OnDisk, file1FileName)) {
                 addActionError(getText("errors.fileNotAdded"));
                 return ERROR;
             } else {

--- a/src/main/java/ca/openosp/openo/billings/ca/on/pageUtil/BillingDocumentErrorReportUpload2Action.java
+++ b/src/main/java/ca/openosp/openo/billings/ca/on/pageUtil/BillingDocumentErrorReportUpload2Action.java
@@ -27,6 +27,8 @@
 package ca.openosp.openo.billings.ca.on.pageUtil;
 
 import org.apache.struts2.ActionSupport;
+import org.apache.struts2.action.UploadedFilesAware;
+import org.apache.struts2.dispatcher.multipart.UploadedFile;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.struts2.ServletActionContext;
 import ca.openosp.openo.commn.dao.BatchEligibilityDao;
@@ -55,7 +57,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Vector;
 
-public class BillingDocumentErrorReportUpload2Action extends ActionSupport {
+public class BillingDocumentErrorReportUpload2Action extends ActionSupport implements UploadedFilesAware {
     HttpServletRequest request = ServletActionContext.getRequest();
     HttpServletResponse response = ServletActionContext.getResponse();
 
@@ -70,7 +72,7 @@ public class BillingDocumentErrorReportUpload2Action extends ActionSupport {
         String filename = request.getParameter("filename");
 
         if (StringUtils.isBlank(filename)) {
-            if (!saveFile(file1, file1FileName)) {
+            if (!saveFile(PathValidationUtils.toFile(file1), file1FileName)) {
                 addActionError(getText("errors.fileNotAdded"));
                 return ERROR;
             } else {
@@ -385,34 +387,17 @@ public class BillingDocumentErrorReportUpload2Action extends ActionSupport {
 
         return hd;
     }
-    private File file1; // Uploaded file
+    private UploadedFile file1; // Uploaded file
     private String file1FileName; // Name of the uploaded file
-    private String file1ContentType; // Content type of the uploaded file
 
     private String filename; // Filename parameter from request
 
-    public File getFile1() {
-        return file1;
-    }
-
-    public void setFile1(File file1) {
-        this.file1 = file1;
-    }
-
-    public String getFile1FileName() {
-        return file1FileName;
-    }
-
-    public void setFile1FileName(String file1FileName) {
-        this.file1FileName = file1FileName;
-    }
-
-    public String getFile1ContentType() {
-        return file1ContentType;
-    }
-
-    public void setFile1ContentType(String file1ContentType) {
-        this.file1ContentType = file1ContentType;
+    @Override
+    public void withUploadedFiles(List<UploadedFile> uploadedFiles) {
+        if (!uploadedFiles.isEmpty()) {
+            this.file1 = uploadedFiles.get(0);
+            this.file1FileName = file1.getOriginalName();
+        }
     }
 
     public String getFilename() {

--- a/src/main/java/ca/openosp/openo/billings/ca/on/pageUtil/BillingDocumentErrorReportUpload2Action.java
+++ b/src/main/java/ca/openosp/openo/billings/ca/on/pageUtil/BillingDocumentErrorReportUpload2Action.java
@@ -390,6 +390,7 @@ public class BillingDocumentErrorReportUpload2Action extends ActionSupport imple
     private UploadedFile file1; // Uploaded file
     private File file1OnDisk;
     private String file1FileName; // Name of the uploaded file
+    private String file1ContentType;
 
     private String filename; // Filename parameter from request
 
@@ -399,6 +400,7 @@ public class BillingDocumentErrorReportUpload2Action extends ActionSupport imple
             this.file1 = uploadedFiles.get(0);
             this.file1OnDisk = PathValidationUtils.toFile(file1);
             this.file1FileName = file1.getOriginalName();
+            this.file1ContentType = file1.getContentType();
         }
     }
 

--- a/src/main/java/ca/openosp/openo/casemgmt/web/CaseManagementView2Action.java
+++ b/src/main/java/ca/openosp/openo/casemgmt/web/CaseManagementView2Action.java
@@ -32,6 +32,8 @@ import ca.openosp.openo.commn.model.*;
 import ca.openosp.openo.services.security.SecurityManager;
 import ca.openosp.openo.util.UtilDateUtilities;
 import org.apache.struts2.ActionSupport;
+import org.apache.struts2.action.UploadedFilesAware;
+import org.apache.struts2.dispatcher.multipart.UploadedFile;
 import ca.openosp.openo.model.security.Secrole;
 import ca.openosp.openo.services.security.RolesManager;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -80,7 +82,7 @@ import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.util.*;
 
-public class CaseManagementView2Action extends ActionSupport {
+public class CaseManagementView2Action extends ActionSupport implements UploadedFilesAware {
 
     HttpServletRequest request = ServletActionContext.getRequest();
     HttpServletResponse response = ServletActionContext.getResponse();
@@ -1854,7 +1856,7 @@ public class CaseManagementView2Action extends ActionSupport {
     private CaseManagementCPP cpp = new CaseManagementCPP();
     private EncounterWindow ectWin = new EncounterWindow();
     public static final String[] tabs = {"Current Issues", "Client History", "Allergies", "Prescriptions", "Reminders", "Ticklers", "Search"};
-    private File imageFile;
+    private UploadedFile imageFile;
 
     private String searchStartDate;
     private String searchEndDate;
@@ -1895,12 +1897,11 @@ public class CaseManagementView2Action extends ActionSupport {
         this.note_sort = note_sort;
     }
 
-    public File getImageFile() {
-        return imageFile;
-    }
-
-    public void setImageFile(File imageFile) {
-        this.imageFile = imageFile;
+    @Override
+    public void withUploadedFiles(List<UploadedFile> uploadedFiles) {
+        if (!uploadedFiles.isEmpty()) {
+            this.imageFile = uploadedFiles.get(0);
+        }
     }
 
     public CaseManagementCPP getCpp() {

--- a/src/main/java/ca/openosp/openo/casemgmt/web/ClientImage2Action.java
+++ b/src/main/java/ca/openosp/openo/casemgmt/web/ClientImage2Action.java
@@ -39,17 +39,28 @@ import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 import java.io.File;
 import java.nio.file.Files;
+import java.util.List;
+import org.apache.struts2.action.UploadedFilesAware;
+import org.apache.struts2.dispatcher.multipart.UploadedFile;
 
-public class ClientImage2Action extends ActionSupport {
+public class ClientImage2Action extends ActionSupport implements UploadedFilesAware {
     HttpServletRequest request = ServletActionContext.getRequest();
     HttpServletResponse response = ServletActionContext.getResponse();
 
-    private File clientImage;
+    private UploadedFile clientImage;
     private String clientImageFileName;
 
     private static Logger log = MiscUtils.getLogger();
 
     private ClientImageManager clientImageManager = SpringUtils.getBean(ClientImageManager.class);
+
+    @Override
+    public void withUploadedFiles(List<UploadedFile> uploadedFiles) {
+        if (!uploadedFiles.isEmpty()) {
+            this.clientImage = uploadedFiles.get(0);
+            this.clientImageFileName = clientImage.getOriginalName();
+        }
+    }
 
     // Execute on struts action call
     public String execute() {
@@ -72,13 +83,15 @@ public class ClientImage2Action extends ActionSupport {
 
         // Ensure that the upload directory is correct and create a new image object that will be saved to the client
         try {
+            File rawImage = PathValidationUtils.toFile(clientImage);
+
             // Validate that the uploaded file is in an allowed temp directory
-            if (!PathValidationUtils.isInAllowedTempDirectory(clientImage)) {
-                throw new IllegalArgumentException("Invalid file path: " + clientImage.getPath());
+            if (!PathValidationUtils.isInAllowedTempDirectory(rawImage)) {
+                throw new IllegalArgumentException("Invalid file path: " + rawImage.getPath());
             }
 
             // Re-validate at point of use for static analysis visibility
-            File validatedImage = PathValidationUtils.validateUpload(clientImage);
+            File validatedImage = PathValidationUtils.validateUpload(rawImage);
             byte[] imageData = Files.readAllBytes(validatedImage.toPath());
 
             ClientImage clientImageObj = new ClientImage();
@@ -96,13 +109,5 @@ public class ClientImage2Action extends ActionSupport {
 
         request.setAttribute("success", true);
         return SUCCESS;
-    }
-
-    public void setClientImage(File clientImage) { 
-        this.clientImage = clientImage; 
-    }
-
-    public void setClientImageFileName(String name) { 
-        this.clientImageFileName = name; 
     }
 }

--- a/src/main/java/ca/openosp/openo/casemgmt/web/ClientImage2Action.java
+++ b/src/main/java/ca/openosp/openo/casemgmt/web/ClientImage2Action.java
@@ -48,6 +48,7 @@ public class ClientImage2Action extends ActionSupport implements UploadedFilesAw
     HttpServletResponse response = ServletActionContext.getResponse();
 
     private UploadedFile clientImage;
+    private File clientImageOnDisk;
     private String clientImageFileName;
 
     private static Logger log = MiscUtils.getLogger();
@@ -58,6 +59,7 @@ public class ClientImage2Action extends ActionSupport implements UploadedFilesAw
     public void withUploadedFiles(List<UploadedFile> uploadedFiles) {
         if (!uploadedFiles.isEmpty()) {
             this.clientImage = uploadedFiles.get(0);
+            this.clientImageOnDisk = PathValidationUtils.toFile(clientImage);
             this.clientImageFileName = clientImage.getOriginalName();
         }
     }
@@ -83,15 +85,13 @@ public class ClientImage2Action extends ActionSupport implements UploadedFilesAw
 
         // Ensure that the upload directory is correct and create a new image object that will be saved to the client
         try {
-            File rawImage = PathValidationUtils.toFile(clientImage);
-
             // Validate that the uploaded file is in an allowed temp directory
-            if (!PathValidationUtils.isInAllowedTempDirectory(rawImage)) {
-                throw new IllegalArgumentException("Invalid file path: " + rawImage.getPath());
+            if (!PathValidationUtils.isInAllowedTempDirectory(clientImageOnDisk)) {
+                throw new IllegalArgumentException("Invalid file path: " + clientImageOnDisk.getPath());
             }
 
             // Re-validate at point of use for static analysis visibility
-            File validatedImage = PathValidationUtils.validateUpload(rawImage);
+            File validatedImage = PathValidationUtils.validateUpload(clientImageOnDisk);
             byte[] imageData = Files.readAllBytes(validatedImage.toPath());
 
             ClientImage clientImageObj = new ClientImage();

--- a/src/main/java/ca/openosp/openo/dashboard/admin/ManageDashboard2Action.java
+++ b/src/main/java/ca/openosp/openo/dashboard/admin/ManageDashboard2Action.java
@@ -114,14 +114,13 @@ public class ManageDashboard2Action extends ActionSupport implements UploadedFil
 
         byte[] filebytes = null;
         ObjectNode json = null;
-        File templateFile = indicatorTemplateFile != null ? PathValidationUtils.toFile(indicatorTemplateFile) : null;
 
-        if (templateFile != null) {
+        if (indicatorTemplateFileOnDisk != null) {
             try {
                 // Validate uploaded file before any file operations
-                PathValidationUtils.validateUpload(templateFile);
+                PathValidationUtils.validateUpload(indicatorTemplateFileOnDisk);
 
-                filebytes = Files.readAllBytes(templateFile.toPath());
+                filebytes = Files.readAllBytes(indicatorTemplateFileOnDisk.toPath());
             } catch (Exception e) {
                 json = objectMapper.createObjectNode();
                 json.put("status", "error");
@@ -169,7 +168,7 @@ public class ManageDashboard2Action extends ActionSupport implements UploadedFil
                 builder.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
 
                 // Build the JDOM2 document
-                Document xmlDocument = builder.build(templateFile);
+                Document xmlDocument = builder.build(indicatorTemplateFileOnDisk);
 
                 // Setup XSD validation
                 SAXParserFactory factory = SAXParserFactory.newInstance();
@@ -439,11 +438,13 @@ public class ManageDashboard2Action extends ActionSupport implements UploadedFil
     }
 
     private UploadedFile indicatorTemplateFile;
+    private File indicatorTemplateFileOnDisk;
 
     @Override
     public void withUploadedFiles(List<UploadedFile> uploadedFiles) {
         if (!uploadedFiles.isEmpty()) {
             this.indicatorTemplateFile = uploadedFiles.get(0);
+            this.indicatorTemplateFileOnDisk = PathValidationUtils.toFile(indicatorTemplateFile);
         }
     }
     

--- a/src/main/java/ca/openosp/openo/dashboard/admin/ManageDashboard2Action.java
+++ b/src/main/java/ca/openosp/openo/dashboard/admin/ManageDashboard2Action.java
@@ -26,6 +26,8 @@
 package ca.openosp.openo.dashboard.admin;
 
 import org.apache.struts2.ActionSupport;
+import org.apache.struts2.action.UploadedFilesAware;
+import org.apache.struts2.dispatcher.multipart.UploadedFile;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.logging.log4j.Logger;
@@ -63,7 +65,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class ManageDashboard2Action extends ActionSupport {
+public class ManageDashboard2Action extends ActionSupport implements UploadedFilesAware {
     HttpServletRequest request = ServletActionContext.getRequest();
     HttpServletResponse response = ServletActionContext.getResponse();
 
@@ -112,13 +114,14 @@ public class ManageDashboard2Action extends ActionSupport {
 
         byte[] filebytes = null;
         ObjectNode json = null;
+        File templateFile = indicatorTemplateFile != null ? PathValidationUtils.toFile(indicatorTemplateFile) : null;
 
-        if (indicatorTemplateFile != null) {
+        if (templateFile != null) {
             try {
                 // Validate uploaded file before any file operations
-                PathValidationUtils.validateUpload(indicatorTemplateFile);
+                PathValidationUtils.validateUpload(templateFile);
 
-                filebytes = Files.readAllBytes(indicatorTemplateFile.toPath());
+                filebytes = Files.readAllBytes(templateFile.toPath());
             } catch (Exception e) {
                 json = objectMapper.createObjectNode();
                 json.put("status", "error");
@@ -166,7 +169,7 @@ public class ManageDashboard2Action extends ActionSupport {
                 builder.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
 
                 // Build the JDOM2 document
-                Document xmlDocument = builder.build(indicatorTemplateFile);
+                Document xmlDocument = builder.build(templateFile);
 
                 // Setup XSD validation
                 SAXParserFactory factory = SAXParserFactory.newInstance();
@@ -435,14 +438,13 @@ public class ManageDashboard2Action extends ActionSupport {
         }
     }
 
-    private File indicatorTemplateFile;
+    private UploadedFile indicatorTemplateFile;
 
-    public File getIndicatorTemplateFile() {
-        return indicatorTemplateFile;
-    }
-
-    public void setIndicatorTemplateFile(File indicatorTemplateFile) {
-        this.indicatorTemplateFile = indicatorTemplateFile;
+    @Override
+    public void withUploadedFiles(List<UploadedFile> uploadedFiles) {
+        if (!uploadedFiles.isEmpty()) {
+            this.indicatorTemplateFile = uploadedFiles.get(0);
+        }
     }
     
     /**

--- a/src/main/java/ca/openosp/openo/demographic/pageUtil/ImportDemographicDataAction42Action.java
+++ b/src/main/java/ca/openosp/openo/demographic/pageUtil/ImportDemographicDataAction42Action.java
@@ -229,8 +229,7 @@ public class ImportDemographicDataAction42Action extends ActionSupport implement
          * thread to close gracefully while the import is being processed.
          */
         String filename = importFileFileName;
-        File importFileRaw = PathValidationUtils.toFile(importFile);
-        Path filePath = importFileRaw.toPath().normalize();
+        Path filePath = importFileOnDisk.toPath().normalize();
 
         // Get context of the temp directory, get the file path to the the temp directory
         ServletContext servletContext = ServletActionContext.getServletContext();
@@ -4847,6 +4846,7 @@ public class ImportDemographicDataAction42Action extends ActionSupport implement
     }
 
     private UploadedFile importFile = null;
+    private File importFileOnDisk;
     private String importFileFileName;
     private boolean matchProviderNames = true;
     private int timeshiftInDays;
@@ -4856,6 +4856,7 @@ public class ImportDemographicDataAction42Action extends ActionSupport implement
     public void withUploadedFiles(List<UploadedFile> uploadedFiles) {
         if (!uploadedFiles.isEmpty()) {
             this.importFile = uploadedFiles.get(0);
+            this.importFileOnDisk = PathValidationUtils.toFile(importFile);
             this.importFileFileName = importFile.getOriginalName();
         }
     }

--- a/src/main/java/ca/openosp/openo/demographic/pageUtil/ImportDemographicDataAction42Action.java
+++ b/src/main/java/ca/openosp/openo/demographic/pageUtil/ImportDemographicDataAction42Action.java
@@ -228,6 +228,11 @@ public class ImportDemographicDataAction42Action extends ActionSupport implement
          * save the upload stream to a temp directory.  This should allow the HTTP
          * thread to close gracefully while the import is being processed.
          */
+        if (importFileOnDisk == null || importFileFileName == null || importFileFileName.trim().isEmpty()) {
+            addActionError("No upload file was provided.");
+            return ERROR;
+        }
+
         String filename = importFileFileName;
         Path filePath = importFileOnDisk.toPath().normalize();
 

--- a/src/main/java/ca/openosp/openo/demographic/pageUtil/ImportDemographicDataAction42Action.java
+++ b/src/main/java/ca/openosp/openo/demographic/pageUtil/ImportDemographicDataAction42Action.java
@@ -62,6 +62,8 @@ import cdsDt.DiabetesMotivationalCounselling.CounsellingPerformed;
 import cdsDt.PersonNameStandard.LegalName;
 import cdsDt.PersonNameStandard.OtherNames;
 import org.apache.struts2.ActionSupport;
+import org.apache.struts2.action.UploadedFilesAware;
+import org.apache.struts2.dispatcher.multipart.UploadedFile;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.FileUtils;
@@ -136,7 +138,7 @@ import java.util.*;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
-public class ImportDemographicDataAction42Action extends ActionSupport {
+public class ImportDemographicDataAction42Action extends ActionSupport implements UploadedFilesAware {
     HttpServletRequest request = ServletActionContext.getRequest();
     HttpServletResponse response = ServletActionContext.getResponse();
 
@@ -227,7 +229,8 @@ public class ImportDemographicDataAction42Action extends ActionSupport {
          * thread to close gracefully while the import is being processed.
          */
         String filename = importFileFileName;
-        Path filePath = importFile.toPath().normalize();
+        File importFileRaw = PathValidationUtils.toFile(importFile);
+        Path filePath = importFileRaw.toPath().normalize();
 
         // Get context of the temp directory, get the file path to the the temp directory
         ServletContext servletContext = ServletActionContext.getServletContext();
@@ -4843,26 +4846,18 @@ public class ImportDemographicDataAction42Action extends ActionSupport {
         return ret;
     }
 
-    private File importFile = null;
+    private UploadedFile importFile = null;
     private String importFileFileName;
     private boolean matchProviderNames = true;
     private int timeshiftInDays;
     private String courseId;
 
-    public File getImportFile() {
-        return importFile;
-    }
-
-    public void setImportFile(File importFile) {
-        this.importFile = importFile;
-    }
-
-    public String getImportFileFileName() {
-        return importFileFileName;
-    }
-
-    public void setImportFileFileName(String importFileFileName) {
-        this.importFileFileName = importFileFileName;
+    @Override
+    public void withUploadedFiles(List<UploadedFile> uploadedFiles) {
+        if (!uploadedFiles.isEmpty()) {
+            this.importFile = uploadedFiles.get(0);
+            this.importFileFileName = importFile.getOriginalName();
+        }
     }
 
     public boolean isMatchProviderNames() {

--- a/src/main/java/ca/openosp/openo/documentManager/actions/AddEditDocument2Action.java
+++ b/src/main/java/ca/openosp/openo/documentManager/actions/AddEditDocument2Action.java
@@ -37,6 +37,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Date;
 import java.util.Hashtable;
+import java.util.List;
 import java.util.ResourceBundle;
 
 import javax.servlet.http.HttpServletRequest;
@@ -81,8 +82,10 @@ import com.itextpdf.text.pdf.PdfReader;
 
 import org.apache.struts2.ActionSupport;
 import org.apache.struts2.ServletActionContext;
+import org.apache.struts2.action.UploadedFilesAware;
+import org.apache.struts2.dispatcher.multipart.UploadedFile;
 
-public class AddEditDocument2Action extends ActionSupport {
+public class AddEditDocument2Action extends ActionSupport implements UploadedFilesAware {
     HttpServletRequest request = ServletActionContext.getRequest();
     HttpServletResponse response = ServletActionContext.getResponse();
 
@@ -96,8 +99,10 @@ public class AddEditDocument2Action extends ActionSupport {
             throw new SecurityException("missing required sec object (_edoc)");
         }
 
+        File rawDocFile = docFile != null ? PathValidationUtils.toFile(docFile) : null;
+
         int numberOfPages = 0;
-        String fileName = MiscUtils.sanitizeFileName(this.getDocFile().getName());
+        String fileName = MiscUtils.sanitizeFileName(rawDocFile.getName());
         String user = (String) request.getSession().getAttribute("user");
         EDoc newDoc = new EDoc("", "", fileName, "", user, user, this.getSource(), 'A', UtilDateUtilities.getToday("yyyy-MM-dd"), "", "", "demographic", "-1", 0);
         newDoc.setDocPublic("0");
@@ -112,14 +117,14 @@ public class AddEditDocument2Action extends ActionSupport {
         }
 
         // save local file;
-        if (this.getDocFile().length() == 0) {
+        if (rawDocFile.length() == 0) {
             response.setHeader("oscar_error", props.getString("dms.addDocument.errorZeroSize"));
             response.sendError(500, props.getString("dms.addDocument.errorZeroSize"));
             return null;
         }
-        File file = writeLocalFile(Files.newInputStream(this.getDocFile().toPath()), fileName);// write file to local dir
+        File file = writeLocalFile(Files.newInputStream(rawDocFile.toPath()), fileName);// write file to local dir
 
-        if (!file.exists() || file.length() < this.getDocFile().length()) {
+        if (!file.exists() || file.length() < rawDocFile.length()) {
             response.setHeader("oscar_error", props.getString("dms.addDocument.errorNoWrite"));
             response.sendError(500, props.getString("dms.addDocument.errorNoWrite"));
             return null;
@@ -243,8 +248,8 @@ public class AddEditDocument2Action extends ActionSupport {
                 errors.put("typemissing", "dms.error.typeMissing");
                 throw new Exception();
             }
-            File docFile = this.getDocFile();
-            if (docFile.length() == 0) {
+            File rawDocFile = this.docFile != null ? PathValidationUtils.toFile(this.docFile) : null;
+            if (rawDocFile == null || rawDocFile.length() == 0) {
                 errors.put("uploaderror", "dms.error.uploadError");
                 throw new FileNotFoundException();
             }
@@ -261,7 +266,7 @@ public class AddEditDocument2Action extends ActionSupport {
             String fileName2 = newDoc.getFileName();
 
             // save local file
-            File file = writeLocalFile(Files.newInputStream(docFile.toPath()), fileName2);
+            File file = writeLocalFile(Files.newInputStream(rawDocFile.toPath()), fileName2);
             newDoc.setContentType(this.docFileContentType);
 
             if (fileName2.toLowerCase().endsWith(".pdf")) {
@@ -387,8 +392,8 @@ public class AddEditDocument2Action extends ActionSupport {
 
             if (OscarProperties.getInstance().getBooleanProperty("ALLOW_UPDATE_DOCUMENT_CONTENT", "true"))
             {
-                File docFile = this.getDocFile();
-                if (docFile != null && docFile.exists()) {
+                File rawDocFileEdit = this.docFile != null ? PathValidationUtils.toFile(this.docFile) : null;
+                if (rawDocFileEdit != null && rawDocFileEdit.exists()) {
                     fileName = MiscUtils.sanitizeFileName(this.docFileFileName);
                     updateFileContent = true; // set update to true
                 }
@@ -426,7 +431,8 @@ this.getSource(), 'A', this.getObservationDate(), reviewerId, reviewDateTime, th
             if (updateFileContent) {
                 fileName = MiscUtils.sanitizeFileName(newDoc.getFileName());
                 // save local file
-                writeLocalFile(Files.newInputStream(this.getDocFile().toPath()), fileName);
+                File rawDocFileForWrite = PathValidationUtils.toFile(this.docFile);
+                writeLocalFile(Files.newInputStream(rawDocFileForWrite.toPath()), fileName);
                 if (fileName.toLowerCase().endsWith(".pdf")) {
                     newDoc.setContentType("application/pdf");
                     int numberOfPages = countNumOfPages(fileName);
@@ -538,9 +544,9 @@ this.getSource(), 'A', this.getObservationDate(), reviewerId, reviewDateTime, th
     private String responsibleId = "";
     private String source = "";
     private String sourceFacility = "";
-    private File docFile;
+    private UploadedFile docFile;
 
-    private File filedata;
+    private UploadedFile filedata;
 
     private String docPublic = "";
     private String mode = "";
@@ -640,14 +646,6 @@ this.getSource(), 'A', this.getObservationDate(), reviewerId, reviewDateTime, th
         this.sourceFacility = sourceFacility;
     }
 
-    public File getDocFile() {
-        return docFile;
-    }
-
-    public void setDocFile(File docFile) {
-        this.docFile = docFile;
-    }
-
     public String getMode() {
         return mode;
     }
@@ -712,14 +710,6 @@ this.getSource(), 'A', this.getObservationDate(), reviewerId, reviewDateTime, th
         this.html = html;
     }
 
-    public File getFiledata() {
-        return filedata;
-    }
-
-    public void setFiledata(File Filedata) {
-        this.filedata = Filedata;
-    }
-
     public String getAppointmentNo() {
         return appointmentNo;
     }
@@ -768,14 +758,21 @@ this.getSource(), 'A', this.getObservationDate(), reviewerId, reviewDateTime, th
         this.extraReviewDoc = extraReviewDoc;
     }
 
-    private String docFileFileName;    
-    private String docFileContentType; 
+    private String docFileFileName;
+    private String docFileContentType;
 
-    public void setDocFileFileName(String docFileFileName) {
-        this.docFileFileName = docFileFileName;
-    }
-
-    public void setDocFileContentType(String docFileContentType) {
-        this.docFileContentType = docFileContentType;
+    @Override
+    public void withUploadedFiles(List<UploadedFile> uploadedFiles) {
+        if (!uploadedFiles.isEmpty()) {
+            for (UploadedFile uf : uploadedFiles) {
+                if ("docFile".equals(uf.getInputName())) {
+                    this.docFile = uf;
+                    this.docFileFileName = uf.getOriginalName();
+                    this.docFileContentType = uf.getContentType();
+                } else if ("filedata".equals(uf.getInputName())) {
+                    this.filedata = uf;
+                }
+            }
+        }
     }
 }

--- a/src/main/java/ca/openosp/openo/documentManager/actions/AddEditDocument2Action.java
+++ b/src/main/java/ca/openosp/openo/documentManager/actions/AddEditDocument2Action.java
@@ -498,6 +498,7 @@ this.getSource(), 'A', this.getObservationDate(), reviewerId, reviewDateTime, th
         } catch (Exception e) {
             MiscUtils.getLogger().error("Error", e);
         } finally {
+            if (is != null) is.close();
             if (fos != null) fos.close();
         }
         return file;
@@ -768,6 +769,9 @@ this.getSource(), 'A', this.getObservationDate(), reviewerId, reviewDateTime, th
                     this.docFileContentType = docFile.getContentType();
                 } else if ("filedata".equals(uploadedFile.getInputName())) {
                     this.filedata = uploadedFile;
+                    this.docFileOnDisk = PathValidationUtils.toFile(uploadedFile);
+                    this.docFileFileName = uploadedFile.getOriginalName();
+                    this.docFileContentType = uploadedFile.getContentType();
                 }
             }
         }

--- a/src/main/java/ca/openosp/openo/documentManager/actions/AddEditDocument2Action.java
+++ b/src/main/java/ca/openosp/openo/documentManager/actions/AddEditDocument2Action.java
@@ -99,6 +99,12 @@ public class AddEditDocument2Action extends ActionSupport implements UploadedFil
             throw new SecurityException("missing required sec object (_edoc)");
         }
 
+        if (docFileOnDisk == null) {
+            response.setHeader("oscar_error", props.getString("dms.addDocument.errorZeroSize"));
+            response.sendError(500, props.getString("dms.addDocument.errorZeroSize"));
+            return null;
+        }
+
         int numberOfPages = 0;
         String fileName = MiscUtils.sanitizeFileName(docFileOnDisk.getName());
         String user = (String) request.getSession().getAttribute("user");

--- a/src/main/java/ca/openosp/openo/documentManager/actions/AddEditDocument2Action.java
+++ b/src/main/java/ca/openosp/openo/documentManager/actions/AddEditDocument2Action.java
@@ -99,10 +99,8 @@ public class AddEditDocument2Action extends ActionSupport implements UploadedFil
             throw new SecurityException("missing required sec object (_edoc)");
         }
 
-        File rawDocFile = docFile != null ? PathValidationUtils.toFile(docFile) : null;
-
         int numberOfPages = 0;
-        String fileName = MiscUtils.sanitizeFileName(rawDocFile.getName());
+        String fileName = MiscUtils.sanitizeFileName(docFileOnDisk.getName());
         String user = (String) request.getSession().getAttribute("user");
         EDoc newDoc = new EDoc("", "", fileName, "", user, user, this.getSource(), 'A', UtilDateUtilities.getToday("yyyy-MM-dd"), "", "", "demographic", "-1", 0);
         newDoc.setDocPublic("0");
@@ -117,14 +115,14 @@ public class AddEditDocument2Action extends ActionSupport implements UploadedFil
         }
 
         // save local file;
-        if (rawDocFile.length() == 0) {
+        if (docFileOnDisk.length() == 0) {
             response.setHeader("oscar_error", props.getString("dms.addDocument.errorZeroSize"));
             response.sendError(500, props.getString("dms.addDocument.errorZeroSize"));
             return null;
         }
-        File file = writeLocalFile(Files.newInputStream(rawDocFile.toPath()), fileName);// write file to local dir
+        File file = writeLocalFile(Files.newInputStream(docFileOnDisk.toPath()), fileName);// write file to local dir
 
-        if (!file.exists() || file.length() < rawDocFile.length()) {
+        if (!file.exists() || file.length() < docFileOnDisk.length()) {
             response.setHeader("oscar_error", props.getString("dms.addDocument.errorNoWrite"));
             response.sendError(500, props.getString("dms.addDocument.errorNoWrite"));
             return null;
@@ -248,8 +246,7 @@ public class AddEditDocument2Action extends ActionSupport implements UploadedFil
                 errors.put("typemissing", "dms.error.typeMissing");
                 throw new Exception();
             }
-            File rawDocFile = this.docFile != null ? PathValidationUtils.toFile(this.docFile) : null;
-            if (rawDocFile == null || rawDocFile.length() == 0) {
+            if (docFileOnDisk == null || docFileOnDisk.length() == 0) {
                 errors.put("uploaderror", "dms.error.uploadError");
                 throw new FileNotFoundException();
             }
@@ -266,7 +263,7 @@ public class AddEditDocument2Action extends ActionSupport implements UploadedFil
             String fileName2 = newDoc.getFileName();
 
             // save local file
-            File file = writeLocalFile(Files.newInputStream(rawDocFile.toPath()), fileName2);
+            File file = writeLocalFile(Files.newInputStream(docFileOnDisk.toPath()), fileName2);
             newDoc.setContentType(this.docFileContentType);
 
             if (fileName2.toLowerCase().endsWith(".pdf")) {
@@ -392,8 +389,7 @@ public class AddEditDocument2Action extends ActionSupport implements UploadedFil
 
             if (OscarProperties.getInstance().getBooleanProperty("ALLOW_UPDATE_DOCUMENT_CONTENT", "true"))
             {
-                File rawDocFileEdit = this.docFile != null ? PathValidationUtils.toFile(this.docFile) : null;
-                if (rawDocFileEdit != null && rawDocFileEdit.exists()) {
+                if (docFileOnDisk != null && docFileOnDisk.exists()) {
                     fileName = MiscUtils.sanitizeFileName(this.docFileFileName);
                     updateFileContent = true; // set update to true
                 }
@@ -431,8 +427,7 @@ this.getSource(), 'A', this.getObservationDate(), reviewerId, reviewDateTime, th
             if (updateFileContent) {
                 fileName = MiscUtils.sanitizeFileName(newDoc.getFileName());
                 // save local file
-                File rawDocFileForWrite = PathValidationUtils.toFile(this.docFile);
-                writeLocalFile(Files.newInputStream(rawDocFileForWrite.toPath()), fileName);
+                writeLocalFile(Files.newInputStream(docFileOnDisk.toPath()), fileName);
                 if (fileName.toLowerCase().endsWith(".pdf")) {
                     newDoc.setContentType("application/pdf");
                     int numberOfPages = countNumOfPages(fileName);
@@ -545,6 +540,7 @@ this.getSource(), 'A', this.getObservationDate(), reviewerId, reviewDateTime, th
     private String source = "";
     private String sourceFacility = "";
     private UploadedFile docFile;
+    private File docFileOnDisk;
 
     private UploadedFile filedata;
 
@@ -764,13 +760,14 @@ this.getSource(), 'A', this.getObservationDate(), reviewerId, reviewDateTime, th
     @Override
     public void withUploadedFiles(List<UploadedFile> uploadedFiles) {
         if (!uploadedFiles.isEmpty()) {
-            for (UploadedFile uf : uploadedFiles) {
-                if ("docFile".equals(uf.getInputName())) {
-                    this.docFile = uf;
-                    this.docFileFileName = uf.getOriginalName();
-                    this.docFileContentType = uf.getContentType();
-                } else if ("filedata".equals(uf.getInputName())) {
-                    this.filedata = uf;
+            for (UploadedFile uploadedFile : uploadedFiles) {
+                if ("docFile".equals(uploadedFile.getInputName())) {
+                    this.docFile = uploadedFile;
+                    this.docFileOnDisk = PathValidationUtils.toFile(docFile);
+                    this.docFileFileName = docFile.getOriginalName();
+                    this.docFileContentType = docFile.getContentType();
+                } else if ("filedata".equals(uploadedFile.getInputName())) {
+                    this.filedata = uploadedFile;
                 }
             }
         }

--- a/src/main/java/ca/openosp/openo/documentManager/actions/AddEditHtml2Action.java
+++ b/src/main/java/ca/openosp/openo/documentManager/actions/AddEditHtml2Action.java
@@ -368,7 +368,13 @@ public class AddEditHtml2Action extends ActionSupport implements UploadedFilesAw
     @Override
     public void withUploadedFiles(List<UploadedFile> uploadedFiles) {
         if (!uploadedFiles.isEmpty()) {
-            this.docFile = uploadedFiles.get(0);
+            for (UploadedFile uploadedFile : uploadedFiles) {
+                if ("docFile".equals(uploadedFile.getInputName())) {
+                    this.docFile = uploadedFile;
+                } else if ("filedata".equals(uploadedFile.getInputName())) {
+                    this.filedata = uploadedFile;
+                }
+            }
         }
     }
 

--- a/src/main/java/ca/openosp/openo/documentManager/actions/AddEditHtml2Action.java
+++ b/src/main/java/ca/openosp/openo/documentManager/actions/AddEditHtml2Action.java
@@ -30,6 +30,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Date;
 import java.util.Hashtable;
+import java.util.List;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -52,9 +53,11 @@ import org.springframework.web.context.support.WebApplicationContextUtils;
 import ca.openosp.openo.util.UtilDateUtilities;
 
 import org.apache.struts2.ActionSupport;
+import org.apache.struts2.action.UploadedFilesAware;
+import org.apache.struts2.dispatcher.multipart.UploadedFile;
 import org.apache.struts2.ServletActionContext;
 
-public class AddEditHtml2Action extends ActionSupport {
+public class AddEditHtml2Action extends ActionSupport implements UploadedFilesAware {
     HttpServletRequest request = ServletActionContext.getRequest();
     HttpServletResponse response = ServletActionContext.getResponse();
 
@@ -196,9 +199,9 @@ public class AddEditHtml2Action extends ActionSupport {
     private String responsibleId = "";
     private String source = "";
     private String sourceFacility = "";
-    private File docFile;
+    private UploadedFile docFile;
 
-    private File filedata;
+    private UploadedFile filedata;
 
     private String docPublic = "";
     private String mode = "";
@@ -298,14 +301,6 @@ public class AddEditHtml2Action extends ActionSupport {
         this.sourceFacility = sourceFacility;
     }
 
-    public File getDocFile() {
-        return docFile;
-    }
-
-    public void setDocFile(File docFile) {
-        this.docFile = docFile;
-    }
-
     public String getMode() {
         return mode;
     }
@@ -370,12 +365,11 @@ public class AddEditHtml2Action extends ActionSupport {
         this.html = html;
     }
 
-    public File getFiledata() {
-        return filedata;
-    }
-
-    public void setFiledata(File Filedata) {
-        this.filedata = Filedata;
+    @Override
+    public void withUploadedFiles(List<UploadedFile> uploadedFiles) {
+        if (!uploadedFiles.isEmpty()) {
+            this.docFile = uploadedFiles.get(0);
+        }
     }
 
     public String getAppointmentNo() {

--- a/src/main/java/ca/openosp/openo/documentManager/actions/DocumentUpload2Action.java
+++ b/src/main/java/ca/openosp/openo/documentManager/actions/DocumentUpload2Action.java
@@ -19,6 +19,7 @@ import java.nio.file.Files;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.HashMap;
+import java.util.List;
 import java.util.ResourceBundle;
 
 import javax.servlet.http.HttpServletRequest;
@@ -54,8 +55,10 @@ import ca.openosp.openo.log.LogConst;
 
 import org.apache.struts2.ActionSupport;
 import org.apache.struts2.ServletActionContext;
+import org.apache.struts2.action.UploadedFilesAware;
+import org.apache.struts2.dispatcher.multipart.UploadedFile;
 
-public class DocumentUpload2Action extends ActionSupport {
+public class DocumentUpload2Action extends ActionSupport implements UploadedFilesAware {
     HttpServletRequest request = ServletActionContext.getRequest();
     HttpServletResponse response = ServletActionContext.getResponse();
 
@@ -75,7 +78,7 @@ public class DocumentUpload2Action extends ActionSupport {
         }
 
         HashMap<String, Object> map = new HashMap<String, Object>();
-        File docFile = this.getFiledata();
+        File docFile = this.filedata != null ? PathValidationUtils.toFile(this.filedata) : null;
         String destination = request.getParameter("destination");
         ResourceBundle props = ResourceBundle.getBundle("oscarResources");
         if (docFile == null) {
@@ -374,9 +377,9 @@ public class DocumentUpload2Action extends ActionSupport {
     private String docCreator = "";
     private String responsibleId = "";
     private String source = "";
-    private File docFile;
+    private UploadedFile docFile;
 
-    private File filedata;
+    private UploadedFile filedata;
     private String filedataFileName;
     private String filedataContentType;
 
@@ -445,14 +448,6 @@ public class DocumentUpload2Action extends ActionSupport {
         this.source = source;
     }
 
-    public File getDocFile() {
-        return docFile;
-    }
-
-    public void setDocFile(File docFile) {
-        this.docFile = docFile;
-    }
-
     public String getMode() {
         return mode;
     }
@@ -509,27 +504,18 @@ public class DocumentUpload2Action extends ActionSupport {
         this.html = html;
     }
 
-    public File getFiledata() {
-        return filedata;
-    }
-
-    public void setFiledata(File Filedata) {
-        this.filedata = Filedata;
-    }
-
-    public String getFiledataFileName() {
-        return filedataFileName;
-    }
-
-    public void setFiledataFileName(String filedataFileName) {
-        this.filedataFileName = filedataFileName;
-    }
-
-    public String getFiledataContentType() {
-        return filedataContentType;
-    }
-
-    public void setFiledataContentType(String filedataContentType) {
-        this.filedataContentType = filedataContentType;
+    @Override
+    public void withUploadedFiles(List<UploadedFile> uploadedFiles) {
+        if (!uploadedFiles.isEmpty()) {
+            for (UploadedFile uf : uploadedFiles) {
+                if ("docFile".equals(uf.getInputName())) {
+                    this.docFile = uf;
+                } else if ("filedata".equals(uf.getInputName())) {
+                    this.filedata = uf;
+                    this.filedataFileName = uf.getOriginalName();
+                    this.filedataContentType = uf.getContentType();
+                }
+            }
+        }
     }
 }

--- a/src/main/java/ca/openosp/openo/documentManager/actions/DocumentUpload2Action.java
+++ b/src/main/java/ca/openosp/openo/documentManager/actions/DocumentUpload2Action.java
@@ -78,7 +78,7 @@ public class DocumentUpload2Action extends ActionSupport implements UploadedFile
         }
 
         HashMap<String, Object> map = new HashMap<String, Object>();
-        File docFile = this.filedata != null ? PathValidationUtils.toFile(this.filedata) : null;
+        File docFile = filedataOnDisk;
         String destination = request.getParameter("destination");
         ResourceBundle props = ResourceBundle.getBundle("oscarResources");
         if (docFile == null) {
@@ -380,6 +380,7 @@ public class DocumentUpload2Action extends ActionSupport implements UploadedFile
     private UploadedFile docFile;
 
     private UploadedFile filedata;
+    private File filedataOnDisk;
     private String filedataFileName;
     private String filedataContentType;
 
@@ -507,13 +508,14 @@ public class DocumentUpload2Action extends ActionSupport implements UploadedFile
     @Override
     public void withUploadedFiles(List<UploadedFile> uploadedFiles) {
         if (!uploadedFiles.isEmpty()) {
-            for (UploadedFile uf : uploadedFiles) {
-                if ("docFile".equals(uf.getInputName())) {
-                    this.docFile = uf;
-                } else if ("filedata".equals(uf.getInputName())) {
-                    this.filedata = uf;
-                    this.filedataFileName = uf.getOriginalName();
-                    this.filedataContentType = uf.getContentType();
+            for (UploadedFile uploadedFile : uploadedFiles) {
+                if ("docFile".equals(uploadedFile.getInputName())) {
+                    this.docFile = uploadedFile;
+                } else if ("filedata".equals(uploadedFile.getInputName())) {
+                    this.filedata = uploadedFile;
+                    this.filedataOnDisk = PathValidationUtils.toFile(filedata);
+                    this.filedataFileName = filedata.getOriginalName();
+                    this.filedataContentType = filedata.getContentType();
                 }
             }
         }

--- a/src/main/java/ca/openosp/openo/dxresearch/pageUtil/dxResearchLoadAssociations2Action.java
+++ b/src/main/java/ca/openosp/openo/dxresearch/pageUtil/dxResearchLoadAssociations2Action.java
@@ -175,17 +175,15 @@ public class dxResearchLoadAssociations2Action extends ActionSupport implements 
             return ERROR;
         }
 
-        File uploadedFile = PathValidationUtils.toFile(file);
-
         // Validate that the file is a valid uploaded file and prevent path traversal
-        if (!isValidUploadedFile(uploadedFile)) {
+        if (!isValidUploadedFile(fileOnDisk)) {
             MiscUtils.getLogger().error("SECURITY WARNING: Invalid file path detected for file upload");
             addActionError("Invalid file upload.");
             return ERROR;
         }
 
         // Re-validate at point of use for static analysis visibility
-        File validatedFile = PathValidationUtils.validateUpload(uploadedFile);
+        File validatedFile = PathValidationUtils.validateUpload(fileOnDisk);
         String[][] data = ExcelCSVParser.parse(new FileReader(validatedFile));
 
         int rowsInserted = 0;
@@ -279,12 +277,14 @@ public class dxResearchLoadAssociations2Action extends ActionSupport implements 
     }
 
     private UploadedFile file; // Uploaded file
+    private File fileOnDisk;
     private boolean replace = true; // Flag for replacement
 
     @Override
     public void withUploadedFiles(List<UploadedFile> uploadedFiles) {
         if (!uploadedFiles.isEmpty()) {
             this.file = uploadedFiles.get(0);
+            this.fileOnDisk = PathValidationUtils.toFile(file);
         }
     }
 

--- a/src/main/java/ca/openosp/openo/dxresearch/pageUtil/dxResearchLoadAssociations2Action.java
+++ b/src/main/java/ca/openosp/openo/dxresearch/pageUtil/dxResearchLoadAssociations2Action.java
@@ -30,6 +30,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.struts2.action.UploadedFilesAware;
+import org.apache.struts2.dispatcher.multipart.UploadedFile;
+
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -56,7 +59,7 @@ import com.Ostermiller.util.ExcelCSVPrinter;
 import org.apache.struts2.ActionSupport;
 import org.apache.struts2.ServletActionContext;
 
-public class dxResearchLoadAssociations2Action extends ActionSupport {
+public class dxResearchLoadAssociations2Action extends ActionSupport implements UploadedFilesAware {
     HttpServletRequest request = ServletActionContext.getRequest();
     HttpServletResponse response = ServletActionContext.getResponse();
 
@@ -172,15 +175,17 @@ public class dxResearchLoadAssociations2Action extends ActionSupport {
             return ERROR;
         }
 
+        File uploadedFile = PathValidationUtils.toFile(file);
+
         // Validate that the file is a valid uploaded file and prevent path traversal
-        if (!isValidUploadedFile(file)) {
+        if (!isValidUploadedFile(uploadedFile)) {
             MiscUtils.getLogger().error("SECURITY WARNING: Invalid file path detected for file upload");
             addActionError("Invalid file upload.");
             return ERROR;
         }
 
         // Re-validate at point of use for static analysis visibility
-        File validatedFile = PathValidationUtils.validateUpload(file);
+        File validatedFile = PathValidationUtils.validateUpload(uploadedFile);
         String[][] data = ExcelCSVParser.parse(new FileReader(validatedFile));
 
         int rowsInserted = 0;
@@ -273,15 +278,14 @@ public class dxResearchLoadAssociations2Action extends ActionSupport {
         return uploadedFile.exists() && uploadedFile.isFile();
     }
 
-    private File file; // Uploaded file
+    private UploadedFile file; // Uploaded file
     private boolean replace = true; // Flag for replacement
 
-    public File getFile() {
-        return file;
-    }
-
-    public void setFile(File file) {
-        this.file = file;
+    @Override
+    public void withUploadedFiles(List<UploadedFile> uploadedFiles) {
+        if (!uploadedFiles.isEmpty()) {
+            this.file = uploadedFiles.get(0);
+        }
     }
 
     public boolean isReplace() {

--- a/src/main/java/ca/openosp/openo/eform/actions/HtmlEdit2Action.java
+++ b/src/main/java/ca/openosp/openo/eform/actions/HtmlEdit2Action.java
@@ -27,6 +27,8 @@
 package ca.openosp.openo.eform.actions;
 
 import org.apache.struts2.ActionSupport;
+import org.apache.struts2.action.UploadedFilesAware;
+import org.apache.struts2.dispatcher.multipart.UploadedFile;
 import org.apache.struts2.ServletActionContext;
 import ca.openosp.openo.managers.SecurityInfoManager;
 import ca.openosp.openo.utility.LoggedInInfo;
@@ -38,10 +40,10 @@ import ca.openosp.openo.eform.data.EFormBase;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.io.File;
 import java.util.HashMap;
+import java.util.List;
 
-public class HtmlEdit2Action extends ActionSupport {
+public class HtmlEdit2Action extends ActionSupport implements UploadedFilesAware {
     HttpServletRequest request = ServletActionContext.getRequest();
     HttpServletResponse response = ServletActionContext.getResponse();
 
@@ -112,7 +114,7 @@ public class HtmlEdit2Action extends ActionSupport {
         return curht;
     }
 
-    private File uploadFile;
+    private UploadedFile uploadFile;
     private String fid = "";
     private String formName = "";
     private String formSubject = "";
@@ -122,12 +124,11 @@ public class HtmlEdit2Action extends ActionSupport {
     private boolean patientIndependent = false;
     private String roleType = "";
 
-    public File getUploadFile() {
-        return uploadFile;
-    }
-
-    public void setUploadFile(File uploadFile) {
-        this.uploadFile = uploadFile;
+    @Override
+    public void withUploadedFiles(List<UploadedFile> uploadedFiles) {
+        if (!uploadedFiles.isEmpty()) {
+            this.uploadFile = uploadedFiles.get(0);
+        }
     }
 
     public String getFid() {

--- a/src/main/java/ca/openosp/openo/eform/actions/ManageEForm2Action.java
+++ b/src/main/java/ca/openosp/openo/eform/actions/ManageEForm2Action.java
@@ -85,8 +85,7 @@ public class ManageEForm2Action extends ActionSupport implements UploadedFilesAw
         }
 
         List<String> errors = Collections.emptyList();
-        File zippedFormFile = PathValidationUtils.toFile(zippedForm);
-        try (InputStream zippedFormStream = Files.newInputStream(zippedFormFile.toPath())) {
+        try (InputStream zippedFormStream = Files.newInputStream(zippedFormOnDisk.toPath())) {
             request.setAttribute("input", "import");
             EFormExportZip eFormExportZip = new EFormExportZip();
             errors = eFormExportZip.importForm(zippedFormStream);
@@ -101,11 +100,13 @@ public class ManageEForm2Action extends ActionSupport implements UploadedFilesAw
     }
 
     private UploadedFile zippedForm;
+    private File zippedFormOnDisk;
 
     @Override
     public void withUploadedFiles(List<UploadedFile> uploadedFiles) {
         if (!uploadedFiles.isEmpty()) {
             this.zippedForm = uploadedFiles.get(0);
+            this.zippedFormOnDisk = PathValidationUtils.toFile(zippedForm);
         }
     }
 }

--- a/src/main/java/ca/openosp/openo/eform/actions/ManageEForm2Action.java
+++ b/src/main/java/ca/openosp/openo/eform/actions/ManageEForm2Action.java
@@ -84,6 +84,11 @@ public class ManageEForm2Action extends ActionSupport implements UploadedFilesAw
             throw new SecurityException("missing required sec object (_eform)");
         }
 
+        if (zippedFormOnDisk == null) {
+            addActionError("No file uploaded.");
+            return ERROR;
+        }
+
         List<String> errors = Collections.emptyList();
         try (InputStream zippedFormStream = Files.newInputStream(zippedFormOnDisk.toPath())) {
             request.setAttribute("input", "import");

--- a/src/main/java/ca/openosp/openo/eform/actions/ManageEForm2Action.java
+++ b/src/main/java/ca/openosp/openo/eform/actions/ManageEForm2Action.java
@@ -27,8 +27,11 @@
 package ca.openosp.openo.eform.actions;
 
 import org.apache.struts2.ActionSupport;
+import org.apache.struts2.action.UploadedFilesAware;
+import org.apache.struts2.dispatcher.multipart.UploadedFile;
 import org.apache.struts2.ServletActionContext;
 import ca.openosp.openo.managers.SecurityInfoManager;
+import ca.openosp.openo.utility.PathValidationUtils;
 import ca.openosp.openo.utility.LoggedInInfo;
 import ca.openosp.openo.utility.MiscUtils;
 import ca.openosp.openo.utility.SpringUtils;
@@ -44,7 +47,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-public class ManageEForm2Action extends ActionSupport {
+public class ManageEForm2Action extends ActionSupport implements UploadedFilesAware {
     HttpServletRequest request = ServletActionContext.getRequest();
     HttpServletResponse response = ServletActionContext.getResponse();
 
@@ -82,7 +85,8 @@ public class ManageEForm2Action extends ActionSupport {
         }
 
         List<String> errors = Collections.emptyList();
-        try (InputStream zippedFormStream = Files.newInputStream(zippedForm.toPath())) {
+        File zippedFormFile = PathValidationUtils.toFile(zippedForm);
+        try (InputStream zippedFormStream = Files.newInputStream(zippedFormFile.toPath())) {
             request.setAttribute("input", "import");
             EFormExportZip eFormExportZip = new EFormExportZip();
             errors = eFormExportZip.importForm(zippedFormStream);
@@ -96,13 +100,12 @@ public class ManageEForm2Action extends ActionSupport {
         }
     }
 
-    private File zippedForm; // 接收上传的文件
+    private UploadedFile zippedForm;
 
-    public File getZippedForm() {
-        return zippedForm;
-    }
-
-    public void setZippedForm(File zippedForm) {
-        this.zippedForm = zippedForm;
+    @Override
+    public void withUploadedFiles(List<UploadedFile> uploadedFiles) {
+        if (!uploadedFiles.isEmpty()) {
+            this.zippedForm = uploadedFiles.get(0);
+        }
     }
 }

--- a/src/main/java/ca/openosp/openo/eform/upload/HtmlUpload2Action.java
+++ b/src/main/java/ca/openosp/openo/eform/upload/HtmlUpload2Action.java
@@ -54,6 +54,11 @@ public class HtmlUpload2Action extends ActionSupport implements UploadedFilesAwa
         if (!securityInfoManager.hasPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), "_eform", "w", null)) {
             throw new SecurityException("missing required sec object (_eform)");
         }
+        if (formHtmlOnDisk == null) {
+            addFieldError("formHtml", "Form HTML file is required.");
+            return INPUT;
+        }
+
         try {
             String formHtmlStr = new String(Files.readAllBytes(formHtmlOnDisk.toPath()));
             formHtmlStr = formHtmlStr.replaceAll("\\\\n", "\\\\\\\\n");

--- a/src/main/java/ca/openosp/openo/eform/upload/HtmlUpload2Action.java
+++ b/src/main/java/ca/openosp/openo/eform/upload/HtmlUpload2Action.java
@@ -71,6 +71,7 @@ public class HtmlUpload2Action extends ActionSupport implements UploadedFilesAwa
     private UploadedFile formHtml;
     private File formHtmlOnDisk;
     private String formHtmlFileName;
+    private String formHtmlContentType;
     private String formName;
     private String subject;
     private boolean showLatestFormOnly;
@@ -83,6 +84,7 @@ public class HtmlUpload2Action extends ActionSupport implements UploadedFilesAwa
             this.formHtml = uploadedFiles.get(0);
             this.formHtmlOnDisk = PathValidationUtils.toFile(formHtml);
             this.formHtmlFileName = formHtml.getOriginalName();
+            this.formHtmlContentType = formHtml.getContentType();
         }
     }
 

--- a/src/main/java/ca/openosp/openo/eform/upload/HtmlUpload2Action.java
+++ b/src/main/java/ca/openosp/openo/eform/upload/HtmlUpload2Action.java
@@ -26,9 +26,13 @@
 
 package ca.openosp.openo.eform.upload;
 
+import java.util.List;
 import org.apache.struts2.ActionSupport;
+import org.apache.struts2.action.UploadedFilesAware;
+import org.apache.struts2.dispatcher.multipart.UploadedFile;
 import org.apache.struts2.ServletActionContext;
 import ca.openosp.openo.managers.SecurityInfoManager;
+import ca.openosp.openo.utility.PathValidationUtils;
 import ca.openosp.openo.utility.LoggedInInfo;
 import ca.openosp.openo.utility.MiscUtils;
 import ca.openosp.openo.utility.SpringUtils;
@@ -39,7 +43,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.File;
 import java.nio.file.Files;
 
-public class HtmlUpload2Action extends ActionSupport {
+public class HtmlUpload2Action extends ActionSupport implements UploadedFilesAware {
     HttpServletRequest request = ServletActionContext.getRequest();
     HttpServletResponse response = ServletActionContext.getResponse();
 
@@ -51,9 +55,10 @@ public class HtmlUpload2Action extends ActionSupport {
             throw new SecurityException("missing required sec object (_eform)");
         }
         try {
-            String formHtmlStr = new String(Files.readAllBytes(formHtml.toPath()));
+            File formHtmlFile = PathValidationUtils.toFile(formHtml);
+            String formHtmlStr = new String(Files.readAllBytes(formHtmlFile.toPath()));
             formHtmlStr = formHtmlStr.replaceAll("\\\\n", "\\\\\\\\n");
-            String fileName = formHtml.getName();
+            String fileName = formHtmlFileName;
             EFormUtil.saveEForm(formName, subject, fileName, formHtmlStr, showLatestFormOnly, patientIndependent, roleType);
             request.setAttribute("status", "success");
             return SUCCESS;
@@ -64,37 +69,20 @@ public class HtmlUpload2Action extends ActionSupport {
 
     }
 
-    private File formHtml; // 上传的文件
-    private String formHtmlContentType; // 文件的 MIME 类型
-    private String formHtmlFileName; // 文件的原始名称
+    private UploadedFile formHtml;
+    private String formHtmlFileName;
     private String formName;
     private String subject;
     private boolean showLatestFormOnly;
     private boolean patientIndependent;
     private String roleType;
 
-    public File getFormHtml() {
-        return formHtml;
-    }
-
-    public void setFormHtml(File formHtml) {
-        this.formHtml = formHtml;
-    }
-
-    public String getFormHtmlContentType() {
-        return formHtmlContentType;
-    }
-
-    public void setFormHtmlContentType(String formHtmlContentType) {
-        this.formHtmlContentType = formHtmlContentType;
-    }
-
-    public String getFormHtmlFileName() {
-        return formHtmlFileName;
-    }
-
-    public void setFormHtmlFileName(String formHtmlFileName) {
-        this.formHtmlFileName = formHtmlFileName;
+    @Override
+    public void withUploadedFiles(List<UploadedFile> uploadedFiles) {
+        if (!uploadedFiles.isEmpty()) {
+            this.formHtml = uploadedFiles.get(0);
+            this.formHtmlFileName = formHtml.getOriginalName();
+        }
     }
 
     public String getFormName() {

--- a/src/main/java/ca/openosp/openo/eform/upload/HtmlUpload2Action.java
+++ b/src/main/java/ca/openosp/openo/eform/upload/HtmlUpload2Action.java
@@ -55,8 +55,7 @@ public class HtmlUpload2Action extends ActionSupport implements UploadedFilesAwa
             throw new SecurityException("missing required sec object (_eform)");
         }
         try {
-            File formHtmlFile = PathValidationUtils.toFile(formHtml);
-            String formHtmlStr = new String(Files.readAllBytes(formHtmlFile.toPath()));
+            String formHtmlStr = new String(Files.readAllBytes(formHtmlOnDisk.toPath()));
             formHtmlStr = formHtmlStr.replaceAll("\\\\n", "\\\\\\\\n");
             String fileName = formHtmlFileName;
             EFormUtil.saveEForm(formName, subject, fileName, formHtmlStr, showLatestFormOnly, patientIndependent, roleType);
@@ -70,6 +69,7 @@ public class HtmlUpload2Action extends ActionSupport implements UploadedFilesAwa
     }
 
     private UploadedFile formHtml;
+    private File formHtmlOnDisk;
     private String formHtmlFileName;
     private String formName;
     private String subject;
@@ -81,6 +81,7 @@ public class HtmlUpload2Action extends ActionSupport implements UploadedFilesAwa
     public void withUploadedFiles(List<UploadedFile> uploadedFiles) {
         if (!uploadedFiles.isEmpty()) {
             this.formHtml = uploadedFiles.get(0);
+            this.formHtmlOnDisk = PathValidationUtils.toFile(formHtml);
             this.formHtmlFileName = formHtml.getOriginalName();
         }
     }

--- a/src/main/java/ca/openosp/openo/eform/upload/ImageUpload2Action.java
+++ b/src/main/java/ca/openosp/openo/eform/upload/ImageUpload2Action.java
@@ -26,7 +26,10 @@
 
 package ca.openosp.openo.eform.upload;
 
+import java.util.List;
 import org.apache.struts2.ActionSupport;
+import org.apache.struts2.action.UploadedFilesAware;
+import org.apache.struts2.dispatcher.multipart.UploadedFile;
 import org.apache.struts2.ServletActionContext;
 import ca.openosp.openo.managers.SecurityInfoManager;
 import ca.openosp.openo.utility.LoggedInInfo;
@@ -43,7 +46,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
 
-public class ImageUpload2Action extends ActionSupport {
+public class ImageUpload2Action extends ActionSupport implements UploadedFilesAware {
     HttpServletRequest request = ServletActionContext.getRequest();
     HttpServletResponse response = ServletActionContext.getResponse();
 
@@ -83,11 +86,14 @@ public class ImageUpload2Action extends ActionSupport {
                 return ERROR;
             }
 
+            // Extract File from UploadedFile for validation and I/O
+            File imageFile = PathValidationUtils.toFile(image);
+
             // Validate upload: source file location + destination path traversal protection
-            File destinationFile = PathValidationUtils.validateUpload(image, imageFileName, imageFolder);
+            File destinationFile = PathValidationUtils.validateUpload(imageFile, imageFileName, imageFolder);
 
             // Upload the file
-            try (InputStream fis = Files.newInputStream(image.toPath());
+            try (InputStream fis = Files.newInputStream(imageFile.toPath());
                  OutputStream fos = Files.newOutputStream(destinationFile.toPath())) {
                 byte[] buffer = new byte[4096];
                 int bytesRead;
@@ -122,24 +128,14 @@ public class ImageUpload2Action extends ActionSupport {
         return imageFolder;
     }
 
-    private File image;
+    private UploadedFile image;
+    private String imageFileName;
 
-    public File getImage() {
-        return image;
-    }
-
-    public void setImage(File image) {
-        this.image = image;
-    }
-
-    private String imageFileName;    
-    private String imageFileContentType; 
-
-    public void setImageFileName(String imageFileName) {
-        this.imageFileName = imageFileName;
-    }
-
-    public void setImageFileContentType(String imageFileContentType) {
-        this.imageFileContentType = imageFileContentType;
+    @Override
+    public void withUploadedFiles(List<UploadedFile> uploadedFiles) {
+        if (!uploadedFiles.isEmpty()) {
+            this.image = uploadedFiles.get(0);
+            this.imageFileName = image.getOriginalName();
+        }
     }
 }

--- a/src/main/java/ca/openosp/openo/eform/upload/ImageUpload2Action.java
+++ b/src/main/java/ca/openosp/openo/eform/upload/ImageUpload2Action.java
@@ -86,14 +86,11 @@ public class ImageUpload2Action extends ActionSupport implements UploadedFilesAw
                 return ERROR;
             }
 
-            // Extract File from UploadedFile for validation and I/O
-            File imageFile = PathValidationUtils.toFile(image);
-
             // Validate upload: source file location + destination path traversal protection
-            File destinationFile = PathValidationUtils.validateUpload(imageFile, imageFileName, imageFolder);
+            File destinationFile = PathValidationUtils.validateUpload(imageOnDisk, imageFileName, imageFolder);
 
             // Upload the file
-            try (InputStream fis = Files.newInputStream(imageFile.toPath());
+            try (InputStream fis = Files.newInputStream(imageOnDisk.toPath());
                  OutputStream fos = Files.newOutputStream(destinationFile.toPath())) {
                 byte[] buffer = new byte[4096];
                 int bytesRead;
@@ -129,12 +126,14 @@ public class ImageUpload2Action extends ActionSupport implements UploadedFilesAw
     }
 
     private UploadedFile image;
+    private File imageOnDisk;
     private String imageFileName;
 
     @Override
     public void withUploadedFiles(List<UploadedFile> uploadedFiles) {
         if (!uploadedFiles.isEmpty()) {
             this.image = uploadedFiles.get(0);
+            this.imageOnDisk = PathValidationUtils.toFile(image);
             this.imageFileName = image.getOriginalName();
         }
     }

--- a/src/main/java/ca/openosp/openo/eform/upload/ImageUpload2Action.java
+++ b/src/main/java/ca/openosp/openo/eform/upload/ImageUpload2Action.java
@@ -128,6 +128,7 @@ public class ImageUpload2Action extends ActionSupport implements UploadedFilesAw
     private UploadedFile image;
     private File imageOnDisk;
     private String imageFileName;
+    private String imageContentType;
 
     @Override
     public void withUploadedFiles(List<UploadedFile> uploadedFiles) {
@@ -135,6 +136,7 @@ public class ImageUpload2Action extends ActionSupport implements UploadedFilesAw
             this.image = uploadedFiles.get(0);
             this.imageOnDisk = PathValidationUtils.toFile(image);
             this.imageFileName = image.getOriginalName();
+            this.imageContentType = image.getContentType();
         }
     }
 }

--- a/src/main/java/ca/openosp/openo/encounter/oscarMeasurements/hl7/MeasurementHL7Uploader2Action.java
+++ b/src/main/java/ca/openosp/openo/encounter/oscarMeasurements/hl7/MeasurementHL7Uploader2Action.java
@@ -106,7 +106,13 @@ public class MeasurementHL7Uploader2Action extends ActionSupport implements Uplo
             boolean checkPassword = StringUtils.isNotBlank(hl7UploadPassword);
 
             // file is encrypted using RSA public keys if no password enforced
-            hl7msg = checkPassword ? IOUtils.toString(Files.newInputStream(importFileOnDisk.toPath())) : extractEncryptedMessage(importFileOnDisk, request);
+            if (checkPassword) {
+                try (InputStream is = Files.newInputStream(importFileOnDisk.toPath())) {
+                    hl7msg = IOUtils.toString(is);
+                }
+            } else {
+                hl7msg = extractEncryptedMessage(importFileOnDisk, request);
+            }
 
             if (checkPassword && hl7UploadPassword.length() < 16)
                 throw new RuntimeException("Upload password length is too weak, please check oscar property file and make sure it's more than 16 letters.");

--- a/src/main/java/ca/openosp/openo/encounter/oscarMeasurements/hl7/MeasurementHL7Uploader2Action.java
+++ b/src/main/java/ca/openosp/openo/encounter/oscarMeasurements/hl7/MeasurementHL7Uploader2Action.java
@@ -61,9 +61,12 @@ import ca.uhn.hl7v2.parser.Parser;
 import ca.uhn.hl7v2.validation.impl.NoValidation;
 
 import org.apache.struts2.ActionSupport;
+import org.apache.struts2.action.UploadedFilesAware;
+import org.apache.struts2.dispatcher.multipart.UploadedFile;
 import org.apache.struts2.ServletActionContext;
+import ca.openosp.openo.utility.PathValidationUtils;
 
-public class MeasurementHL7Uploader2Action extends ActionSupport {
+public class MeasurementHL7Uploader2Action extends ActionSupport implements UploadedFilesAware {
     HttpServletRequest request = ServletActionContext.getRequest();
     HttpServletResponse response = ServletActionContext.getResponse();
 
@@ -102,8 +105,10 @@ public class MeasurementHL7Uploader2Action extends ActionSupport {
         try {
             boolean checkPassword = StringUtils.isNotBlank(hl7UploadPassword);
 
+            File importFileOnDisk = PathValidationUtils.toFile(importFile);
+
             // file is encrypted using RSA public keys if no password enforced
-            hl7msg = checkPassword ? IOUtils.toString(Files.newInputStream(importFile.toPath())) : extractEncryptedMessage(importFile, request);
+            hl7msg = checkPassword ? IOUtils.toString(Files.newInputStream(importFileOnDisk.toPath())) : extractEncryptedMessage(importFileOnDisk, request);
 
             if (checkPassword && hl7UploadPassword.length() < 16)
                 throw new RuntimeException("Upload password length is too weak, please check oscar property file and make sure it's more than 16 letters.");
@@ -241,13 +246,12 @@ public class MeasurementHL7Uploader2Action extends ActionSupport {
         }
     }
 
-    private File importFile;
+    private UploadedFile importFile;
 
-    public File getImportFile() {
-        return importFile;
-    }
-
-    public void setImportFile(File importFile) {
-        this.importFile = importFile;
+    @Override
+    public void withUploadedFiles(List<UploadedFile> uploadedFiles) {
+        if (!uploadedFiles.isEmpty()) {
+            this.importFile = uploadedFiles.get(0);
+        }
     }
 }

--- a/src/main/java/ca/openosp/openo/encounter/oscarMeasurements/hl7/MeasurementHL7Uploader2Action.java
+++ b/src/main/java/ca/openosp/openo/encounter/oscarMeasurements/hl7/MeasurementHL7Uploader2Action.java
@@ -105,8 +105,6 @@ public class MeasurementHL7Uploader2Action extends ActionSupport implements Uplo
         try {
             boolean checkPassword = StringUtils.isNotBlank(hl7UploadPassword);
 
-            File importFileOnDisk = PathValidationUtils.toFile(importFile);
-
             // file is encrypted using RSA public keys if no password enforced
             hl7msg = checkPassword ? IOUtils.toString(Files.newInputStream(importFileOnDisk.toPath())) : extractEncryptedMessage(importFileOnDisk, request);
 
@@ -247,11 +245,13 @@ public class MeasurementHL7Uploader2Action extends ActionSupport implements Uplo
     }
 
     private UploadedFile importFile;
+    private File importFileOnDisk;
 
     @Override
     public void withUploadedFiles(List<UploadedFile> uploadedFiles) {
         if (!uploadedFiles.isEmpty()) {
             this.importFile = uploadedFiles.get(0);
+            this.importFileOnDisk = PathValidationUtils.toFile(importFile);
         }
     }
 }

--- a/src/main/java/ca/openosp/openo/encounter/oscarMeasurements/pageUtil/EctAddMeasurementStyleSheet2Action.java
+++ b/src/main/java/ca/openosp/openo/encounter/oscarMeasurements/pageUtil/EctAddMeasurementStyleSheet2Action.java
@@ -71,7 +71,7 @@ public class EctAddMeasurementStyleSheet2Action extends ActionSupport implements
             ArrayList<String> messages = new ArrayList<String>();
             String contextPath = request.getContextPath();
 
-            if (!saveFile(fileOnDisk, fileName)) {
+            if (fileOnDisk == null || fileName == null || fileName.trim().isEmpty() || !saveFile(fileOnDisk, fileName)) {
                 addActionError(getText("errors.fileNotAdded"));
                 response.sendRedirect(contextPath + "/oscarEncounter/oscarMeasurements/AddMeasurementStyleSheet.jsp");
                 return NONE;

--- a/src/main/java/ca/openosp/openo/encounter/oscarMeasurements/pageUtil/EctAddMeasurementStyleSheet2Action.java
+++ b/src/main/java/ca/openosp/openo/encounter/oscarMeasurements/pageUtil/EctAddMeasurementStyleSheet2Action.java
@@ -49,11 +49,13 @@ import ca.openosp.openo.utility.SpringUtils;
 
 import ca.openosp.OscarProperties;
 
-
+import java.util.List;
 import org.apache.struts2.ActionSupport;
+import org.apache.struts2.action.UploadedFilesAware;
+import org.apache.struts2.dispatcher.multipart.UploadedFile;
 import org.apache.struts2.ServletActionContext;
 
-public class EctAddMeasurementStyleSheet2Action extends ActionSupport {
+public class EctAddMeasurementStyleSheet2Action extends ActionSupport implements UploadedFilesAware {
     HttpServletRequest request = ServletActionContext.getRequest();
     HttpServletResponse response = ServletActionContext.getResponse();
 
@@ -70,7 +72,8 @@ public class EctAddMeasurementStyleSheet2Action extends ActionSupport {
             ArrayList<String> messages = new ArrayList<String>();
             String contextPath = request.getContextPath();
 
-            if (!saveFile(file, fileName)) {
+            File uploadedFile = PathValidationUtils.toFile(file);
+            if (!saveFile(uploadedFile, fileName)) {
                 addActionError(getText("errors.fileNotAdded"));
                 response.sendRedirect(contextPath + "/oscarEncounter/oscarMeasurements/AddMeasurementStyleSheet.jsp");
                 return NONE;
@@ -92,7 +95,7 @@ public class EctAddMeasurementStyleSheet2Action extends ActionSupport {
      *
      * @param file
      */
-    public boolean saveFile(File file, String fileName) {
+    public boolean saveFile(File file, String fileName) { //NOSONAR - File parameter kept for API compatibility
         boolean isAdded = true;
 
         try {
@@ -160,22 +163,21 @@ public class EctAddMeasurementStyleSheet2Action extends ActionSupport {
         dao.persist(m);
     }
 
-    private File file;
+    private UploadedFile file;
     private String fileName; // Name of the uploaded file
 
-    public File getFile() {
-        return file;
-    }
-
-    public void setFile(File file) {
-        this.file = file;
+    @Override
+    public void withUploadedFiles(List<UploadedFile> uploadedFiles) {
+        if (!uploadedFiles.isEmpty()) {
+            this.file = uploadedFiles.get(0);
+        }
     }
 
     public String getFileName() {
         return fileName;
     }
 
-    public void setFileFileName(String fileName) {
+    public void setFileName(String fileName) {
         this.fileName = fileName;
     }
 }

--- a/src/main/java/ca/openosp/openo/encounter/oscarMeasurements/pageUtil/EctAddMeasurementStyleSheet2Action.java
+++ b/src/main/java/ca/openosp/openo/encounter/oscarMeasurements/pageUtil/EctAddMeasurementStyleSheet2Action.java
@@ -49,7 +49,6 @@ import ca.openosp.openo.utility.SpringUtils;
 
 import ca.openosp.OscarProperties;
 
-import java.util.List;
 import org.apache.struts2.ActionSupport;
 import org.apache.struts2.action.UploadedFilesAware;
 import org.apache.struts2.dispatcher.multipart.UploadedFile;
@@ -175,11 +174,4 @@ public class EctAddMeasurementStyleSheet2Action extends ActionSupport implements
         }
     }
 
-    public String getFileName() {
-        return fileName;
-    }
-
-    public void setFileName(String fileName) {
-        this.fileName = fileName;
-    }
 }

--- a/src/main/java/ca/openosp/openo/encounter/oscarMeasurements/pageUtil/EctAddMeasurementStyleSheet2Action.java
+++ b/src/main/java/ca/openosp/openo/encounter/oscarMeasurements/pageUtil/EctAddMeasurementStyleSheet2Action.java
@@ -72,8 +72,7 @@ public class EctAddMeasurementStyleSheet2Action extends ActionSupport implements
             ArrayList<String> messages = new ArrayList<String>();
             String contextPath = request.getContextPath();
 
-            File uploadedFile = PathValidationUtils.toFile(file);
-            if (!saveFile(uploadedFile, fileName)) {
+            if (!saveFile(fileOnDisk, fileName)) {
                 addActionError(getText("errors.fileNotAdded"));
                 response.sendRedirect(contextPath + "/oscarEncounter/oscarMeasurements/AddMeasurementStyleSheet.jsp");
                 return NONE;
@@ -95,7 +94,7 @@ public class EctAddMeasurementStyleSheet2Action extends ActionSupport implements
      *
      * @param file
      */
-    public boolean saveFile(File file, String fileName) { //NOSONAR - File parameter kept for API compatibility
+    public boolean saveFile(File file, String fileName) {
         boolean isAdded = true;
 
         try {
@@ -164,12 +163,15 @@ public class EctAddMeasurementStyleSheet2Action extends ActionSupport implements
     }
 
     private UploadedFile file;
+    private File fileOnDisk;
     private String fileName; // Name of the uploaded file
 
     @Override
     public void withUploadedFiles(List<UploadedFile> uploadedFiles) {
         if (!uploadedFiles.isEmpty()) {
             this.file = uploadedFiles.get(0);
+            this.fileOnDisk = PathValidationUtils.toFile(file);
+            this.fileName = file.getOriginalName();
         }
     }
 

--- a/src/main/java/ca/openosp/openo/form/pageUtil/FrmXmlUpload2Action.java
+++ b/src/main/java/ca/openosp/openo/form/pageUtil/FrmXmlUpload2Action.java
@@ -75,6 +75,11 @@ public class FrmXmlUpload2Action extends ActionSupport implements UploadedFilesA
             throw new IllegalStateException("Temporary directory attribute is not set.");
         }
         
+        if (file1OnDisk == null) {
+            addActionError("No file was uploaded.");
+            return ERROR;
+        }
+
         File normalizedFile = file1OnDisk.toPath().normalize().toFile();
 
         // Validate file path using PathValidationUtils

--- a/src/main/java/ca/openosp/openo/form/pageUtil/FrmXmlUpload2Action.java
+++ b/src/main/java/ca/openosp/openo/form/pageUtil/FrmXmlUpload2Action.java
@@ -26,7 +26,10 @@
 
 package ca.openosp.openo.form.pageUtil;
 
+import java.util.List;
 import org.apache.struts2.ActionSupport;
+import org.apache.struts2.action.UploadedFilesAware;
+import org.apache.struts2.dispatcher.multipart.UploadedFile;
 import org.apache.struts2.ServletActionContext;
 import ca.openosp.openo.managers.SecurityInfoManager;
 import ca.openosp.openo.utility.LoggedInInfo;
@@ -43,7 +46,7 @@ import java.util.Enumeration;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
-public class FrmXmlUpload2Action extends ActionSupport {
+public class FrmXmlUpload2Action extends ActionSupport implements UploadedFilesAware {
     HttpServletRequest request = ServletActionContext.getRequest();
     HttpServletResponse response = ServletActionContext.getResponse();
 
@@ -72,7 +75,8 @@ public class FrmXmlUpload2Action extends ActionSupport {
             throw new IllegalStateException("Temporary directory attribute is not set.");
         }
         
-        File normalizedFile = file1.toPath().normalize().toFile();
+        File file1OnDisk = PathValidationUtils.toFile(file1);
+        File normalizedFile = file1OnDisk.toPath().normalize().toFile();
 
         // Validate file path using PathValidationUtils
         try {
@@ -104,33 +108,12 @@ public class FrmXmlUpload2Action extends ActionSupport {
         return SUCCESS;
     }
 
-    private File file1; // Uploaded file
-    private String file1FileName; // Name of the uploaded file
-    private String file1ContentType; // Content type of the uploaded file
+    private UploadedFile file1;
 
-
-    // Setters and Getters for file upload properties
-    public File getFile1() {
-        return file1;
-    }
-
-    public void setFile1(File file1) {
-        this.file1 = file1;
-    }
-
-    public String getFile1FileName() {
-        return file1FileName;
-    }
-
-    public void setFile1FileName(String file1FileName) {
-        this.file1FileName = file1FileName;
-    }
-
-    public String getFile1ContentType() {
-        return file1ContentType;
-    }
-
-    public void setFile1ContentType(String file1ContentType) {
-        this.file1ContentType = file1ContentType;
+    @Override
+    public void withUploadedFiles(List<UploadedFile> uploadedFiles) {
+        if (!uploadedFiles.isEmpty()) {
+            this.file1 = uploadedFiles.get(0);
+        }
     }
 }

--- a/src/main/java/ca/openosp/openo/form/pageUtil/FrmXmlUpload2Action.java
+++ b/src/main/java/ca/openosp/openo/form/pageUtil/FrmXmlUpload2Action.java
@@ -109,12 +109,16 @@ public class FrmXmlUpload2Action extends ActionSupport implements UploadedFilesA
 
     private UploadedFile file1;
     private File file1OnDisk;
+    private String file1FileName;
+    private String file1ContentType;
 
     @Override
     public void withUploadedFiles(List<UploadedFile> uploadedFiles) {
         if (!uploadedFiles.isEmpty()) {
             this.file1 = uploadedFiles.get(0);
             this.file1OnDisk = PathValidationUtils.toFile(file1);
+            this.file1FileName = file1.getOriginalName();
+            this.file1ContentType = file1.getContentType();
         }
     }
 }

--- a/src/main/java/ca/openosp/openo/form/pageUtil/FrmXmlUpload2Action.java
+++ b/src/main/java/ca/openosp/openo/form/pageUtil/FrmXmlUpload2Action.java
@@ -75,7 +75,6 @@ public class FrmXmlUpload2Action extends ActionSupport implements UploadedFilesA
             throw new IllegalStateException("Temporary directory attribute is not set.");
         }
         
-        File file1OnDisk = PathValidationUtils.toFile(file1);
         File normalizedFile = file1OnDisk.toPath().normalize().toFile();
 
         // Validate file path using PathValidationUtils
@@ -109,11 +108,13 @@ public class FrmXmlUpload2Action extends ActionSupport implements UploadedFilesA
     }
 
     private UploadedFile file1;
+    private File file1OnDisk;
 
     @Override
     public void withUploadedFiles(List<UploadedFile> uploadedFiles) {
         if (!uploadedFiles.isEmpty()) {
             this.file1 = uploadedFiles.get(0);
+            this.file1OnDisk = PathValidationUtils.toFile(file1);
         }
     }
 }

--- a/src/main/java/ca/openosp/openo/hospitalReportManager/HRMUploadKey2Action.java
+++ b/src/main/java/ca/openosp/openo/hospitalReportManager/HRMUploadKey2Action.java
@@ -88,6 +88,7 @@ public class HRMUploadKey2Action extends ActionSupport implements UploadedFilesA
     private UploadedFile importFile;
     private File importFileOnDisk;
     private String importFileFileName;
+    private String importFileContentType;
 
     @Override
     public void withUploadedFiles(List<UploadedFile> uploadedFiles) {
@@ -95,6 +96,7 @@ public class HRMUploadKey2Action extends ActionSupport implements UploadedFilesA
             this.importFile = uploadedFiles.get(0);
             this.importFileOnDisk = PathValidationUtils.toFile(importFile);
             this.importFileFileName = importFile.getOriginalName();
+            this.importFileContentType = importFile.getContentType();
         }
     }
 }

--- a/src/main/java/ca/openosp/openo/hospitalReportManager/HRMUploadKey2Action.java
+++ b/src/main/java/ca/openosp/openo/hospitalReportManager/HRMUploadKey2Action.java
@@ -45,19 +45,24 @@ public class HRMUploadKey2Action extends ActionSupport implements UploadedFilesA
         String proNo = (String) request.getSession().getAttribute("user");
         String outcome = "failure";
 
-        try {
-            InputStream is = Files.newInputStream(importFileOnDisk.toPath());
+        if (importFileOnDisk == null) {
+            request.setAttribute("outcome", "failure");
+            return SUCCESS;
+        }
 
+        try {
             String type = request.getParameter("type");
 
-
-            String filePath = Utilities.saveFile(is, filename);
-            is.close();
+            String filePath;
+            try (InputStream is = Files.newInputStream(importFileOnDisk.toPath())) {
+                filePath = Utilities.saveFile(is, filename);
+            }
             File file = new File(filePath);
 
-            is = new FileInputStream(filePath);
-            int checkFileUploadedSuccessfully = FileUploadCheck.addFile(file.getName(), is, proNo);
-            is.close();
+            int checkFileUploadedSuccessfully;
+            try (InputStream is2 = new FileInputStream(filePath)) {
+                checkFileUploadedSuccessfully = FileUploadCheck.addFile(file.getName(), is2, proNo);
+            }
 
             if (checkFileUploadedSuccessfully != FileUploadCheck.UNSUCCESSFUL_SAVE) {
                 logger.debug("filePath" + filePath);

--- a/src/main/java/ca/openosp/openo/hospitalReportManager/HRMUploadKey2Action.java
+++ b/src/main/java/ca/openosp/openo/hospitalReportManager/HRMUploadKey2Action.java
@@ -26,10 +26,14 @@ import ca.openosp.openo.lab.ca.all.upload.HandlerClassFactory;
 import ca.openosp.openo.lab.ca.all.upload.handlers.DefaultHandler;
 import ca.openosp.openo.lab.ca.all.util.Utilities;
 
+import java.util.List;
 import org.apache.struts2.ActionSupport;
+import org.apache.struts2.action.UploadedFilesAware;
+import org.apache.struts2.dispatcher.multipart.UploadedFile;
 import org.apache.struts2.ServletActionContext;
+import ca.openosp.openo.utility.PathValidationUtils;
 
-public class HRMUploadKey2Action extends ActionSupport {
+public class HRMUploadKey2Action extends ActionSupport implements UploadedFilesAware {
     HttpServletRequest request = ServletActionContext.getRequest();
     HttpServletResponse response = ServletActionContext.getResponse();
 
@@ -42,7 +46,8 @@ public class HRMUploadKey2Action extends ActionSupport {
         String outcome = "failure";
 
         try {
-            InputStream is = Files.newInputStream(importFile.toPath());
+            File importFileOnDisk = PathValidationUtils.toFile(importFile);
+            InputStream is = Files.newInputStream(importFileOnDisk.toPath());
 
             String type = request.getParameter("type");
 
@@ -81,8 +86,14 @@ public class HRMUploadKey2Action extends ActionSupport {
         return SUCCESS;
     }
 
-    private File importFile; // Uploaded file
-    private String importFileFileName; // Name of the uploaded file
-    private String importFileContentType; // Content type of the uploaded file
+    private UploadedFile importFile;
+    private String importFileFileName;
 
+    @Override
+    public void withUploadedFiles(List<UploadedFile> uploadedFiles) {
+        if (!uploadedFiles.isEmpty()) {
+            this.importFile = uploadedFiles.get(0);
+            this.importFileFileName = importFile.getOriginalName();
+        }
+    }
 }

--- a/src/main/java/ca/openosp/openo/hospitalReportManager/HRMUploadKey2Action.java
+++ b/src/main/java/ca/openosp/openo/hospitalReportManager/HRMUploadKey2Action.java
@@ -46,7 +46,6 @@ public class HRMUploadKey2Action extends ActionSupport implements UploadedFilesA
         String outcome = "failure";
 
         try {
-            File importFileOnDisk = PathValidationUtils.toFile(importFile);
             InputStream is = Files.newInputStream(importFileOnDisk.toPath());
 
             String type = request.getParameter("type");
@@ -87,12 +86,14 @@ public class HRMUploadKey2Action extends ActionSupport implements UploadedFilesA
     }
 
     private UploadedFile importFile;
+    private File importFileOnDisk;
     private String importFileFileName;
 
     @Override
     public void withUploadedFiles(List<UploadedFile> uploadedFiles) {
         if (!uploadedFiles.isEmpty()) {
             this.importFile = uploadedFiles.get(0);
+            this.importFileOnDisk = PathValidationUtils.toFile(importFile);
             this.importFileFileName = importFile.getOriginalName();
         }
     }

--- a/src/main/java/ca/openosp/openo/hospitalReportManager/HRMUploadLab2Action.java
+++ b/src/main/java/ca/openosp/openo/hospitalReportManager/HRMUploadLab2Action.java
@@ -13,9 +13,12 @@ import ca.openosp.openo.lab.ca.all.util.Utilities;
 import ca.openosp.openo.managers.SecurityInfoManager;
 import ca.openosp.openo.utility.LoggedInInfo;
 import ca.openosp.openo.utility.MiscUtils;
+import ca.openosp.openo.utility.PathValidationUtils;
 import ca.openosp.openo.utility.SpringUtils;
 import org.apache.struts2.ActionSupport;
 import org.apache.struts2.ServletActionContext;
+import org.apache.struts2.action.UploadedFilesAware;
+import org.apache.struts2.dispatcher.multipart.UploadedFile;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -25,15 +28,14 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URLDecoder;
 import java.text.Normalizer;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class HRMUploadLab2Action extends ActionSupport {
-    private List<File> uploads;
-    private List<String> uploadsContentType;
-    private List<String> uploadsFileName;
+public class HRMUploadLab2Action extends ActionSupport implements UploadedFilesAware {
+    private List<UploadedFile> uploads;
 
     private SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
 
@@ -48,16 +50,9 @@ public class HRMUploadLab2Action extends ActionSupport {
         "image/gif"
     );
 
-    public void setUploads(List<File> uploads) {
-        this.uploads = uploads;
-    }
-
-    public void setUploadsContentType(List<String> uploadsContentType) {
-        this.uploadsContentType = uploadsContentType;
-    }
-
-    public void setUploadsFileName(List<String> uploadsFileName) {
-        this.uploadsFileName = uploadsFileName;
+    @Override
+    public void withUploadedFiles(List<UploadedFile> uploadedFiles) {
+        this.uploads = new ArrayList<>(uploadedFiles);
     }
 
     public enum FileStatus {
@@ -91,10 +86,10 @@ public class HRMUploadLab2Action extends ActionSupport {
         Map<String, FileStatus> filesStatusMap = new HashMap<>();
 
         for (int i = 0; i < uploads.size(); i++) {
-            File file = uploads.get(i);
-            String fileName = uploadsFileName.get(i);
-            String contentType = (uploadsContentType != null && i < uploadsContentType.size())
-                ? uploadsContentType.get(i) : null;
+            UploadedFile uf = uploads.get(i);
+            File file = PathValidationUtils.toFile(uf);
+            String fileName = uf.getOriginalName();
+            String contentType = uf.getContentType();
 
             // Validate content type
             if (!isValidContentType(contentType)) {

--- a/src/main/java/ca/openosp/openo/hospitalReportManager/v2018/HRM2Action.java
+++ b/src/main/java/ca/openosp/openo/hospitalReportManager/v2018/HRM2Action.java
@@ -31,6 +31,7 @@ import java.io.InputStream;
 import java.net.URLDecoder;
 import java.text.Normalizer;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -81,6 +82,8 @@ import ca.openosp.OscarProperties;
 
 import org.apache.struts2.ActionSupport;
 import org.apache.struts2.ServletActionContext;
+import org.apache.struts2.action.UploadedFilesAware;
+import org.apache.struts2.dispatcher.multipart.UploadedFile;
 
 /**
  * Struts 2 action for Hospital Report Manager (HRM) operations and administration.
@@ -112,7 +115,7 @@ import org.apache.struts2.ServletActionContext;
  *
  * @since 2006-04-20
  */
-public class HRM2Action extends ActionSupport {
+public class HRM2Action extends ActionSupport implements UploadedFilesAware {
     HttpServletRequest request = ServletActionContext.getRequest();
     HttpServletResponse response = ServletActionContext.getResponse();
 
@@ -129,14 +132,10 @@ public class HRM2Action extends ActionSupport {
     private HRMDocumentToDemographicDao hrmDocumentToDemographicDao = SpringUtils.getBean(HRMDocumentToDemographicDao.class);
 
     // Struts 2 file upload properties for HRM report upload
-    private List<File> hrm_file;
-    private List<String> hrm_fileContentType;
-    private List<String> hrm_fileFileName;
+    private List<UploadedFile> hrm_file;
 
     // Struts 2 file upload properties for private key upload
-    private List<File> privateKeyFile;
-    private List<String> privateKeyFileContentType;
-    private List<String> privateKeyFileFileName;
+    private List<UploadedFile> privateKeyFile;
 
     /**
      * Uploads an HRM report file and adds it to the provider inbox.
@@ -168,8 +167,9 @@ public class HRM2Action extends ActionSupport {
         try {
             if (hrm_file != null && !hrm_file.isEmpty()) {
                 for (int i = 0; i < hrm_file.size(); i++) {
-                    File uploadedFile = hrm_file.get(i);
-                    String originalFileName = hrm_fileFileName.get(i);
+                    UploadedFile uf = hrm_file.get(i);
+                    File uploadedFile = PathValidationUtils.toFile(uf);
+                    String originalFileName = uf.getOriginalName();
 
                     // Sanitize filename to prevent path traversal attacks
                     String sanitizedFileName = sanitizeFileName(originalFileName);
@@ -261,8 +261,9 @@ public class HRM2Action extends ActionSupport {
         try {
             if (privateKeyFile != null && !privateKeyFile.isEmpty()) {
                 for (int i = 0; i < privateKeyFile.size(); i++) {
-                    File uploadedFile = privateKeyFile.get(i);
-                    String originalFileName = privateKeyFileFileName.get(i);
+                    UploadedFile uf = privateKeyFile.get(i);
+                    File uploadedFile = PathValidationUtils.toFile(uf);
+                    String originalFileName = uf.getOriginalName();
 
                     // Sanitize filename to prevent path traversal attacks
                     String sanitizedFileName = sanitizeFileName(originalFileName);
@@ -1026,32 +1027,19 @@ public class HRM2Action extends ActionSupport {
         return sanitized;
     }
 
-    // Struts 2 property injection setters for HRM report upload
-
-    public void setHrm_file(List<File> hrm_file) {
-        this.hrm_file = hrm_file;
-    }
-
-    public void setHrm_fileContentType(List<String> hrm_fileContentType) {
-        this.hrm_fileContentType = hrm_fileContentType;
-    }
-
-    public void setHrm_fileFileName(List<String> hrm_fileFileName) {
-        this.hrm_fileFileName = hrm_fileFileName;
-    }
-
-    // Struts 2 property injection setters for private key upload
-
-    public void setPrivateKeyFile(List<File> privateKeyFile) {
-        this.privateKeyFile = privateKeyFile;
-    }
-
-    public void setPrivateKeyFileContentType(List<String> privateKeyFileContentType) {
-        this.privateKeyFileContentType = privateKeyFileContentType;
-    }
-
-    public void setPrivateKeyFileFileName(List<String> privateKeyFileFileName) {
-        this.privateKeyFileFileName = privateKeyFileFileName;
+    @Override
+    public void withUploadedFiles(List<UploadedFile> uploadedFiles) {
+        this.hrm_file = new ArrayList<>();
+        this.privateKeyFile = new ArrayList<>();
+        if (!uploadedFiles.isEmpty()) {
+            for (UploadedFile uf : uploadedFiles) {
+                if ("hrm_file".equals(uf.getInputName())) {
+                    this.hrm_file.add(uf);
+                } else if ("privateKeyFile".equals(uf.getInputName())) {
+                    this.privateKeyFile.add(uf);
+                }
+            }
+        }
     }
 
 }

--- a/src/main/java/ca/openosp/openo/hospitalReportManager/v2018/HRM2Action.java
+++ b/src/main/java/ca/openosp/openo/hospitalReportManager/v2018/HRM2Action.java
@@ -1032,11 +1032,11 @@ public class HRM2Action extends ActionSupport implements UploadedFilesAware {
         this.hrm_file = new ArrayList<>();
         this.privateKeyFile = new ArrayList<>();
         if (!uploadedFiles.isEmpty()) {
-            for (UploadedFile uf : uploadedFiles) {
-                if ("hrm_file".equals(uf.getInputName())) {
-                    this.hrm_file.add(uf);
-                } else if ("privateKeyFile".equals(uf.getInputName())) {
-                    this.privateKeyFile.add(uf);
+            for (UploadedFile uploadedFile : uploadedFiles) {
+                if ("hrm_file".equals(uploadedFile.getInputName())) {
+                    this.hrm_file.add(uploadedFile);
+                } else if ("privateKeyFile".equals(uploadedFile.getInputName())) {
+                    this.privateKeyFile.add(uploadedFile);
                 }
             }
         }

--- a/src/main/java/ca/openosp/openo/integration/mcedt/Update2Action.java
+++ b/src/main/java/ca/openosp/openo/integration/mcedt/Update2Action.java
@@ -134,6 +134,7 @@ public class Update2Action extends ActionSupport implements UploadedFilesAware {
 
     private String resourceId;
     private UploadedFile content;
+    private File contentOnDisk;
 
     public String getResourceId() {
         return resourceId;
@@ -147,6 +148,7 @@ public class Update2Action extends ActionSupport implements UploadedFilesAware {
     public void withUploadedFiles(List<UploadedFile> uploadedFiles) {
         if (!uploadedFiles.isEmpty()) {
             this.content = uploadedFiles.get(0);
+            this.contentOnDisk = PathValidationUtils.toFile(content);
         }
     }
 
@@ -154,8 +156,7 @@ public class Update2Action extends ActionSupport implements UploadedFilesAware {
         UpdateRequest result = new UpdateRequest();
         result.setResourceID(BigInteger.valueOf(ConversionUtils.fromIntString(resourceId)));
         try {
-            File contentFile = PathValidationUtils.toFile(content);
-            result.setContent(Files.readAllBytes(contentFile.toPath()));
+            result.setContent(Files.readAllBytes(contentOnDisk.toPath()));
         } catch (Exception e) {
             throw new RuntimeException("Unable to read upload data", e);
         }

--- a/src/main/java/ca/openosp/openo/integration/mcedt/Update2Action.java
+++ b/src/main/java/ca/openosp/openo/integration/mcedt/Update2Action.java
@@ -155,6 +155,9 @@ public class Update2Action extends ActionSupport implements UploadedFilesAware {
     public UpdateRequest toUpdateRequest() {
         UpdateRequest result = new UpdateRequest();
         result.setResourceID(BigInteger.valueOf(ConversionUtils.fromIntString(resourceId)));
+        if (contentOnDisk == null) {
+            throw new RuntimeException("No upload file was provided");
+        }
         try {
             result.setContent(Files.readAllBytes(contentOnDisk.toPath()));
         } catch (Exception e) {

--- a/src/main/java/ca/openosp/openo/integration/mcedt/Update2Action.java
+++ b/src/main/java/ca/openosp/openo/integration/mcedt/Update2Action.java
@@ -25,9 +25,13 @@
 package ca.openosp.openo.integration.mcedt;
 
 import ca.ontario.health.edt.*;
+import java.util.List;
 import org.apache.struts2.ActionSupport;
+import org.apache.struts2.action.UploadedFilesAware;
+import org.apache.struts2.dispatcher.multipart.UploadedFile;
 import org.apache.logging.log4j.Logger;
 import org.apache.struts2.ServletActionContext;
+import ca.openosp.openo.utility.PathValidationUtils;
 import ca.openosp.openo.utility.MiscUtils;
 import ca.openosp.openo.util.ConversionUtils;
 
@@ -41,7 +45,7 @@ import java.util.List;
 import static ca.openosp.openo.integration.mcedt.ActionUtils.*;
 import static ca.openosp.openo.integration.mcedt.McedtConstants.SESSION_KEY_UPLOAD_DETAILS;
 
-public class Update2Action extends ActionSupport {
+public class Update2Action extends ActionSupport implements UploadedFilesAware {
     HttpServletRequest request = ServletActionContext.getRequest();
     HttpServletResponse response = ServletActionContext.getResponse();
 
@@ -129,7 +133,7 @@ public class Update2Action extends ActionSupport {
     }
 
     private String resourceId;
-    private File content;
+    private UploadedFile content;
 
     public String getResourceId() {
         return resourceId;
@@ -139,19 +143,19 @@ public class Update2Action extends ActionSupport {
         this.resourceId = resourceId;
     }
 
-    public File getContent() {
-        return content;
-    }
-
-    public void setContent(File content) {
-        this.content = content;
+    @Override
+    public void withUploadedFiles(List<UploadedFile> uploadedFiles) {
+        if (!uploadedFiles.isEmpty()) {
+            this.content = uploadedFiles.get(0);
+        }
     }
 
     public UpdateRequest toUpdateRequest() {
         UpdateRequest result = new UpdateRequest();
         result.setResourceID(BigInteger.valueOf(ConversionUtils.fromIntString(resourceId)));
         try {
-            result.setContent(Files.readAllBytes(content.toPath()));
+            File contentFile = PathValidationUtils.toFile(content);
+            result.setContent(Files.readAllBytes(contentFile.toPath()));
         } catch (Exception e) {
             throw new RuntimeException("Unable to read upload data", e);
         }

--- a/src/main/java/ca/openosp/openo/integration/mcedt/mailbox/Upload2Action.java
+++ b/src/main/java/ca/openosp/openo/integration/mcedt/mailbox/Upload2Action.java
@@ -25,12 +25,15 @@ package ca.openosp.openo.integration.mcedt.mailbox;
 
 import ca.ontario.health.edt.*;
 import org.apache.struts2.ActionSupport;
+import org.apache.struts2.action.UploadedFilesAware;
+import org.apache.struts2.dispatcher.multipart.UploadedFile;
 import org.apache.cxf.helpers.FileUtils;
 import org.apache.logging.log4j.Logger;
 import org.apache.struts2.ServletActionContext;
 import ca.openosp.openo.integration.mcedt.DelegateFactory;
 import ca.openosp.openo.integration.mcedt.McedtMessageCreator;
 import ca.openosp.openo.utility.MiscUtils;
+import ca.openosp.openo.utility.PathValidationUtils;
 import ca.openosp.OscarProperties;
 
 import javax.servlet.http.HttpServletRequest;
@@ -46,7 +49,7 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 
-public class Upload2Action extends ActionSupport {
+public class Upload2Action extends ActionSupport implements UploadedFilesAware {
     HttpServletRequest request = ServletActionContext.getRequest();
     HttpServletResponse response = ServletActionContext.getResponse();
 
@@ -332,8 +335,9 @@ public class Upload2Action extends ActionSupport {
         } else {
             OscarProperties props = OscarProperties.getInstance();
             File myFile = new File(props.getProperty("ONEDT_OUTBOX", "") + this.getFileName());
+            File rawUploadFile = PathValidationUtils.toFile(this.addUploadFile);
             try (FileOutputStream outputStream = new FileOutputStream(myFile)) {
-                outputStream.write(Files.readAllBytes(this.getAddUploadFile().toPath()));
+                outputStream.write(Files.readAllBytes(rawUploadFile.toPath()));
                 outputStream.close();
                 addActionMessage(getText("uploadAction.upload.add.success", new String[]{this.getFileName() + " is succesfully added to the uploads list!"}));
             } catch (IOException e) {
@@ -405,9 +409,7 @@ public class Upload2Action extends ActionSupport {
     private String resourceType;
     private String fileName;
     private BigInteger resourceId;
-    private File addUploadFile;
-    private String addUploadFileFileName;
-    private String addUploadFileContentType;
+    private UploadedFile addUploadFile;
 
     public String getDescription() {
         return description;
@@ -441,27 +443,12 @@ public class Upload2Action extends ActionSupport {
         this.resourceId = resourceId;
     }
 
-    public File getAddUploadFile() {
-        return addUploadFile;
-    }
 
-    public void setAddUploadFile(File addUploadFile) {
-        this.addUploadFile = addUploadFile;
-    }
-
-    public String getAddUploadFileFileName() {
-        return addUploadFileFileName;
-    }
-    public void setAddUploadFileFileName(String addUploadFileFileName) {
-        this.addUploadFileFileName = addUploadFileFileName;
-        this.setFileName(addUploadFileFileName); // set the file name to the upload file name
-    }
-
-    public String getAddUploadFileContentType() {
-        return addUploadFileContentType;
-    }
-    public void setAddUploadFileContentType(String addUploadFileContentType) {
-        this.addUploadFileContentType = addUploadFileContentType;
-        this.setResourceType(addUploadFileContentType); // set the resource type to the upload file content type
+    @Override
+    public void withUploadedFiles(List<UploadedFile> uploadedFiles) {
+        if (!uploadedFiles.isEmpty()) {
+            this.addUploadFile = uploadedFiles.get(0);
+            this.fileName = addUploadFile.getOriginalName();
+        }
     }
 }

--- a/src/main/java/ca/openosp/openo/integration/mcedt/mailbox/Upload2Action.java
+++ b/src/main/java/ca/openosp/openo/integration/mcedt/mailbox/Upload2Action.java
@@ -335,9 +335,8 @@ public class Upload2Action extends ActionSupport implements UploadedFilesAware {
         } else {
             OscarProperties props = OscarProperties.getInstance();
             File myFile = new File(props.getProperty("ONEDT_OUTBOX", "") + this.getFileName());
-            File rawUploadFile = PathValidationUtils.toFile(this.addUploadFile);
             try (FileOutputStream outputStream = new FileOutputStream(myFile)) {
-                outputStream.write(Files.readAllBytes(rawUploadFile.toPath()));
+                outputStream.write(Files.readAllBytes(addUploadFileOnDisk.toPath()));
                 outputStream.close();
                 addActionMessage(getText("uploadAction.upload.add.success", new String[]{this.getFileName() + " is succesfully added to the uploads list!"}));
             } catch (IOException e) {
@@ -410,6 +409,7 @@ public class Upload2Action extends ActionSupport implements UploadedFilesAware {
     private String fileName;
     private BigInteger resourceId;
     private UploadedFile addUploadFile;
+    private File addUploadFileOnDisk;
 
     public String getDescription() {
         return description;
@@ -448,6 +448,7 @@ public class Upload2Action extends ActionSupport implements UploadedFilesAware {
     public void withUploadedFiles(List<UploadedFile> uploadedFiles) {
         if (!uploadedFiles.isEmpty()) {
             this.addUploadFile = uploadedFiles.get(0);
+            this.addUploadFileOnDisk = PathValidationUtils.toFile(addUploadFile);
             this.fileName = addUploadFile.getOriginalName();
         }
     }

--- a/src/main/java/ca/openosp/openo/integration/mcedt/mailbox/Upload2Action.java
+++ b/src/main/java/ca/openosp/openo/integration/mcedt/mailbox/Upload2Action.java
@@ -450,6 +450,7 @@ public class Upload2Action extends ActionSupport implements UploadedFilesAware {
             this.addUploadFile = uploadedFiles.get(0);
             this.addUploadFileOnDisk = PathValidationUtils.toFile(addUploadFile);
             this.fileName = addUploadFile.getOriginalName();
+            this.resourceType = addUploadFile.getContentType();
         }
     }
 }

--- a/src/main/java/ca/openosp/openo/lab/ca/all/pageUtil/InsideLabUpload2Action.java
+++ b/src/main/java/ca/openosp/openo/lab/ca/all/pageUtil/InsideLabUpload2Action.java
@@ -98,7 +98,7 @@ public class InsideLabUpload2Action extends ActionSupport implements UploadedFil
             String fileName = uf.getOriginalName();
 
             // Process each file
-            FileStatus status = processUploadedFile(loggedInInfo, file, fileName, null);
+            FileStatus status = processUploadedFile(loggedInInfo, file, fileName, uf.getContentType());
             filesStatusMap.put(fileName, status);
         }
         

--- a/src/main/java/ca/openosp/openo/lab/ca/all/pageUtil/InsideLabUpload2Action.java
+++ b/src/main/java/ca/openosp/openo/lab/ca/all/pageUtil/InsideLabUpload2Action.java
@@ -42,6 +42,7 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -61,8 +62,12 @@ import ca.openosp.openo.lab.ca.all.util.Utilities;
 
 import org.apache.struts2.ActionSupport;
 import org.apache.struts2.ServletActionContext;
+import org.apache.struts2.action.UploadedFilesAware;
+import org.apache.struts2.dispatcher.multipart.UploadedFile;
 
-public class InsideLabUpload2Action extends ActionSupport {
+import ca.openosp.openo.utility.PathValidationUtils;
+
+public class InsideLabUpload2Action extends ActionSupport implements UploadedFilesAware {
     HttpServletRequest request = ServletActionContext.getRequest();
     HttpServletResponse response = ServletActionContext.getResponse();
 
@@ -73,9 +78,7 @@ public class InsideLabUpload2Action extends ActionSupport {
         EXISTS
     }
 
-    private List<File> importFiles;
-    private List<String> importFilesFileName;
-    private List<String> importFilesContentType;
+    private List<UploadedFile> importFiles;
     
     @Override
     public String execute() {
@@ -90,12 +93,12 @@ public class InsideLabUpload2Action extends ActionSupport {
         Map<String, FileStatus> filesStatusMap = new HashMap<>();
         
         for (int i = 0; i < importFiles.size(); i++) {
-            File file = importFiles.get(i);
-            String fileName = importFilesFileName.get(i);
-            String contentType = importFilesContentType.get(i);
-            
+            UploadedFile uf = importFiles.get(i);
+            File file = PathValidationUtils.toFile(uf);
+            String fileName = uf.getOriginalName();
+
             // Process each file
-            FileStatus status = processUploadedFile(loggedInInfo, file, fileName, contentType);
+            FileStatus status = processUploadedFile(loggedInInfo, file, fileName, null);
             filesStatusMap.put(fileName, status);
         }
         
@@ -158,30 +161,8 @@ public class InsideLabUpload2Action extends ActionSupport {
         return FileStatus.INVALID;
     }
 
-    public List<File> getImportFiles() 
-    { 
-        return importFiles; 
-    }
-    public void setImportFiles(List<File> importFiles) 
-    { 
-        this.importFiles = importFiles; 
-    }
-    
-    public List<String> getImportFilesFileName() 
-    { 
-        return importFilesFileName; 
-    }
-    public void setImportFilesFileName(List<String> importFilesFileName) 
-    { 
-        this.importFilesFileName = importFilesFileName; 
-    }
-    
-    public List<String> getImportFilesContentType() 
-    { 
-        return importFilesContentType; 
-    }
-    public void setImportFilesContentType(List<String> importFilesContentType) 
-    { 
-        this.importFilesContentType = importFilesContentType; 
+    @Override
+    public void withUploadedFiles(List<UploadedFile> uploadedFiles) {
+        this.importFiles = new ArrayList<>(uploadedFiles);
     }
 }

--- a/src/main/java/ca/openosp/openo/lab/ca/all/pageUtil/LabUpload2Action.java
+++ b/src/main/java/ca/openosp/openo/lab/ca/all/pageUtil/LabUpload2Action.java
@@ -36,6 +36,8 @@
 package ca.openosp.openo.lab.ca.all.pageUtil;
 
 import org.apache.struts2.ActionSupport;
+import org.apache.struts2.action.UploadedFilesAware;
+import org.apache.struts2.dispatcher.multipart.UploadedFile;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.Logger;
@@ -70,8 +72,9 @@ import java.security.Signature;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
 import java.util.ArrayList;
+import java.util.List;
 
-public class LabUpload2Action extends ActionSupport {
+public class LabUpload2Action extends ActionSupport implements UploadedFilesAware {
     HttpServletRequest request = ServletActionContext.getRequest();
     HttpServletResponse response = ServletActionContext.getResponse();
 
@@ -93,7 +96,7 @@ public class LabUpload2Action extends ActionSupport {
         String type = (String) clientInfo.get(1);
 
         try {
-            // Validate the uploaded file to prevent path traversal attacks
+            // Extract File from UploadedFile
             if (importFile == null) {
                 logger.error("No file provided for upload");
                 outcome = "exception";
@@ -103,11 +106,13 @@ public class LabUpload2Action extends ActionSupport {
                 return SUCCESS;
             }
 
+            File rawImportFile = PathValidationUtils.toFile(importFile);
+
             // Validate file is from an allowed temp directory
             try {
-                importFile = PathValidationUtils.validateUpload(importFile);
+                rawImportFile = PathValidationUtils.validateUpload(rawImportFile);
             } catch (SecurityException e) {
-                logger.error("Invalid upload source - potential path traversal: " + importFile.getPath());
+                logger.error("Invalid upload source - potential path traversal: " + rawImportFile.getPath());
                 outcome = "exception";
                 httpCode = HttpServletResponse.SC_FORBIDDEN;
                 request.setAttribute("outcome", outcome);
@@ -115,8 +120,8 @@ public class LabUpload2Action extends ActionSupport {
                 return SUCCESS;
             }
 
-            InputStream is = decryptMessage(Files.newInputStream(importFile.toPath()), key, clientKey);
-            String fileName = importFile.getName();
+            InputStream is = decryptMessage(Files.newInputStream(rawImportFile.toPath()), key, clientKey);
+            String fileName = rawImportFile.getName();
             String filePath = null;
             if (type.equals("PDFDOC")) {
                 filePath = Utilities.savePdfFile(is, fileName);
@@ -305,13 +310,12 @@ public class LabUpload2Action extends ActionSupport {
         return (Key);
     }
 
-    private File importFile;
+    private UploadedFile importFile;
 
-    public File getImportFile() {
-        return importFile;
-    }
-
-    public void setImportFile(File importFile) {
-        this.importFile = importFile;
+    @Override
+    public void withUploadedFiles(List<UploadedFile> uploadedFiles) {
+        if (!uploadedFiles.isEmpty()) {
+            this.importFile = uploadedFiles.get(0);
+        }
     }
 }

--- a/src/main/java/ca/openosp/openo/lab/ca/all/pageUtil/LabUpload2Action.java
+++ b/src/main/java/ca/openosp/openo/lab/ca/all/pageUtil/LabUpload2Action.java
@@ -106,13 +106,11 @@ public class LabUpload2Action extends ActionSupport implements UploadedFilesAwar
                 return SUCCESS;
             }
 
-            File rawImportFile = PathValidationUtils.toFile(importFile);
-
             // Validate file is from an allowed temp directory
             try {
-                rawImportFile = PathValidationUtils.validateUpload(rawImportFile);
+                importFileOnDisk = PathValidationUtils.validateUpload(importFileOnDisk);
             } catch (SecurityException e) {
-                logger.error("Invalid upload source - potential path traversal: " + rawImportFile.getPath());
+                logger.error("Invalid upload source - potential path traversal: " + importFileOnDisk.getPath());
                 outcome = "exception";
                 httpCode = HttpServletResponse.SC_FORBIDDEN;
                 request.setAttribute("outcome", outcome);
@@ -120,8 +118,8 @@ public class LabUpload2Action extends ActionSupport implements UploadedFilesAwar
                 return SUCCESS;
             }
 
-            InputStream is = decryptMessage(Files.newInputStream(rawImportFile.toPath()), key, clientKey);
-            String fileName = rawImportFile.getName();
+            InputStream is = decryptMessage(Files.newInputStream(importFileOnDisk.toPath()), key, clientKey);
+            String fileName = importFileOnDisk.getName();
             String filePath = null;
             if (type.equals("PDFDOC")) {
                 filePath = Utilities.savePdfFile(is, fileName);
@@ -311,11 +309,13 @@ public class LabUpload2Action extends ActionSupport implements UploadedFilesAwar
     }
 
     private UploadedFile importFile;
+    private File importFileOnDisk;
 
     @Override
     public void withUploadedFiles(List<UploadedFile> uploadedFiles) {
         if (!uploadedFiles.isEmpty()) {
             this.importFile = uploadedFiles.get(0);
+            this.importFileOnDisk = PathValidationUtils.toFile(importFile);
         }
     }
 }

--- a/src/main/java/ca/openosp/openo/lab/ca/bc/PathNet/pageUtil/LabUpload2Action.java
+++ b/src/main/java/ca/openosp/openo/lab/ca/bc/PathNet/pageUtil/LabUpload2Action.java
@@ -75,23 +75,21 @@ public class LabUpload2Action extends ActionSupport implements UploadedFilesAwar
                 return SUCCESS;
             }
 
-            File rawImportFile = PathValidationUtils.toFile(importFile);
-
             // Validate file is from an allowed temp directory
             try {
-                rawImportFile = PathValidationUtils.validateUpload(rawImportFile);
+                importFileOnDisk = PathValidationUtils.validateUpload(importFileOnDisk);
             } catch (SecurityException e) {
-                _logger.error("Invalid upload source - potential path traversal: " + rawImportFile.getPath());
+                _logger.error("Invalid upload source - potential path traversal: " + importFileOnDisk.getPath());
                 outcome = "exception";
                 request.setAttribute("outcome", outcome);
                 return SUCCESS;
             }
 
-            MiscUtils.getLogger().debug("Lab Upload content type = " + rawImportFile.getName());
+            MiscUtils.getLogger().debug("Lab Upload content type = " + importFileOnDisk.getName());
             // Re-validate at point of use for static analysis visibility
-            File validatedImportFile = PathValidationUtils.validateUpload(rawImportFile);
+            File validatedImportFile = PathValidationUtils.validateUpload(importFileOnDisk);
             InputStream is = Files.newInputStream(validatedImportFile.toPath());
-            filename = rawImportFile.getName();
+            filename = importFileOnDisk.getName();
 
             int check = FileUploadCheck.addFile(filename, is, proNo);
             is.reset();
@@ -196,11 +194,13 @@ public class LabUpload2Action extends ActionSupport implements UploadedFilesAwar
     }
 
     private UploadedFile importFile;
+    private File importFileOnDisk;
 
     @Override
     public void withUploadedFiles(List<UploadedFile> uploadedFiles) {
         if (!uploadedFiles.isEmpty()) {
             this.importFile = uploadedFiles.get(0);
+            this.importFileOnDisk = PathValidationUtils.toFile(importFile);
         }
     }
 }

--- a/src/main/java/ca/openosp/openo/lab/ca/bc/PathNet/pageUtil/LabUpload2Action.java
+++ b/src/main/java/ca/openosp/openo/lab/ca/bc/PathNet/pageUtil/LabUpload2Action.java
@@ -27,6 +27,8 @@
 package ca.openosp.openo.lab.ca.bc.PathNet.pageUtil;
 
 import org.apache.struts2.ActionSupport;
+import org.apache.struts2.action.UploadedFilesAware;
+import org.apache.struts2.dispatcher.multipart.UploadedFile;
 import org.apache.logging.log4j.Logger;
 import org.apache.struts2.ServletActionContext;
 import ca.openosp.openo.managers.SecurityInfoManager;
@@ -46,8 +48,9 @@ import java.nio.file.Files;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 
-public class LabUpload2Action extends ActionSupport {
+public class LabUpload2Action extends ActionSupport implements UploadedFilesAware {
     HttpServletRequest request = ServletActionContext.getRequest();
     HttpServletResponse response = ServletActionContext.getResponse();
 
@@ -64,7 +67,7 @@ public class LabUpload2Action extends ActionSupport {
         String outcome = "";
 
         try {
-            // Validate the uploaded file to prevent path traversal attacks
+            // Extract File from UploadedFile
             if (importFile == null) {
                 _logger.error("No file provided for upload");
                 outcome = "exception";
@@ -72,21 +75,23 @@ public class LabUpload2Action extends ActionSupport {
                 return SUCCESS;
             }
 
+            File rawImportFile = PathValidationUtils.toFile(importFile);
+
             // Validate file is from an allowed temp directory
             try {
-                importFile = PathValidationUtils.validateUpload(importFile);
+                rawImportFile = PathValidationUtils.validateUpload(rawImportFile);
             } catch (SecurityException e) {
-                _logger.error("Invalid upload source - potential path traversal: " + importFile.getPath());
+                _logger.error("Invalid upload source - potential path traversal: " + rawImportFile.getPath());
                 outcome = "exception";
                 request.setAttribute("outcome", outcome);
                 return SUCCESS;
             }
 
-            MiscUtils.getLogger().debug("Lab Upload content type = " + importFile.getName());
+            MiscUtils.getLogger().debug("Lab Upload content type = " + rawImportFile.getName());
             // Re-validate at point of use for static analysis visibility
-            File validatedImportFile = PathValidationUtils.validateUpload(importFile);
+            File validatedImportFile = PathValidationUtils.validateUpload(rawImportFile);
             InputStream is = Files.newInputStream(validatedImportFile.toPath());
-            filename = importFile.getName();
+            filename = rawImportFile.getName();
 
             int check = FileUploadCheck.addFile(filename, is, proNo);
             is.reset();
@@ -190,13 +195,12 @@ public class LabUpload2Action extends ActionSupport {
         return isAdded;
     }
 
-    private File importFile;
+    private UploadedFile importFile;
 
-    public File getImportFile() {
-        return importFile;
-    }
-
-    public void setImportFile(File importFile) {
-        this.importFile = importFile;
+    @Override
+    public void withUploadedFiles(List<UploadedFile> uploadedFiles) {
+        if (!uploadedFiles.isEmpty()) {
+            this.importFile = uploadedFiles.get(0);
+        }
     }
 }

--- a/src/main/java/ca/openosp/openo/lab/ca/on/CML/Upload/LabUpload2Action.java
+++ b/src/main/java/ca/openosp/openo/lab/ca/on/CML/Upload/LabUpload2Action.java
@@ -83,24 +83,22 @@ public class LabUpload2Action extends ActionSupport implements UploadedFilesAwar
                     return SUCCESS;
                 }
 
-                File rawImportFile = PathValidationUtils.toFile(importFile);
-
                 try {
                     // Validates source file is from an allowed temp location
-                    rawImportFile = PathValidationUtils.validateUpload(rawImportFile);
+                    importFileOnDisk = PathValidationUtils.validateUpload(importFileOnDisk);
                 } catch (SecurityException e) {
-                    _logger.error("Invalid upload source: " + rawImportFile.getPath());
+                    _logger.error("Invalid upload source: " + importFileOnDisk.getPath());
                     outcome = "accessDenied";
                     request.setAttribute("outcome", outcome);
                     return SUCCESS;
                 }
 
-                MiscUtils.getLogger().debug("Lab Upload content type = " + rawImportFile.getName());
-                File validatedImportFile = PathValidationUtils.validateUpload(rawImportFile);
+                MiscUtils.getLogger().debug("Lab Upload content type = " + importFileOnDisk.getName());
+                File validatedImportFile = PathValidationUtils.validateUpload(importFileOnDisk);
                 InputStream is = Files.newInputStream(validatedImportFile.toPath());
 
                 // Get sanitized filename from the validated source
-                filename = rawImportFile.getName();
+                filename = importFileOnDisk.getName();
 
                 String localFileName = saveFile(is, filename);
                 is.close();
@@ -226,11 +224,13 @@ public class LabUpload2Action extends ActionSupport implements UploadedFilesAwar
     }
 
     private UploadedFile importFile;
+    private File importFileOnDisk;
 
     @Override
     public void withUploadedFiles(List<UploadedFile> uploadedFiles) {
         if (!uploadedFiles.isEmpty()) {
             this.importFile = uploadedFiles.get(0);
+            this.importFileOnDisk = PathValidationUtils.toFile(importFile);
         }
     }
 }

--- a/src/main/java/ca/openosp/openo/lab/ca/on/CML/Upload/LabUpload2Action.java
+++ b/src/main/java/ca/openosp/openo/lab/ca/on/CML/Upload/LabUpload2Action.java
@@ -27,6 +27,8 @@
 package ca.openosp.openo.lab.ca.on.CML.Upload;
 
 import org.apache.struts2.ActionSupport;
+import org.apache.struts2.action.UploadedFilesAware;
+import org.apache.struts2.dispatcher.multipart.UploadedFile;
 import org.apache.logging.log4j.Logger;
 import org.apache.struts2.ServletActionContext;
 import ca.openosp.openo.managers.SecurityInfoManager;
@@ -46,8 +48,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Date;
+import java.util.List;
 
-public class LabUpload2Action extends ActionSupport {
+public class LabUpload2Action extends ActionSupport implements UploadedFilesAware {
     HttpServletRequest request = ServletActionContext.getRequest();
     HttpServletResponse response = ServletActionContext.getResponse();
 
@@ -73,29 +76,31 @@ public class LabUpload2Action extends ActionSupport {
         if (key != null && keyToMatch != null && keyToMatch.equals(key)) {
 
             try {
-                // Validate the uploaded file using PathValidationUtils
+                // Extract File from UploadedFile
                 if (importFile == null) {
                     outcome = "accessDenied";
                     request.setAttribute("outcome", outcome);
                     return SUCCESS;
                 }
 
+                File rawImportFile = PathValidationUtils.toFile(importFile);
+
                 try {
                     // Validates source file is from an allowed temp location
-                    importFile = PathValidationUtils.validateUpload(importFile);
+                    rawImportFile = PathValidationUtils.validateUpload(rawImportFile);
                 } catch (SecurityException e) {
-                    _logger.error("Invalid upload source: " + importFile.getPath());
+                    _logger.error("Invalid upload source: " + rawImportFile.getPath());
                     outcome = "accessDenied";
                     request.setAttribute("outcome", outcome);
                     return SUCCESS;
                 }
 
-                MiscUtils.getLogger().debug("Lab Upload content type = " + importFile.getName());
-                File validatedImportFile = PathValidationUtils.validateUpload(importFile);
+                MiscUtils.getLogger().debug("Lab Upload content type = " + rawImportFile.getName());
+                File validatedImportFile = PathValidationUtils.validateUpload(rawImportFile);
                 InputStream is = Files.newInputStream(validatedImportFile.toPath());
 
                 // Get sanitized filename from the validated source
-                filename = importFile.getName();
+                filename = rawImportFile.getName();
 
                 String localFileName = saveFile(is, filename);
                 is.close();
@@ -220,13 +225,12 @@ public class LabUpload2Action extends ActionSupport {
         return retVal;
     }
 
-    private File importFile;
+    private UploadedFile importFile;
 
-    public File getImportFile() {
-        return importFile;
-    }
-
-    public void setImportFile(File importFile) {
-        this.importFile = importFile;
+    @Override
+    public void withUploadedFiles(List<UploadedFile> uploadedFiles) {
+        if (!uploadedFiles.isEmpty()) {
+            this.importFile = uploadedFiles.get(0);
+        }
     }
 }

--- a/src/main/java/ca/openosp/openo/login/UploadLoginText2Action.java
+++ b/src/main/java/ca/openosp/openo/login/UploadLoginText2Action.java
@@ -108,9 +108,8 @@ public class UploadLoginText2Action extends ActionSupport implements UploadedFil
 
 
         try {
-            File rawImportFile = PathValidationUtils.toFile(importFile);
-            if (rawImportFile.getName().length() > 0) {
-                fis = Files.newInputStream(rawImportFile.toPath());
+            if (importFileOnDisk.getName().length() > 0) {
+                fis = Files.newInputStream(importFileOnDisk.toPath());
                 String savePath = OscarProperties.getInstance().getProperty("DOCUMENT_DIR") + "/OSCARloginText.txt";
                 fos = new FileOutputStream(savePath);
                 byte[] buf = new byte[128 * 1024];
@@ -130,11 +129,13 @@ public class UploadLoginText2Action extends ActionSupport implements UploadedFil
     }
 
     private UploadedFile importFile;
+    private File importFileOnDisk;
 
     @Override
     public void withUploadedFiles(List<UploadedFile> uploadedFiles) {
         if (!uploadedFiles.isEmpty()) {
             this.importFile = uploadedFiles.get(0);
+            this.importFileOnDisk = PathValidationUtils.toFile(importFile);
         }
     }
 }

--- a/src/main/java/ca/openosp/openo/login/UploadLoginText2Action.java
+++ b/src/main/java/ca/openosp/openo/login/UploadLoginText2Action.java
@@ -62,8 +62,6 @@ public class UploadLoginText2Action extends ActionSupport implements UploadedFil
             throw new SecurityException("missing required sec object (_admin)");
         }
 
-        InputStream fis = null;
-        FileOutputStream fos = null;
         boolean error = false;
 
         String validDurationNumber = request.getParameter("validDurationNumber");// verify it's a number
@@ -108,14 +106,15 @@ public class UploadLoginText2Action extends ActionSupport implements UploadedFil
 
 
         try {
-            if (importFileOnDisk.getName().length() > 0) {
-                fis = Files.newInputStream(importFileOnDisk.toPath());
+            if (importFileOnDisk != null && importFileOnDisk.getName().length() > 0) {
                 String savePath = OscarProperties.getInstance().getProperty("DOCUMENT_DIR") + "/OSCARloginText.txt";
-                fos = new FileOutputStream(savePath);
-                byte[] buf = new byte[128 * 1024];
-                int i = 0;
-                while ((i = fis.read(buf)) != -1) {
-                    fos.write(buf, 0, i);
+                try (InputStream fis2 = Files.newInputStream(importFileOnDisk.toPath());
+                     FileOutputStream fos2 = new FileOutputStream(savePath)) {
+                    byte[] buf = new byte[128 * 1024];
+                    int i = 0;
+                    while ((i = fis2.read(buf)) != -1) {
+                        fos2.write(buf, 0, i);
+                    }
                 }
                 error = false;
             }

--- a/src/main/java/ca/openosp/openo/login/UploadLoginText2Action.java
+++ b/src/main/java/ca/openosp/openo/login/UploadLoginText2Action.java
@@ -28,6 +28,8 @@ package ca.openosp.openo.login;
 
 import ca.openosp.OscarProperties;
 import org.apache.struts2.ActionSupport;
+import org.apache.struts2.action.UploadedFilesAware;
+import org.apache.struts2.dispatcher.multipart.UploadedFile;
 import org.apache.logging.log4j.Logger;
 import org.apache.struts2.ServletActionContext;
 import ca.openosp.openo.commn.dao.PropertyDao;
@@ -36,6 +38,7 @@ import ca.openosp.openo.commn.service.AcceptableUseAgreementManager;
 import ca.openosp.openo.managers.SecurityInfoManager;
 import ca.openosp.openo.utility.LoggedInInfo;
 import ca.openosp.openo.utility.MiscUtils;
+import ca.openosp.openo.utility.PathValidationUtils;
 import ca.openosp.openo.utility.SpringUtils;
 
 import javax.servlet.http.HttpServletRequest;
@@ -44,8 +47,9 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.nio.file.Files;
+import java.util.List;
 
-public class UploadLoginText2Action extends ActionSupport {
+public class UploadLoginText2Action extends ActionSupport implements UploadedFilesAware {
     HttpServletRequest request = ServletActionContext.getRequest();
     HttpServletResponse response = ServletActionContext.getResponse();
 
@@ -104,8 +108,9 @@ public class UploadLoginText2Action extends ActionSupport {
 
 
         try {
-            if (importFile.getName().length() > 0) {
-                fis = Files.newInputStream(importFile.toPath());
+            File rawImportFile = PathValidationUtils.toFile(importFile);
+            if (rawImportFile.getName().length() > 0) {
+                fis = Files.newInputStream(rawImportFile.toPath());
                 String savePath = OscarProperties.getInstance().getProperty("DOCUMENT_DIR") + "/OSCARloginText.txt";
                 fos = new FileOutputStream(savePath);
                 byte[] buf = new byte[128 * 1024];
@@ -124,13 +129,12 @@ public class UploadLoginText2Action extends ActionSupport {
         return SUCCESS;
     }
 
-    private File importFile;
+    private UploadedFile importFile;
 
-    public File getImportFile() {
-        return importFile;
-    }
-
-    public void setImportFile(File importFile) {
-        this.importFile = importFile;
+    @Override
+    public void withUploadedFiles(List<UploadedFile> uploadedFiles) {
+        if (!uploadedFiles.isEmpty()) {
+            this.importFile = uploadedFiles.get(0);
+        }
     }
 }

--- a/src/main/java/ca/openosp/openo/report/pageUtil/ManagePatientLetters2Action.java
+++ b/src/main/java/ca/openosp/openo/report/pageUtil/ManagePatientLetters2Action.java
@@ -27,6 +27,8 @@
 package ca.openosp.openo.report.pageUtil;
 
 import org.apache.struts2.ActionSupport;
+import org.apache.struts2.action.UploadedFilesAware;
+import org.apache.struts2.dispatcher.multipart.UploadedFile;
 import net.sf.jasperreports.engine.JRException;
 import net.sf.jasperreports.engine.JasperCompileManager;
 import net.sf.jasperreports.engine.JasperReport;
@@ -46,8 +48,9 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.List;
 
-public class ManagePatientLetters2Action extends ActionSupport {
+public class ManagePatientLetters2Action extends ActionSupport implements UploadedFilesAware {
     HttpServletRequest request = ServletActionContext.getRequest();
     HttpServletResponse response = ServletActionContext.getResponse();
 
@@ -80,26 +83,28 @@ public class ManagePatientLetters2Action extends ActionSupport {
         byte[] fileData = null;
 
         try {
-            // Validate the uploaded file to prevent path traversal attacks
+            // Extract File from UploadedFile
             if (reportFile == null) {
                 log.error("No report file uploaded");
                 return SUCCESS;
             }
 
+            File rawReportFile = PathValidationUtils.toFile(reportFile);
+
             // Use PathValidationUtils to validate the uploaded file is in temp directory
-            if (!PathValidationUtils.isInAllowedTempDirectory(reportFile)) {
-                log.error("Attempted path traversal attack detected for file: " + reportFile.getPath());
+            if (!PathValidationUtils.isInAllowedTempDirectory(rawReportFile)) {
+                log.error("Attempted path traversal attack detected for file: " + rawReportFile.getPath());
                 throw new SecurityException("Invalid file upload - path traversal detected");
             }
 
             // Additional validation: ensure the file exists and is a regular file
-            if (!reportFile.exists() || !reportFile.isFile()) {
+            if (!rawReportFile.exists() || !rawReportFile.isFile()) {
                 log.error("Invalid file upload: File does not exist or is not a regular file");
                 return SUCCESS;
             }
 
             // Re-validate at point of use for static analysis visibility
-            File validatedReportFile = PathValidationUtils.validateUpload(reportFile);
+            File validatedReportFile = PathValidationUtils.validateUpload(rawReportFile);
             fileData = Files.readAllBytes(validatedReportFile.toPath());
             String reportName = request.getParameter("reportName");
 
@@ -110,7 +115,7 @@ public class ManagePatientLetters2Action extends ActionSupport {
             JasperReport jasperReport = JasperCompileManager.compileReport(new ByteArrayInputStream(fileData));
 
             ManageLetters manageLetters = new ManageLetters();
-            manageLetters.saveReport((String) request.getSession().getAttribute("user"), reportName, reportFile.getName(), fileData);
+            manageLetters.saveReport((String) request.getSession().getAttribute("user"), reportName, rawReportFile.getName(), fileData);
         } catch (FileNotFoundException ex) {
             MiscUtils.getLogger().error("Error", ex);
         } catch (IOException ex) {
@@ -129,13 +134,12 @@ public class ManagePatientLetters2Action extends ActionSupport {
         return SUCCESS;
     }
 
-    private File reportFile;
+    private UploadedFile reportFile;
 
-    public File getReportFile() {
-        return reportFile;
-    }
-
-    public void setReportFile(File reportFile) {
-        this.reportFile = reportFile;
+    @Override
+    public void withUploadedFiles(List<UploadedFile> uploadedFiles) {
+        if (!uploadedFiles.isEmpty()) {
+            this.reportFile = uploadedFiles.get(0);
+        }
     }
 }

--- a/src/main/java/ca/openosp/openo/report/pageUtil/ManagePatientLetters2Action.java
+++ b/src/main/java/ca/openosp/openo/report/pageUtil/ManagePatientLetters2Action.java
@@ -89,22 +89,20 @@ public class ManagePatientLetters2Action extends ActionSupport implements Upload
                 return SUCCESS;
             }
 
-            File rawReportFile = PathValidationUtils.toFile(reportFile);
-
             // Use PathValidationUtils to validate the uploaded file is in temp directory
-            if (!PathValidationUtils.isInAllowedTempDirectory(rawReportFile)) {
-                log.error("Attempted path traversal attack detected for file: " + rawReportFile.getPath());
+            if (!PathValidationUtils.isInAllowedTempDirectory(reportFileOnDisk)) {
+                log.error("Attempted path traversal attack detected for file: " + reportFileOnDisk.getPath());
                 throw new SecurityException("Invalid file upload - path traversal detected");
             }
 
             // Additional validation: ensure the file exists and is a regular file
-            if (!rawReportFile.exists() || !rawReportFile.isFile()) {
+            if (!reportFileOnDisk.exists() || !reportFileOnDisk.isFile()) {
                 log.error("Invalid file upload: File does not exist or is not a regular file");
                 return SUCCESS;
             }
 
             // Re-validate at point of use for static analysis visibility
-            File validatedReportFile = PathValidationUtils.validateUpload(rawReportFile);
+            File validatedReportFile = PathValidationUtils.validateUpload(reportFileOnDisk);
             fileData = Files.readAllBytes(validatedReportFile.toPath());
             String reportName = request.getParameter("reportName");
 
@@ -115,7 +113,7 @@ public class ManagePatientLetters2Action extends ActionSupport implements Upload
             JasperReport jasperReport = JasperCompileManager.compileReport(new ByteArrayInputStream(fileData));
 
             ManageLetters manageLetters = new ManageLetters();
-            manageLetters.saveReport((String) request.getSession().getAttribute("user"), reportName, rawReportFile.getName(), fileData);
+            manageLetters.saveReport((String) request.getSession().getAttribute("user"), reportName, reportFileOnDisk.getName(), fileData);
         } catch (FileNotFoundException ex) {
             MiscUtils.getLogger().error("Error", ex);
         } catch (IOException ex) {
@@ -135,11 +133,13 @@ public class ManagePatientLetters2Action extends ActionSupport implements Upload
     }
 
     private UploadedFile reportFile;
+    private File reportFileOnDisk;
 
     @Override
     public void withUploadedFiles(List<UploadedFile> uploadedFiles) {
         if (!uploadedFiles.isEmpty()) {
             this.reportFile = uploadedFiles.get(0);
+            this.reportFileOnDisk = PathValidationUtils.toFile(reportFile);
         }
     }
 }

--- a/src/main/java/ca/openosp/openo/report/reportByTemplate/actions/UploadTemplates2Action.java
+++ b/src/main/java/ca/openosp/openo/report/reportByTemplate/actions/UploadTemplates2Action.java
@@ -38,6 +38,8 @@ package ca.openosp.openo.report.reportByTemplate.actions;
 
 import ca.openosp.openo.services.security.SecurityManager;
 import org.apache.struts2.ActionSupport;
+import org.apache.struts2.action.UploadedFilesAware;
+import org.apache.struts2.dispatcher.multipart.UploadedFile;
 import org.apache.struts2.ServletActionContext;
 import ca.openosp.openo.utility.MiscUtils;
 import ca.openosp.openo.utility.PathValidationUtils;
@@ -49,8 +51,9 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.List;
 
-public class UploadTemplates2Action extends ActionSupport {
+public class UploadTemplates2Action extends ActionSupport implements UploadedFilesAware {
     HttpServletRequest request = ServletActionContext.getRequest();
     HttpServletResponse response = ServletActionContext.getResponse();
 
@@ -67,8 +70,9 @@ public class UploadTemplates2Action extends ActionSupport {
         
         if (templateFile != null) {
             try {
-                // Validate the uploaded temp file is from an allowed source
-                File validatedTemplateFile = PathValidationUtils.validateUpload(templateFile);
+                // Extract File from UploadedFile and validate
+                File rawTemplateFile = PathValidationUtils.toFile(templateFile);
+                File validatedTemplateFile = PathValidationUtils.validateUpload(rawTemplateFile);
 
                 // Read the file content
                 byte[] bytes = Files.readAllBytes(validatedTemplateFile.toPath());
@@ -100,13 +104,12 @@ public class UploadTemplates2Action extends ActionSupport {
         return SUCCESS;
     }
 
-    private File templateFile;
+    private UploadedFile templateFile;
 
-    public File getTemplateFile() {
-        return templateFile;
-    }
-
-    public void setTemplateFile(File templateFile) {
-        this.templateFile = templateFile;
+    @Override
+    public void withUploadedFiles(List<UploadedFile> uploadedFiles) {
+        if (!uploadedFiles.isEmpty()) {
+            this.templateFile = uploadedFiles.get(0);
+        }
     }
 }

--- a/src/main/java/ca/openosp/openo/report/reportByTemplate/actions/UploadTemplates2Action.java
+++ b/src/main/java/ca/openosp/openo/report/reportByTemplate/actions/UploadTemplates2Action.java
@@ -70,9 +70,8 @@ public class UploadTemplates2Action extends ActionSupport implements UploadedFil
         
         if (templateFile != null) {
             try {
-                // Extract File from UploadedFile and validate
-                File rawTemplateFile = PathValidationUtils.toFile(templateFile);
-                File validatedTemplateFile = PathValidationUtils.validateUpload(rawTemplateFile);
+                // Validate uploaded file
+                File validatedTemplateFile = PathValidationUtils.validateUpload(templateFileOnDisk);
 
                 // Read the file content
                 byte[] bytes = Files.readAllBytes(validatedTemplateFile.toPath());
@@ -105,11 +104,13 @@ public class UploadTemplates2Action extends ActionSupport implements UploadedFil
     }
 
     private UploadedFile templateFile;
+    private File templateFileOnDisk;
 
     @Override
     public void withUploadedFiles(List<UploadedFile> uploadedFiles) {
         if (!uploadedFiles.isEmpty()) {
             this.templateFile = uploadedFiles.get(0);
+            this.templateFileOnDisk = PathValidationUtils.toFile(templateFile);
         }
     }
 }

--- a/src/main/java/ca/openosp/openo/utility/PathValidationUtils.java
+++ b/src/main/java/ca/openosp/openo/utility/PathValidationUtils.java
@@ -14,10 +14,10 @@ import java.util.Set;
 /**
  * Utility class for validating file paths and uploaded files to prevent path traversal attacks.
  *
- * <p>Usage for extracting a {@link java.io.File} from a Struts 2 {@link UploadedFile}:</p>
+ * <p>Usage for extracting and validating a {@link java.io.File} from a Struts 2 {@link UploadedFile}:</p>
  * <pre>
- * File rawFile = PathValidationUtils.toFile(uploadedFile);
- * // Now safe to pass to validation or read methods
+ * File validatedFile = PathValidationUtils.toFile(uploadedFile);
+ * // File is validated — safe for direct use in file operations
  * </pre>
  *
  * <p>Usage for validating a user-provided filename (sanitizes and constructs safe path):</p>
@@ -119,25 +119,29 @@ public final class PathValidationUtils {
     // ========================================================================
 
     /**
-     * Extracts the underlying {@link java.io.File} from a Struts 2 {@link UploadedFile}.
+     * Extracts and validates the underlying {@link java.io.File} from a Struts 2 {@link UploadedFile}.
      *
      * <p>The {@link UploadedFile} interface returns {@link Object} from {@link UploadedFile#getContent()},
      * requiring a cast to {@link java.io.File}. This method centralizes that cast with a safety check
      * via {@link UploadedFile#isFile()}, avoiding raw casts scattered across action classes.</p>
      *
-     * <p>The returned {@link java.io.File} points to a temporary file created by the Struts 2
-     * {@code ActionFileUploadInterceptor}. It should be passed to the {@code validateUpload} methods
-     * in this class before being used for file operations.</p>
+     * <p>The returned {@link java.io.File} has been validated via {@link #validateUpload(File)} to
+     * confirm it resides in an allowed temp directory. Callers can use the result directly for
+     * file operations without additional source validation.</p>
      *
      * @param uploadedFile the Struts 2 uploaded file wrapper
-     * @return File the underlying temporary file
+     * @return File the validated underlying temporary file
      * @throws IllegalStateException if uploadedFile is null or its content is not a File
+     * @throws SecurityException if the file is not in an allowed temp directory
      */
     public static File toFile(UploadedFile uploadedFile) {
-        if (uploadedFile == null || !uploadedFile.isFile()) {
-            throw new IllegalStateException("UploadedFile content is not a File");
+        if (uploadedFile == null) {
+            throw new IllegalStateException("UploadedFile is null");
         }
-        return (File) uploadedFile.getContent();
+        if (!uploadedFile.isFile()) {
+            throw new IllegalStateException("UploadedFile content is not a File: " + uploadedFile.getOriginalName());
+        }
+        return validateUpload((File) uploadedFile.getContent());
     }
 
     /**

--- a/src/main/java/ca/openosp/openo/utility/PathValidationUtils.java
+++ b/src/main/java/ca/openosp/openo/utility/PathValidationUtils.java
@@ -139,7 +139,7 @@ public final class PathValidationUtils {
             throw new IllegalStateException("UploadedFile is null");
         }
         if (!uploadedFile.isFile()) {
-            throw new IllegalStateException("UploadedFile content is not a File: " + uploadedFile.getOriginalName());
+            throw new IllegalStateException("UploadedFile content is not a File");
         }
         return validateUpload((File) uploadedFile.getContent());
     }

--- a/src/main/java/ca/openosp/openo/utility/PathValidationUtils.java
+++ b/src/main/java/ca/openosp/openo/utility/PathValidationUtils.java
@@ -3,6 +3,7 @@ package ca.openosp.openo.utility;
 
 import org.apache.commons.io.FilenameUtils;
 import org.apache.logging.log4j.Logger;
+import org.apache.struts2.dispatcher.multipart.UploadedFile;
 
 import java.io.File;
 import java.io.IOException;
@@ -11,7 +12,13 @@ import java.util.LinkedHashSet;
 import java.util.Set;
 
 /**
- * Utility class for validating file paths to prevent path traversal attacks.
+ * Utility class for validating file paths and uploaded files to prevent path traversal attacks.
+ *
+ * <p>Usage for extracting a {@link java.io.File} from a Struts 2 {@link UploadedFile}:</p>
+ * <pre>
+ * File rawFile = PathValidationUtils.toFile(uploadedFile);
+ * // Now safe to pass to validation or read methods
+ * </pre>
  *
  * <p>Usage for validating a user-provided filename (sanitizes and constructs safe path):</p>
  * <pre>
@@ -110,6 +117,28 @@ public final class PathValidationUtils {
     // ========================================================================
     // UPLOAD VALIDATION - For validating uploaded files
     // ========================================================================
+
+    /**
+     * Extracts the underlying {@link java.io.File} from a Struts 2 {@link UploadedFile}.
+     *
+     * <p>The {@link UploadedFile} interface returns {@link Object} from {@link UploadedFile#getContent()},
+     * requiring a cast to {@link java.io.File}. This method centralizes that cast with a safety check
+     * via {@link UploadedFile#isFile()}, avoiding raw casts scattered across action classes.</p>
+     *
+     * <p>The returned {@link java.io.File} points to a temporary file created by the Struts 2
+     * {@code ActionFileUploadInterceptor}. It should be passed to the {@code validateUpload} methods
+     * in this class before being used for file operations.</p>
+     *
+     * @param uploadedFile the Struts 2 uploaded file wrapper
+     * @return File the underlying temporary file
+     * @throws IllegalStateException if uploadedFile is null or its content is not a File
+     */
+    public static File toFile(UploadedFile uploadedFile) {
+        if (uploadedFile == null || !uploadedFile.isFile()) {
+            throw new IllegalStateException("UploadedFile content is not a File");
+        }
+        return (File) uploadedFile.getContent();
+    }
 
     /**
      * Validates an uploaded source file is from an allowed temp location.

--- a/src/main/webapp/WEB-INF/classes/struts.xml
+++ b/src/main/webapp/WEB-INF/classes/struts.xml
@@ -23,7 +23,9 @@
                 remapping the interceptor name is insufficient because inherited stacks resolve names
                 against the defining package (struts-default), not the extending package.
 
-                Fix: Redefine defaultStack locally so the "fileUpload" ref resolves to the safe class.
+                Fix: Redefine defaultStack locally, removing the "fileUpload" ref entirely and keeping
+                only "actionFileUpload". The interceptor name remap above is retained as a safety net
+                in case any action config explicitly references "fileUpload" by name.
                 This stack mirrors struts-default.xml from Struts 6.8.0 — must be reviewed on upgrade.
 
                 Additional mitigation: all 30 upload actions implement UploadedFilesAware, old File
@@ -46,7 +48,6 @@
                 <interceptor-ref name="chain"/>
                 <interceptor-ref name="scopedModelDriven"/>
                 <interceptor-ref name="modelDriven"/>
-                <interceptor-ref name="fileUpload"/>
                 <interceptor-ref name="actionFileUpload"/>
                 <interceptor-ref name="checkbox"/>
                 <interceptor-ref name="datetime"/>

--- a/src/main/webapp/WEB-INF/classes/struts.xml
+++ b/src/main/webapp/WEB-INF/classes/struts.xml
@@ -14,6 +14,69 @@
     <constant name="struts.multipart.maxSize" value="524288000" />
     <!-- Default package extending struts-default -->
 	<package name="default" namespace="/" extends="struts-default">
+        <interceptors>
+            <!--
+                CVE-2024-53677: Replace the vulnerable FileUploadInterceptor with ActionFileUploadInterceptor.
+
+                The old FileUploadInterceptor pushes attacker-controlled multipart field names into the
+                OGNL parameter pipeline regardless of whether the action has matching setters. Simply
+                remapping the interceptor name is insufficient because inherited stacks resolve names
+                against the defining package (struts-default), not the extending package.
+
+                Fix: Redefine defaultStack locally so the "fileUpload" ref resolves to the safe class.
+                This stack mirrors struts-default.xml from Struts 6.8.0 — must be reviewed on upgrade.
+
+                Additional mitigation: all 30 upload actions implement UploadedFilesAware, old File
+                setters are removed, and PathValidationUtils.toFile() centralizes extraction.
+
+                Remove this block when upgrading to Struts 7+ (which drops FileUploadInterceptor).
+            -->
+            <interceptor name="fileUpload" class="org.apache.struts2.interceptor.ActionFileUploadInterceptor"/>
+            <interceptor-stack name="defaultStack">
+                <interceptor-ref name="exception"/>
+                <interceptor-ref name="alias"/>
+                <interceptor-ref name="servletConfig"/>
+                <interceptor-ref name="httpMethod"/>
+                <interceptor-ref name="i18n"/>
+                <interceptor-ref name="csp">
+                    <param name="disabled">false</param>
+                    <param name="enforcingMode">false</param>
+                </interceptor-ref>
+                <interceptor-ref name="prepare"/>
+                <interceptor-ref name="chain"/>
+                <interceptor-ref name="scopedModelDriven"/>
+                <interceptor-ref name="modelDriven"/>
+                <interceptor-ref name="fileUpload"/>
+                <interceptor-ref name="actionFileUpload"/>
+                <interceptor-ref name="checkbox"/>
+                <interceptor-ref name="datetime"/>
+                <interceptor-ref name="multiselect"/>
+                <interceptor-ref name="staticParams"/>
+                <interceptor-ref name="actionMappingParams"/>
+                <interceptor-ref name="params"/>
+                <interceptor-ref name="conversionError"/>
+                <interceptor-ref name="coep">
+                    <param name="disabled">false</param>
+                    <param name="enforcingMode">false</param>
+                    <param name="exemptedPaths"/>
+                </interceptor-ref>
+                <interceptor-ref name="coop">
+                    <param name="disabled">false</param>
+                    <param name="exemptedPaths"/>
+                    <param name="mode">same-origin</param>
+                </interceptor-ref>
+                <interceptor-ref name="fetchMetadata">
+                    <param name="disabled">false</param>
+                </interceptor-ref>
+                <interceptor-ref name="validation">
+                    <param name="excludeMethods">input,back,cancel,browse</param>
+                </interceptor-ref>
+                <interceptor-ref name="workflow">
+                    <param name="excludeMethods">input,back,cancel,browse</param>
+                </interceptor-ref>
+                <interceptor-ref name="debugging"/>
+            </interceptor-stack>
+        </interceptors>
         <action name="logout" class="ca.openosp.openo.login.Logout2Action">
             <result name="success">/index.jsp</result>
             <result name="logoutsso">/ssoLogin.do?method=ssoLogout</result>

--- a/src/main/webapp/WEB-INF/classes/struts.xml
+++ b/src/main/webapp/WEB-INF/classes/struts.xml
@@ -1179,7 +1179,6 @@
             <result name="continue">/oscarEncounter/oscarMeasurements/DisplayMeasurementStyleSheet.jsp</result>
         </action>
         <action name="oscarEncounter/oscarMeasurements/AddMeasurementStyleSheet" class="ca.openosp.openo.encounter.oscarMeasurements.pageUtil.EctAddMeasurementStyleSheet2Action">
-            <interceptor-ref name="fileUpload" />
             <interceptor-ref name="defaultStack"/>
             <result name="success">/oscarEncounter/oscarMeasurements/AddMeasurementStyleSheet.jsp</result>
         </action>
@@ -1384,7 +1383,6 @@
         </action>
         <action name="dxCodeSearchJSON" class="ca.openosp.openo.dxresearch.pageUtil.dxCodeSearchJSON2Action"/>
         <action name="oscarResearch/oscarDxResearch/dxResearchLoadAssociations" class="ca.openosp.openo.dxresearch.pageUtil.dxResearchLoadAssociations2Action">
-            <interceptor-ref name="fileUpload" />
             <interceptor-ref name="defaultStack"/>
             <result name="success">/oscarResearch/oscarDxResearch/dxResearchSelectAssociations.jsp</result>
         </action>
@@ -1499,7 +1497,6 @@
             <result name="success">/demographic/AddAlternateContact.jsp</result>
         </action>
         <action name="form/importUpload" class="ca.openosp.openo.demographic.pageUtil.ImportDemographicDataAction42Action">
-            <interceptor-ref name="fileUpload" />
             <interceptor-ref name="defaultStack"/>
             <result name="success">/demographic/demographicImport.jsp</result>
         </action>
@@ -1624,7 +1621,6 @@
             <result name="success">/lab/CA/ALL/uploadComplete.jsp</result>
         </action>
         <action name="lab/CA/ALL/insideLabUpload" class="ca.openosp.openo.lab.ca.all.pageUtil.InsideLabUpload2Action">
-            <interceptor-ref name="fileUpload" />
             <interceptor-ref name="defaultStack"/>
             <result name="success">/lab/CA/ALL/testUploader.jsp</result>
             <result name="input">/lab/CA/ALL/testUploader.jsp</result>
@@ -1864,9 +1860,8 @@
         </action>
         <action name="OscarChartPrint" class="ca.openosp.openo.casemgmt.web.EChartPrint2Action"/>
         <action name="ClientImage" class="ca.openosp.openo.casemgmt.web.ClientImage2Action" method="execute">
-            <interceptor-ref name="defaultStack"/>
-            <interceptor-ref name="fileUpload">
-                <param name="allowedTypes">image/jpeg,image/gif</param>
+            <interceptor-ref name="defaultStack">
+                <param name="actionFileUpload.allowedTypes">image/jpeg,image/gif</param>
             </interceptor-ref>
             <result name="success">/casemgmt/uploadimage.jsp</result>
         </action>
@@ -2177,7 +2172,6 @@
         <action name="renal/Renal" class="ca.openosp.openo.renal.web.Renal2Action"/>
         <action name="admin/GenerateTraceAction" class="ca.openosp.openo.admin.traceability.GenerateTrace2Action"/>
         <action name="admin/GenerateTraceabilityReportAction" class="ca.openosp.openo.admin.traceability.GenerateTraceabilityReport2Action">
-            <interceptor-ref name="fileUpload" />
             <interceptor-ref name="defaultStack"/>
         </action>
         <action name="mcedt/mcedt" class="ca.openosp.openo.integration.mcedt.Resource2Action">

--- a/src/main/webapp/WEB-INF/classes/struts.xml
+++ b/src/main/webapp/WEB-INF/classes/struts.xml
@@ -1864,6 +1864,7 @@
                 <param name="actionFileUpload.allowedTypes">image/jpeg,image/gif</param>
             </interceptor-ref>
             <result name="success">/casemgmt/uploadimage.jsp</result>
+            <result name="input">/casemgmt/uploadimage.jsp</result>
         </action>
         <action name="OnCallQuestionnaire" class="ca.openosp.openo.casemgmt.web.OnCallQuestionnaire2Action">
             <result name="form">/casemgmt/OnCallQuestionnaireForm.jsp</result>

--- a/src/main/webapp/eform/efmformmanager.jsp
+++ b/src/main/webapp/eform/efmformmanager.jsp
@@ -26,6 +26,7 @@
 <!DOCTYPE html>
 <%@ page import="ca.openosp.openo.eform.data.*, ca.openosp.openo.eform.*, java.util.*" %>
 <%@ page import="ca.openosp.openo.eform.EFormUtil" %>
+<%@ page import="org.owasp.encoder.Encode" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 
 <%
@@ -181,7 +182,7 @@
             %>
             <tr>
                 <td><%if (curForm.get("formFileName") != null && curForm.get("formFileName").toString().length() != 0) {%><i
-                        class="icon-file" title="<%=curForm.get("formFileName").toString()%>"></i><%}%></td>
+                        class="icon-file" title="<%=Encode.forHtmlAttribute(curForm.get("formFileName").toString())%>"></i><%}%></td>
                 <td title="<%=curForm.get("formName")%>">
                     <a href="#"
                        onclick="newWindow('<%= request.getContextPath() %>/eform/efmshowform_data.jsp?fid=<%=curForm.get("fid")%>', '<%="Form"+i%>'); return false;"><%=curForm.get("formName")%>

--- a/src/main/webapp/eform/efmformmanagerdeleted.jsp
+++ b/src/main/webapp/eform/efmformmanagerdeleted.jsp
@@ -25,6 +25,7 @@
 --%>
 <%@ page import="ca.openosp.openo.eform.data.*, ca.openosp.openo.eform.*, java.util.*" %>
 <%@ page import="ca.openosp.openo.eform.EFormUtil" %>
+<%@ page import="org.owasp.encoder.Encode" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 
 <%
@@ -94,7 +95,7 @@
                    onclick="newWindow('<%= request.getContextPath() %>/eform/efmshowform_data.jsp?fid=<%=curForm.get("fid")%>', '<%="FormD"+i%>'); return false;"><%=curForm.get("formName")%>
             </a></td>
             <td><%=curForm.get("formSubject")%>&nbsp;</td>
-            <td><%=curForm.get("formFileName")%>
+            <td><%=Encode.forHtmlContent(curForm.get("formFileName") != null ? curForm.get("formFileName").toString() : "")%>
             </td>
             <td><%=curForm.get("formDate")%>
             </td>

--- a/src/main/webapp/eform/efmmanageformgroups.jsp
+++ b/src/main/webapp/eform/efmmanageformgroups.jsp
@@ -26,6 +26,7 @@
 <%@page import="java.net.URLEncoder" %>
 <%@ page import="ca.openosp.openo.eform.data.*, ca.openosp.openo.eform.*, java.util.*" %>
 <%@ page import="ca.openosp.openo.eform.EFormUtil" %>
+<%@ page import="org.owasp.encoder.Encode" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 
 <%
@@ -186,7 +187,7 @@
                                 HashMap<String, ? extends Object> curForm = eForms.get(i);
                 %>
                 <tr rel="popover" data-html="true" data-title="<%=curForm.get("formName")%>"
-                    data-content="<strong><fmt:setBundle basename="oscarResources"/><fmt:message key="eform.uploadhtml.btnSubject"/>:</strong><br> <%=curForm.get("formSubject")%> <br> <small><fmt:setBundle basename="oscarResources"/><fmt:message key="eform.uploadhtml.btnFile"/>: <%=curForm.get("formFileName")%></small>"
+                    data-content="<strong><fmt:setBundle basename="oscarResources"/><fmt:message key="eform.uploadhtml.btnSubject"/>:</strong><br> <%=Encode.forHtmlContent(curForm.get("formSubject") != null ? curForm.get("formSubject").toString() : "")%> <br> <small><fmt:setBundle basename="oscarResources"/><fmt:message key="eform.uploadhtml.btnFile"/>: <%=Encode.forHtmlContent(curForm.get("formFileName") != null ? curForm.get("formFileName").toString() : "")%></small>"
                     data-trigger="hover" data-placement="bottom">
 
                     <td>

--- a/src/main/webapp/eform/partials/upload_image.jsp
+++ b/src/main/webapp/eform/partials/upload_image.jsp
@@ -83,7 +83,7 @@
             <button type="button" class="close" data-dismiss="alert">&times;</button>
             <strong>Success!</strong> Your image was uploaded.
             <c:if test="${ not empty sanitizedFileName }">
-                <br/>Saved as: <strong>${Encode.formHtmlContent(sanitizedFileName)}</strong>
+                <br/>Saved as: <strong>${Encode.forHtmlContent(sanitizedFileName)}</strong>
             </c:if>
         </div>
         <script>


### PR DESCRIPTION
## Summary

  - Migrates all 30 Struts2 file upload actions from the deprecated FileUploadInterceptor (OGNL-based) to the secure ActionFileUploadInterceptor (callback-based) to mitigate a CVE
  - Adds PathValidationUtils.toFile() to centralize UploadedFile → File extraction
  - Redefines the defaultStack in struts.xml to prevent the vulnerable interceptor from loading
  - Adds null guards across upload actions to handle empty upload submissions gracefully
  - Adds OWASP output encoding for eForm filenames to prevent stored XSS
  - Fixes stream leaks in UploadLoginText2Action and HRMUploadKey2Action with try-with-resources
  - Removes untrusted filename data from PathValidationUtils exception messages

  Fixes #2389

##  Problem

 The connected CVE is a path traversal vulnerability in the Struts2 FileUploadInterceptor. The old interceptor pushes
  attacker-controlled multipart field names into the OGNL parameter pipeline via ac.getParameters().appendAll(),
  regardless of whether the action has matching setters. This allows crafted field names to be evaluated as OGNL
  expressions by the ParametersInterceptor later in the stack.

  The Struts 6.8.0 defaultStack includes both the old FileUploadInterceptor and the new ActionFileUploadInterceptor, so both run on every request unless the stack is explicitly overridden.

##  Solution

  ### Per-action migration (primary mitigation):
  - All 30 upload actions now implement UploadedFilesAware and receive files via the withUploadedFiles() callback
  - Old File fields and OGNL-injectable getter/setter pairs (setFile(File), setFileFileName(String),
  setFileContentType(String)) are removed
  - UploadedFile fields store the raw upload; File xxxOnDisk fields store the extracted file via
  PathValidationUtils.toFile()
  - File extraction happens once in withUploadedFiles() for single-file actions; multi-file actions (HRM,
  InsideLabUpload) extract in their processing loops

### Null safety for empty uploads:
  - The old FileUploadInterceptor set fields via setters even when no file was uploaded; the new UploadedFilesAware callback only sets fields when the list is non-empty, leaving them null
  - Added null guards in 11 actions to return proper error responses instead of NPEs: UploadLoginText,
  ImportDemographicData, EctAddMeasurementStyleSheet, ScheduleOfBenefitsUpload, BillingDocumentErrorReportUpload, HRMUploadKey, AddEditDocument, FrmXmlUpload, HtmlUpload, Update (mcedt), GenerateTraceabilityReport

  ### Stored XSS fix:
  - eForm manager JSPs (efmformmanager.jsp, efmformmanagerdeleted.jsp, efmmanageformgroups.jsp) rendered user-uploaded filenames without encoding
  - Added OWASP Encode.forHtmlContent() / Encode.forHtmlAttribute() to all formFileName output points


###  Interceptor-level mitigation (defense-in-depth):
  - struts.xml remaps the fileUpload interceptor name to ActionFileUploadInterceptor and redefines the full
  defaultStack locally, since inherited stacks resolve interceptor names against the defining package
  (struts-default), not the extending package
  - Verified via debug logging: the old FileUploadInterceptor no longer appears in the interceptor chain

  ▎ Note: The defaultStack redefinition in struts.xml mirrors struts-default.xml from Struts 6.8.0. This block must
  be reviewed on Struts upgrades and should be removed entirely when upgrading to Struts 7+, which drops
  FileUploadInterceptor.

##  Test plan

  - Verify all 30 upload actions accept valid files through their JSP forms
  - Verify upload actions return proper error messages (not 500s) when submitted without a file
  - Verify ClientImage2Action rejects non-jpeg/gif uploads (content type enforcement)
  - Verify eForm manager pages display filenames with special characters safely (no XSS)
  - Verify no FileUploadInterceptor log lines appear with debug logging enabled for org.apache.struts2.interceptor
  - Verify non-upload actions are unaffected (login, encounter, scheduling workflows)

## Summary by Sourcery

Migrate Struts2 file upload handling to the secure callback-based API and remove use of the deprecated OGNL-based interceptor to address a file upload vulnerability.

Bug Fixes:
- Eliminate use of the vulnerable FileUploadInterceptor from the interceptor stack and action mappings in favor of ActionFileUploadInterceptor with appropriate configuration for allowed content types.
- Correct HTML encoding in the image upload JSP to safely render uploaded filenames.

Enhancements:
- Adopt UploadedFilesAware and UploadedFile across all upload-related actions, centralizing extraction and validation of underlying File instances through PathValidationUtils.toFile().
- Refine file handling in various upload flows, including improved null/zero-length checks and safer stream management.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mitigates CVE-2024-53677 by moving all file uploads from the OGNL-based `org.apache.struts2.interceptor.FileUploadInterceptor` to the callback-based `org.apache.struts2.interceptor.ActionFileUploadInterceptor`. All upload actions now use `UploadedFilesAware` with centralized, validated file extraction and path checks.

- **Bug Fixes**
  - Replaced the vulnerable interceptor with `org.apache.struts2.interceptor.ActionFileUploadInterceptor` and redefined the local `defaultStack` in `struts.xml` to keep the old interceptor out of the chain; remapped `fileUpload` to the new interceptor as a safety net.
  - Migrated all upload actions to `UploadedFilesAware`; removed OGNL-injectable setters and now extract `File` via `PathValidationUtils.toFile()` with temp-dir and path normalization validation.
  - Restored filename/content-type propagation via `withUploadedFiles(...)`; tightened ClientImage to allow only jpeg/gif via `actionFileUpload.allowedTypes` and added an `input` result to match previous rejection behavior.
  - Strengthened safety: added null guards for upload fields, adopted try-with-resources for streams, removed untrusted data from exception messages, and applied OWASP Encoder output encoding in eForm JSPs (filenames/attributes); fixed the `upload_image.jsp` encoder call to `Encode.forHtmlContent(...)`.

- **Migration**
  - On future Struts upgrades, review the local `defaultStack` override; remove it entirely on Struts 7+ (the old interceptor is dropped).
  - For any new upload action, implement `UploadedFilesAware` and use `PathValidationUtils.toFile()` + `validateUpload(...)` before reading or writing files.

<sup>Written for commit d2c4dd8423d655e415943dfdd5548859b2b106b9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized multipart uploads across the app to use Struts2 multipart handling for more consistent upload behavior.
  * Consolidated interceptor configuration to streamline upload processing.

* **Enhancements**
  * Added safer server-side file validation utilities for improved upload handling.

* **Bug Fixes**
  * Fixed view encoding for uploaded filenames to prevent incorrect HTML output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->