### PR TITLE
Chore: fix Maven repository resolution order and update .gitignore   

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,9 @@ __pycache__/
 .editorconfig
 .claude
 CLAUDE.md
+.classpath
+.factorypath
+.project
 
 # Docusaurus
 /website/node_modules/

--- a/pom.xml
+++ b/pom.xml
@@ -63,9 +63,10 @@
             <url>https://repo.maven.apache.org/maven2</url>
         </repository>
 
-        <!-- for the com.github.openosp htmltopdf dependency only. Upgrades
-        from this dependency are welcome. Listed last to avoid JitPack intercepting
-        Maven Central artifacts (JitPack is queried for all groupIds, not just com.github.*) -->
+        <!-- Primarily needed for com.github.openosp:ultrabuk-htmltopdf-java.
+        Listed last so Maven Central is queried first — Maven resolves repositories
+        in declaration order and JitPack will be queried for all groupIds, not just
+        com.github.*. Upgrades from this dependency are welcome. -->
         <repository>
             <id>jitpack.io</id>
             <url>https://jitpack.io</url>

--- a/pom.xml
+++ b/pom.xml
@@ -58,15 +58,17 @@
             <url>file://${basedir}/local_repo</url>
         </repository>
 
-        <!-- for the com.github.openosp htmltopdf dependency only. Upgrades
-        from this dependency are welcome -->
-        <repository>
-            <id>jitpack.io</id>
-            <url>https://jitpack.io</url>
-        </repository>
         <repository>
             <id>central</id>
             <url>https://repo.maven.apache.org/maven2</url>
+        </repository>
+
+        <!-- for the com.github.openosp htmltopdf dependency only. Upgrades
+        from this dependency are welcome. Listed last to avoid JitPack intercepting
+        Maven Central artifacts (JitPack is queried for all groupIds, not just com.github.*) -->
+        <repository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
## Summary

- Move Maven Central repository above JitPack in pom.xml to fix artifact resolution order                                                          
 - Add Eclipse IDE project files (.classpath, .factorypath, .project) to .gitignore
                                                                                                                                                       
## Problem       
A JAR dependency was returning a 404 during builds. The root cause appears to be JitPack being listed before Maven Central in the repository order, Maven queries repositories in declaration order, so JitPack was intercepting resolution for artifacts it doesn't actually host. This likely resulted in JitPack caching or overwriting the artifact reference with a broken version, causing the 404. Removing the broken JAR and fixing the repository order resolved the issue.

Additionally, Eclipse IDE project files were not in .gitignore, risking accidental commits of developer-specific config. This is apparent even outside of the Eclipse IDE, such as within VSCode, as certain extensions like Microsoft's "Extension Pack for Java" will pull in these files                           
   
## Solution                                                                                                                                                           
Reordered pom.xml repositories so Maven Central is queried first, with JitPack listed last only for the com.github.openosp htmltopdf dependency.   
Added a comment explaining the ordering rationale to prevent future reordering. Added Eclipse project files to .gitignore.

## Summary by Sourcery

Adjust Maven repository resolution order and ignore Eclipse-specific project files.

Build:
- Reorder Maven repositories so Maven Central is queried before JitPack, with documentation clarifying the intended order.

Chores:
- Add Eclipse IDE project files to .gitignore to prevent committing local IDE configuration.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reordered repositories in `pom.xml` to query Maven Central before JitPack, fixing incorrect artifact resolution and build 404s. Clarified the JitPack comment (primarily for `com.github.openosp:ultrabuk-htmltopdf-java` and listed last due to Maven’s resolution order) and added Eclipse files (`.classpath`, `.factorypath`, `.project`) to `.gitignore`.

<sup>Written for commit bef4b047b9f7f2df31a3440d51f0741fe42f1410. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Adjust Maven repository configuration and ignore IDE-specific project files.

Build:
- Reorder Maven repositories so Maven Central is preferred over JitPack and document the intended resolution order.

Chores:
- Add Eclipse IDE project files to .gitignore to avoid committing local IDE configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added additional IDE metadata patterns to ignore, reducing repository clutter.
  * Adjusted build repository ordering and updated inline repository note to reflect the intended dependency source ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->