### PR TITLE
Security: phase 2 Path Traversal remediation

### DIFF
--- a/src/main/java/ca/openosp/openo/billing/CA/ON/web/MoveMOHFiles2Action.java
+++ b/src/main/java/ca/openosp/openo/billing/CA/ON/web/MoveMOHFiles2Action.java
@@ -205,7 +205,8 @@ public class MoveMOHFiles2Action extends ActionSupport {
         return null;
     }
 
-    return new File(folderPath, fileName);
+    File folder = new File(folderPath);
+    return PathValidationUtils.validatePath(fileName, folder);
     }
 
     /**

--- a/src/main/java/ca/openosp/openo/billing/CA/ON/web/MoveMOHFiles2Action.java
+++ b/src/main/java/ca/openosp/openo/billing/CA/ON/web/MoveMOHFiles2Action.java
@@ -209,7 +209,7 @@ public class MoveMOHFiles2Action extends ActionSupport {
     try {
         return PathValidationUtils.validatePath(fileName, folder);
     } catch (SecurityException e) {
-        logger.warn("Invalid file path rejected: " + fileName, e);
+        logger.warn("Invalid file path rejected", e);
         return null;
     }
     }

--- a/src/main/java/ca/openosp/openo/billing/CA/ON/web/MoveMOHFiles2Action.java
+++ b/src/main/java/ca/openosp/openo/billing/CA/ON/web/MoveMOHFiles2Action.java
@@ -206,7 +206,12 @@ public class MoveMOHFiles2Action extends ActionSupport {
     }
 
     File folder = new File(folderPath);
-    return PathValidationUtils.validatePath(fileName, folder);
+    try {
+        return PathValidationUtils.validatePath(fileName, folder);
+    } catch (SecurityException e) {
+        logger.warn("Invalid file path rejected: " + fileName, e);
+        return null;
+    }
     }
 
     /**

--- a/src/main/java/ca/openosp/openo/billings/MSP/DocumentTeleplanReportUploadServlet.java
+++ b/src/main/java/ca/openosp/openo/billings/MSP/DocumentTeleplanReportUploadServlet.java
@@ -42,6 +42,7 @@ import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 
 import ca.openosp.openo.utility.MiscUtils;
+import ca.openosp.openo.utility.PathValidationUtils;
 
 import ca.openosp.DocumentBean;
 
@@ -121,7 +122,9 @@ public class DocumentTeleplanReportUploadServlet extends HttpServlet {
                         filename = filename.substring(filename.lastIndexOf('\\') + 1, filename.lastIndexOf('\"'));
 
                         fileheader = filename;
-                        fos = new FileOutputStream(foldername + filename);
+                        File folderDir = new File(foldername);
+                        File validatedFile = PathValidationUtils.validatePath(filename, folderDir);
+                        fos = new FileOutputStream(validatedFile);
                         dest = new BufferedOutputStream(fos, BUFFER);
                     }
                     c = sis.readLine(data2, 0, BUFFER);

--- a/src/main/java/ca/openosp/openo/billings/MSP/ExtractBean.java
+++ b/src/main/java/ca/openosp/openo/billings/MSP/ExtractBean.java
@@ -32,6 +32,7 @@ import ca.openosp.openo.billing.CA.BC.model.LogTeleplanTx;
 import ca.openosp.openo.commn.dao.BillingDao;
 import ca.openosp.openo.commn.model.Billing;
 import ca.openosp.openo.utility.MiscUtils;
+import ca.openosp.openo.utility.PathValidationUtils;
 import ca.openosp.openo.utility.SpringUtils;
 import ca.openosp.OscarProperties;
 import ca.openosp.openo.entities.Billingmaster;
@@ -379,7 +380,9 @@ public class ExtractBean extends Object implements Serializable {
 
             FileOutputStream out;
 
-            out = new FileOutputStream(home_dir + ohipFilename);
+            File homeDir = new File(home_dir);
+            File validatedFile = PathValidationUtils.validatePath(ohipFilename, homeDir);
+            out = new FileOutputStream(validatedFile);
             PrintStream p;
             p = new PrintStream(out);
             p.println(value1);
@@ -405,7 +408,9 @@ public class ExtractBean extends Object implements Serializable {
 
 
             FileOutputStream out1;
-            out1 = new FileOutputStream(home_dir1 + htmlFilename);
+            File homeDir1 = new File(home_dir1);
+            File validatedFile1 = PathValidationUtils.validatePath(htmlFilename, homeDir1);
+            out1 = new FileOutputStream(validatedFile1);
             PrintStream p1;
             p1 = new PrintStream(out1);
 

--- a/src/main/java/ca/openosp/openo/billings/OHIP/ExtractBean.java
+++ b/src/main/java/ca/openosp/openo/billings/OHIP/ExtractBean.java
@@ -25,6 +25,7 @@
 
 package ca.openosp.openo.billings.OHIP;
 
+import java.io.File;
 import java.io.FileOutputStream;
 import java.io.PrintStream;
 import java.io.Serializable;
@@ -41,6 +42,7 @@ import ca.openosp.openo.commn.dao.BillingDao;
 import ca.openosp.openo.commn.model.Billing;
 import ca.openosp.openo.utility.DateRange;
 import ca.openosp.openo.utility.MiscUtils;
+import ca.openosp.openo.utility.PathValidationUtils;
 import ca.openosp.openo.utility.SpringUtils;
 
 import ca.openosp.OscarProperties;
@@ -553,9 +555,10 @@ public class ExtractBean extends Object implements Serializable {
     // write OHIP file to it
     public void writeFile(String value1) {
         try {
-            String home_dir;
-            home_dir = OscarProperties.getInstance().getProperty("HOME_DIR");
-            FileOutputStream out = new FileOutputStream(home_dir + ohipFilename);
+            String home_dir = OscarProperties.getInstance().getProperty("HOME_DIR");
+            File homeDir = new File(home_dir);
+            File validatedFile = PathValidationUtils.validatePath(ohipFilename, homeDir);
+            FileOutputStream out = new FileOutputStream(validatedFile);
             PrintStream p = new PrintStream(out);
             p.println(value1);
 
@@ -570,25 +573,15 @@ public class ExtractBean extends Object implements Serializable {
     // OscarDocument/.../billing/download/, and then write to it
     public void writeHtml(String htmlvalue1) {
         try {
-            String home_dir1;
-			/*
-			String userHomePath1 = System.getProperty("user.home", "user.dir");
+            String home_dir = OscarProperties.getInstance().getProperty("HOME_DIR");
+            File homeDir = new File(home_dir);
+            File validatedFile = PathValidationUtils.validatePath(htmlFilename, homeDir);
+            FileOutputStream out = new FileOutputStream(validatedFile);
+            PrintStream p = new PrintStream(out);
+            p.println(htmlvalue1);
 
-			File pFile1 = new File(userHomePath1, oscar_home);
-			FileInputStream pStream1 = new FileInputStream(pFile1.getPath());
-			Properties ap1 = new Properties();
-			ap1.load(pStream1);
-			pStream1.close();
-			*/
-            home_dir1 = OscarProperties.getInstance().getProperty("HOME_DIR");
-
-            FileOutputStream out1 = new FileOutputStream(home_dir1
-                    + htmlFilename);
-            PrintStream p1 = new PrintStream(out1);
-            p1.println(htmlvalue1);
-
-            p1.close();
-            out1.close();
+            p.close();
+            out.close();
         } catch (Exception e) {
             logger.error("Unexpected error", e);
         }

--- a/src/main/java/ca/openosp/openo/billings/ca/bc/MSP/DocumentTeleplanReportUploadServlet.java
+++ b/src/main/java/ca/openosp/openo/billings/ca/bc/MSP/DocumentTeleplanReportUploadServlet.java
@@ -43,6 +43,7 @@ import org.apache.commons.fileupload.DiskFileUpload;
 import org.apache.commons.fileupload.FileItem;
 import org.apache.commons.fileupload.FileUploadException;
 import ca.openosp.openo.utility.MiscUtils;
+import ca.openosp.openo.utility.PathValidationUtils;
 
 import ca.openosp.DocumentBean;
 import ca.openosp.OscarProperties;
@@ -152,7 +153,9 @@ public class DocumentTeleplanReportUploadServlet extends HttpServlet {
                         filename = filename.substring(filename.lastIndexOf('\\')+1,filename.lastIndexOf('\"'));
 
                         fileheader = filename;
-                        fos = new FileOutputStream(foldername+ filename);
+                        File folderDir = new File(foldername);
+                        File validatedFile = PathValidationUtils.validatePath(filename, folderDir);
+                        fos = new FileOutputStream(validatedFile);
                         dest = new BufferedOutputStream(fos, BUFFER);
                     }
                     c =sis.readLine(data2, 0, BUFFER);

--- a/src/main/java/ca/openosp/openo/billings/ca/bc/MSP/DocumentTeleplanReportUploadServlet.java
+++ b/src/main/java/ca/openosp/openo/billings/ca/bc/MSP/DocumentTeleplanReportUploadServlet.java
@@ -96,11 +96,10 @@ public class DocumentTeleplanReportUploadServlet extends HttpServlet {
                 } else {
                     String pathName = item.getName();
                     String[] fullFile = pathName.split("[/|\\\\]");
-                    File savedFile = new File(foldername, fullFile[fullFile.length - 1]);
-
                     fileheader = fullFile[fullFile.length - 1];
-
-                    item.write(savedFile);
+                    File folderDir = new File(foldername);
+                    File validatedFile = PathValidationUtils.validatePath(fileheader, folderDir);
+                    item.write(validatedFile);
                 }
             }
         } catch (FileUploadException e) {

--- a/src/main/java/ca/openosp/openo/billings/ca/bc/MSP/ExtractBean.java
+++ b/src/main/java/ca/openosp/openo/billings/ca/bc/MSP/ExtractBean.java
@@ -35,6 +35,7 @@ import ca.openosp.openo.commn.dao.BillingServiceDao;
 import ca.openosp.openo.commn.model.Billing;
 import ca.openosp.openo.utility.DateRange;
 import ca.openosp.openo.utility.MiscUtils;
+import ca.openosp.openo.utility.PathValidationUtils;
 import ca.openosp.openo.utility.SpringUtils;
 import ca.openosp.Misc;
 import ca.openosp.OscarProperties;
@@ -42,6 +43,7 @@ import ca.openosp.openo.entities.Billingmaster;
 import ca.openosp.openo.billings.ca.bc.data.BillingmasterDAO;
 import ca.openosp.openo.util.ConversionUtils;
 
+import java.io.File;
 import java.io.FileOutputStream;
 import java.io.PrintStream;
 import java.io.Serializable;
@@ -323,8 +325,9 @@ public class ExtractBean extends Object implements Serializable {
     public void writeFile(String value1) {
         try {
             String home_dir = OscarProperties.getInstance().getProperty("HOME_DIR");
-
-            FileOutputStream out = new FileOutputStream(home_dir + ohipFilename);
+            File homeDir = new File(home_dir);
+            File validatedFile = PathValidationUtils.validatePath(ohipFilename, homeDir);
+            FileOutputStream out = new FileOutputStream(validatedFile);
             PrintStream p = new PrintStream(out);
             p.println(value1);
             p.close();
@@ -337,7 +340,9 @@ public class ExtractBean extends Object implements Serializable {
         if (eFlag.equals("1")) {
             try {
                 String home_dir = OscarProperties.getInstance().getProperty("HOME_DIR");
-                FileOutputStream out = new FileOutputStream(home_dir + htmlFilename);
+                File homeDir = new File(home_dir);
+                File validatedFile = PathValidationUtils.validatePath(htmlFilename, homeDir);
+                FileOutputStream out = new FileOutputStream(validatedFile);
                 PrintStream p = new PrintStream(out);
                 p.println(htmlvalue1);
                 p.close();

--- a/src/main/java/ca/openosp/openo/billings/ca/on/OHIP/ExtractBean.java
+++ b/src/main/java/ca/openosp/openo/billings/ca/on/OHIP/ExtractBean.java
@@ -25,6 +25,7 @@
 
 package ca.openosp.openo.billings.ca.on.OHIP;
 
+import java.io.File;
 import java.io.FileOutputStream;
 import java.io.PrintStream;
 import java.io.Serializable;
@@ -41,6 +42,7 @@ import ca.openosp.openo.commn.dao.BillingDao;
 import ca.openosp.openo.commn.model.Billing;
 import ca.openosp.openo.utility.DateRange;
 import ca.openosp.openo.utility.MiscUtils;
+import ca.openosp.openo.utility.PathValidationUtils;
 import ca.openosp.openo.utility.SpringUtils;
 
 import ca.openosp.OscarProperties;
@@ -518,9 +520,10 @@ public class ExtractBean implements Serializable {
     // write OHIP file to it
     public void writeFile(String value1) {
         try {
-            String home_dir;
-            home_dir = OscarProperties.getInstance().getProperty("HOME_DIR");
-            FileOutputStream out = new FileOutputStream(home_dir + ohipFilename);
+            String home_dir = OscarProperties.getInstance().getProperty("HOME_DIR");
+            File homeDir = new File(home_dir);
+            File validatedFile = PathValidationUtils.validatePath(ohipFilename, homeDir);
+            FileOutputStream out = new FileOutputStream(validatedFile);
             PrintStream p = new PrintStream(out);
             p.println(value1);
 
@@ -535,15 +538,15 @@ public class ExtractBean implements Serializable {
     // OscarDocument/.../billing/download/, and then write to it
     public void writeHtml(String htmlvalue1) {
         try {
-            String home_dir1;
-            home_dir1 = OscarProperties.getInstance().getProperty("HOME_DIR");
+            String home_dir = OscarProperties.getInstance().getProperty("HOME_DIR");
+            File homeDir = new File(home_dir);
+            File validatedFile = PathValidationUtils.validatePath(htmlFilename, homeDir);
+            FileOutputStream out = new FileOutputStream(validatedFile);
+            PrintStream p = new PrintStream(out);
+            p.println(htmlvalue1);
 
-            FileOutputStream out1 = new FileOutputStream(home_dir1 + htmlFilename);
-            PrintStream p1 = new PrintStream(out1);
-            p1.println(htmlvalue1);
-
-            p1.close();
-            out1.close();
+            p.close();
+            out.close();
         } catch (Exception e) {
             logger.error("Write HTML File Error!!!", e);
         }

--- a/src/main/java/ca/openosp/openo/billings/ca/on/data/JdbcBillingCreateBillingFile.java
+++ b/src/main/java/ca/openosp/openo/billings/ca/on/data/JdbcBillingCreateBillingFile.java
@@ -897,7 +897,9 @@ public class JdbcBillingCreateBillingFile {
         propBillingNo = new Properties();
         RandomAccessFile raf = null;
         try {
-            raf = new RandomAccessFile(home_dir + ohipFilename, "r");
+            File homeDir = new File(home_dir);
+            File validatedFile = PathValidationUtils.validatePath(ohipFilename, homeDir);
+            raf = new RandomAccessFile(validatedFile, "r");
             do {
                 String lineValue = raf.readLine();
                 if (lineValue == null) {
@@ -937,12 +939,13 @@ public class JdbcBillingCreateBillingFile {
     public void renameFile() {
         String home_dir;
         home_dir = OscarProperties.getInstance().getProperty("HOME_DIR");
-        File file = new File(home_dir + ohipFilename);
+        File homeDir = new File(home_dir);
+        File file = PathValidationUtils.validatePath(ohipFilename, homeDir);
 
         // new filename
         String newName = ohipFilename + "." + GregorianCalendar.getInstance().getTimeInMillis();
 
-        File file2 = new File(home_dir + newName);
+        File file2 = PathValidationUtils.validatePath(newName, homeDir);
 
         boolean success = file.renameTo(file2);
         if (!success) {

--- a/src/main/java/ca/openosp/openo/billings/ca/on/data/JdbcBillingCreateBillingFile.java
+++ b/src/main/java/ca/openosp/openo/billings/ca/on/data/JdbcBillingCreateBillingFile.java
@@ -924,6 +924,9 @@ public class JdbcBillingCreateBillingFile {
                 }
             } while (true);
 
+        } catch (SecurityException e) {
+            _logger.error("Security violation reading OHIP file", e);
+            throw e;
         } catch (Exception e) {
             _logger.error("Read OHIP File Error");
         } finally {

--- a/src/main/java/ca/openosp/openo/billings/ca/on/data/JdbcBillingCreateBillingFile.java
+++ b/src/main/java/ca/openosp/openo/billings/ca/on/data/JdbcBillingCreateBillingFile.java
@@ -54,6 +54,7 @@ import ca.openosp.openo.managers.DemographicManager;
 import ca.openosp.openo.utility.DateRange;
 import ca.openosp.openo.utility.LoggedInInfo;
 import ca.openosp.openo.utility.MiscUtils;
+import ca.openosp.openo.utility.PathValidationUtils;
 import ca.openosp.openo.utility.SpringUtils;
 
 import ca.openosp.OscarProperties;
@@ -952,9 +953,10 @@ public class JdbcBillingCreateBillingFile {
     // write OHIP file to it
     public void writeFile(String value1) {
         try {
-            String home_dir;
-            home_dir = OscarProperties.getInstance().getProperty("HOME_DIR");
-            FileOutputStream out = new FileOutputStream(home_dir + ohipFilename);
+            String home_dir = OscarProperties.getInstance().getProperty("HOME_DIR");
+            File homeDir = new File(home_dir);
+            File validatedFile = PathValidationUtils.validatePath(ohipFilename, homeDir);
+            FileOutputStream out = new FileOutputStream(validatedFile);
             PrintStream p = new PrintStream(out);
             p.println(value1);
 
@@ -969,15 +971,15 @@ public class JdbcBillingCreateBillingFile {
     // OscarDocument/.../billing/download/, and then write to it
     public void writeHtml(String htmlvalue1) {
         try {
-            String home_dir1;
-            home_dir1 = OscarProperties.getInstance().getProperty("HOME_DIR");
+            String home_dir = OscarProperties.getInstance().getProperty("HOME_DIR");
+            File homeDir = new File(home_dir);
+            File validatedFile = PathValidationUtils.validatePath(htmlFilename, homeDir);
+            FileOutputStream out = new FileOutputStream(validatedFile);
+            PrintStream p = new PrintStream(out);
+            p.println(htmlvalue1);
 
-            FileOutputStream out1 = new FileOutputStream(home_dir1 + htmlFilename);
-            PrintStream p1 = new PrintStream(out1);
-            p1.println(htmlvalue1);
-
-            p1.close();
-            out1.close();
+            p.close();
+            out.close();
         } catch (Exception e) {
             _logger.error("Write HTML File Error!!!", e);
         }

--- a/src/main/java/ca/openosp/openo/commn/model/Document.java
+++ b/src/main/java/ca/openosp/openo/commn/model/Document.java
@@ -58,6 +58,7 @@ import javax.persistence.TemporalType;
 import javax.persistence.Transient;
 
 import ca.openosp.OscarProperties;
+import ca.openosp.openo.utility.PathValidationUtils;
 import org.apache.commons.io.FileUtils;
 
 /**
@@ -423,8 +424,9 @@ public class Document extends AbstractModel<Integer> implements Serializable {
      * @returns a string representing the path of the file on disk, i.e. document_dir+'/'+filename
      */
     public String getDocumentFileFullPath() {
-        String docDir = OscarProperties.getInstance().getProperty("DOCUMENT_DIR");
-        return (docDir + '/' + docfilename);
+        File docDir = new File(OscarProperties.getInstance().getProperty("DOCUMENT_DIR"));
+        File validatedFile = PathValidationUtils.validatePath(this.docfilename, docDir);
+        return validatedFile.getPath();
     }
 
     public byte[] getDocumentFileContentsAsBytes() throws IOException {

--- a/src/main/java/ca/openosp/openo/demographic/pageUtil/DemographicExportAction42Action.java
+++ b/src/main/java/ca/openosp/openo/demographic/pageUtil/DemographicExportAction42Action.java
@@ -114,6 +114,7 @@ import ca.openosp.openo.hospitalReportManager.model.HRMDocumentToProvider;
 import ca.openosp.openo.managers.SecurityInfoManager;
 import ca.openosp.openo.utility.LoggedInInfo;
 import ca.openosp.openo.utility.MiscUtils;
+import ca.openosp.openo.utility.PathValidationUtils;
 import ca.openosp.openo.utility.SpringUtils;
 import ca.openosp.openo.utility.WebUtils;
 import org.w3c.dom.Document;
@@ -2527,7 +2528,7 @@ public class DemographicExportAction42Action extends ActionSupport {
                             String expFile = demographic.getFirstName() + "_" + demographic.getLastName();
                             expFile += "_" + demoNo;
                             expFile += "_" + demographic.getDateOfBirth() + demographic.getMonthOfBirth() + demographic.getYearOfBirth();
-                            files.add(new File(directory, expFile + ".xml"));
+                            files.add(PathValidationUtils.validatePath(expFile + ".xml", directory));
                             dirs.add(getProviderName(demographic.getProviderNo()));
                         } catch (Exception e) {
                             logger.error("Error", e);

--- a/src/main/java/ca/openosp/openo/digitalsignature/DigitalSignature2Action.java
+++ b/src/main/java/ca/openosp/openo/digitalsignature/DigitalSignature2Action.java
@@ -79,6 +79,10 @@ public class DigitalSignature2Action extends ActionSupport {
 
         if (signatureKey != null) {
             String filename = DigitalSignatureUtils.getTempFilePath(signatureKey);
+            if (filename == null || filename.isEmpty()) {
+                response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid signature request ID");
+                return null;
+            }
 
             if ("IPAD".equalsIgnoreCase(uploadSource) && imageString != null && !imageString.isEmpty()) {
                 try (FileOutputStream fos = new FileOutputStream(filename)) {

--- a/src/main/java/ca/openosp/openo/documentManager/EDoc.java
+++ b/src/main/java/ca/openosp/openo/documentManager/EDoc.java
@@ -33,6 +33,7 @@ import ca.openosp.openo.commn.model.CtlDocumentPK;
 import ca.openosp.openo.commn.model.Document;
 import ca.openosp.openo.commn.model.Provider;
 import ca.openosp.openo.utility.MiscUtils;
+import ca.openosp.openo.utility.PathValidationUtils;
 import ca.openosp.MyDateFormat;
 import ca.openosp.OscarProperties;
 import ca.openosp.openo.tags.TagObject;
@@ -217,8 +218,9 @@ public class EDoc extends TagObject implements Comparable<EDoc> {
     public String getFilePath() {
 
         if (this.filePath == null) {
-            this.filePath = OscarProperties.getInstance().getProperty("DOCUMENT_DIR");
-            this.filePath = String.format("%1$s%2$s%3$s", this.filePath, File.separator, this.getFileName());
+            File docDir = new File(OscarProperties.getInstance().getProperty("DOCUMENT_DIR"));
+            File validatedFile = PathValidationUtils.validatePath(this.getFileName(), docDir);
+            this.filePath = validatedFile.getPath();
         }
         return this.filePath;
 

--- a/src/main/java/ca/openosp/openo/documentManager/IncomingDocUtil.java
+++ b/src/main/java/ca/openosp/openo/documentManager/IncomingDocUtil.java
@@ -121,6 +121,9 @@ public final class IncomingDocUtil {
     }
 
     public static String getIncomingDocumentFilePathName(String queueId, String pdfDir, String pdfName) {
+        if (pdfName == null || pdfName.isEmpty()) {
+            throw new IllegalArgumentException("pdfName cannot be null or empty");
+        }
         String filePathName = getIncomingDocumentFilePath(queueId, pdfDir);
 
         File baseDir = new File(filePathName);
@@ -130,6 +133,9 @@ public final class IncomingDocUtil {
     }
 
     public static String getAndCreateIncomingDocumentFilePathName(String queueId, String pdfDir, String pdfName) {
+        if (pdfName == null || pdfName.isEmpty()) {
+            throw new IllegalArgumentException("pdfName cannot be null or empty");
+        }
         String filePathName = getAndCreateIncomingDocumentFilePath(queueId, pdfDir);
 
         File baseDir = new File(filePathName);
@@ -144,6 +150,10 @@ public final class IncomingDocUtil {
         String basePath = OscarProperties.getInstance().getProperty("INCOMINGDOCUMENT_DIR");
         if (basePath == null || basePath.isEmpty()) {
             throw new IllegalStateException("INCOMINGDOCUMENT_DIR property not configured");
+        }
+
+        if (queueId == null || queueId.isEmpty()) {
+            throw new IllegalArgumentException("queueId cannot be null or empty");
         }
 
         // Validate queueId as a path component within INCOMINGDOCUMENT_DIR
@@ -188,6 +198,10 @@ public final class IncomingDocUtil {
             throw new IllegalStateException("INCOMINGDOCUMENT_DIR property not configured");
         }
 
+        if (queueId == null || queueId.isEmpty()) {
+            throw new IllegalArgumentException("queueId cannot be null or empty");
+        }
+
         // Validate queueId as a path component within INCOMINGDOCUMENT_DIR
         File baseDir = new File(basePath);
         File queueDir = PathValidationUtils.validatePath(queueId, baseDir);
@@ -211,11 +225,8 @@ public final class IncomingDocUtil {
 
         File filePathDir = new File(filePath);
 
-        if (!filePathDir.exists()) {
-            boolean created = filePathDir.mkdirs();
-            if (!created) {
-                logger.warn("Failed to create directory: " + filePathDir.getPath());
-            }
+        if (!filePathDir.exists() && !filePathDir.mkdirs() && !filePathDir.isDirectory()) {
+            throw new IllegalStateException("Failed to create directory: " + filePathDir.getPath());
         }
 
         return filePathDir.getPath();
@@ -229,9 +240,10 @@ public final class IncomingDocUtil {
 
         String basePath = getIncomingDocumentFilePath(queueId, myPdfDir);
         File baseDir = new File(basePath);
-        File tempFile = PathValidationUtils.validatePath("T" + myPdfName, baseDir);
+        String safePdfName = PathValidationUtils.validatePath(myPdfName, baseDir).getName();
+        File tempFile = PathValidationUtils.validatePath("T" + safePdfName, baseDir);
         tempFilePathName = tempFile.getPath();
-        filePathName = getIncomingDocumentFilePathName(queueId, myPdfDir, myPdfName);
+        filePathName = getIncomingDocumentFilePathName(queueId, myPdfDir, safePdfName);
 
         File f = new File(filePathName);
         lastModified = f.lastModified();
@@ -288,9 +300,10 @@ public final class IncomingDocUtil {
 
         String basePath = getIncomingDocumentFilePath(queueId, myPdfDir);
         File baseDir = new File(basePath);
-        File tempFile = PathValidationUtils.validatePath("T" + myPdfName, baseDir);
+        String safePdfName = PathValidationUtils.validatePath(myPdfName, baseDir).getName();
+        File tempFile = PathValidationUtils.validatePath("T" + safePdfName, baseDir);
         tempFilePathName = tempFile.getPath();
-        filePathName = getIncomingDocumentFilePathName(queueId, myPdfDir, myPdfName);
+        filePathName = getIncomingDocumentFilePathName(queueId, myPdfDir, safePdfName);
 
         File f = new File(filePathName);
         lastModified = f.lastModified();
@@ -346,9 +359,10 @@ public final class IncomingDocUtil {
 
         String basePath = getIncomingDocumentFilePath(queueId, myPdfDir);
         File baseDir = new File(basePath);
-        File tempFile = PathValidationUtils.validatePath("T" + myPdfName, baseDir);
+        String safePdfName = PathValidationUtils.validatePath(myPdfName, baseDir).getName();
+        File tempFile = PathValidationUtils.validatePath("T" + safePdfName, baseDir);
         tempFilePathName = tempFile.getPath();
-        filePathName = getIncomingDocumentFilePathName(queueId, myPdfDir, myPdfName);
+        filePathName = getIncomingDocumentFilePathName(queueId, myPdfDir, safePdfName);
 
         File f = new File(filePathName);
         lastModified = f.lastModified();
@@ -356,10 +370,10 @@ public final class IncomingDocUtil {
 
         String deletePath = getIncomingDocumentDeletedFilePath(queueId, myPdfDir) + File.separator;
         String deletePathFileName = "";
-        int index = myPdfName.indexOf(".pdf");
+        int index = safePdfName.indexOf(".pdf");
 
-        String myPdfNameF = myPdfName.substring(0, index);
-        String myPdfNameExt = myPdfName.substring(index, myPdfName.length());
+        String myPdfNameF = safePdfName.substring(0, index);
+        String myPdfNameExt = safePdfName.substring(index, safePdfName.length());
 
         PdfReader reader = null;
         Document document = null;
@@ -434,18 +448,19 @@ public final class IncomingDocUtil {
 
         String basePath = getIncomingDocumentFilePath(queueId, myPdfDir);
         File baseDir = new File(basePath);
-        File tempFile = PathValidationUtils.validatePath("T" + myPdfName, baseDir);
+        String safePdfName = PathValidationUtils.validatePath(myPdfName, baseDir).getName();
+        File tempFile = PathValidationUtils.validatePath("T" + safePdfName, baseDir);
         tempFilePathName = tempFile.getPath();
-        filePathName = getIncomingDocumentFilePathName(queueId, myPdfDir, myPdfName);
+        filePathName = getIncomingDocumentFilePathName(queueId, myPdfDir, safePdfName);
 
         File f = new File(filePathName);
         lastModified = f.lastModified();
         f.setReadOnly();
 
         String extractBasePath = getIncomingDocumentFilePath(queueId, myPdfDir);
-        int index = myPdfName.toLowerCase().indexOf(".pdf");
-        String myPdfNameF = myPdfName.substring(0, index);
-        String myPdfNameExt = myPdfName.substring(index, myPdfName.length());
+        int index = safePdfName.toLowerCase().indexOf(".pdf");
+        String myPdfNameF = safePdfName.substring(0, index);
+        String myPdfNameExt = safePdfName.substring(index, safePdfName.length());
 
         ArrayList<String> extractList = new ArrayList<String>();
         int startPage, endPage;

--- a/src/main/java/ca/openosp/openo/documentManager/IncomingDocUtil.java
+++ b/src/main/java/ca/openosp/openo/documentManager/IncomingDocUtil.java
@@ -54,46 +54,6 @@ import org.apache.logging.log4j.Logger;
 public final class IncomingDocUtil {
     private static final Logger logger = MiscUtils.getLogger();
     
-    /**
-     * Validates that a path component does not contain path traversal sequences.
-     * Delegates to PathValidationUtils for consistent validation.
-     * @param pathComponent The path component to validate
-     * @return true if the component is safe, false otherwise
-     */
-    private static boolean isValidPathComponent(String pathComponent) {
-        if (pathComponent == null || pathComponent.isEmpty()) {
-            return false;
-        }
-
-        // Use PathValidationUtils to validate - try to construct a safe path
-        try {
-            File tempDir = new File(System.getProperty("java.io.tmpdir"));
-            PathValidationUtils.validatePath(pathComponent, tempDir);
-            return true;
-        } catch (SecurityException e) {
-            return false;
-        }
-    }
-
-    /**
-     * Validates that a constructed path is within the allowed base directory.
-     * Delegates to PathValidationUtils for consistent validation.
-     * @param basePath The base directory path
-     * @param targetPath The path to validate
-     * @return true if the path is within bounds, false otherwise
-     */
-    private static boolean isPathWithinBounds(String basePath, String targetPath) {
-        try {
-            File baseDir = new File(basePath).getCanonicalFile();
-            File targetFile = new File(targetPath).getCanonicalFile();
-            PathValidationUtils.validateExistingPath(targetFile, baseDir);
-            return true;
-        } catch (SecurityException | IOException e) {
-            logger.error("Error validating path bounds", e);
-            return false;
-        }
-    }
-
     private ArrayList<String> pdfListModifiedDate = new ArrayList<String>();
     private static final Comparator<File> lastModified = new Comparator<File>() {
         @Override
@@ -161,63 +121,35 @@ public final class IncomingDocUtil {
     }
 
     public static String getIncomingDocumentFilePathName(String queueId, String pdfDir, String pdfName) {
-        // Validate pdfName to prevent path traversal
-        if (!isValidPathComponent(pdfName)) {
-            throw new IllegalArgumentException("Invalid pdfName: contains illegal characters or path traversal sequences");
-        }
-        
         String filePathName = getIncomingDocumentFilePath(queueId, pdfDir);
-        
-        // Use File constructor to safely combine paths
-        File file = new File(filePathName, pdfName);
-        
-        // Validate the final path is within bounds
-        String baseDir = OscarProperties.getInstance().getProperty("INCOMINGDOCUMENT_DIR");
-        if (!isPathWithinBounds(baseDir, file.getPath())) {
-            throw new SecurityException("Attempted path traversal detected in file path");
-        }
-        
-        return file.getPath();
+
+        File baseDir = new File(filePathName);
+        File validatedFile = PathValidationUtils.validatePath(pdfName, baseDir);
+
+        return validatedFile.getPath();
     }
 
     public static String getAndCreateIncomingDocumentFilePathName(String queueId, String pdfDir, String pdfName) {
-        // Validate pdfName to prevent path traversal
-        if (!isValidPathComponent(pdfName)) {
-            throw new IllegalArgumentException("Invalid pdfName: contains illegal characters or path traversal sequences");
-        }
-        
         String filePathName = getAndCreateIncomingDocumentFilePath(queueId, pdfDir);
-        
-        // Use File constructor to safely combine paths
-        File file = new File(filePathName, pdfName);
-        
-        // Validate the final path is within bounds
-        String baseDir = OscarProperties.getInstance().getProperty("INCOMINGDOCUMENT_DIR");
-        if (!isPathWithinBounds(baseDir, file.getPath())) {
-            throw new SecurityException("Attempted path traversal detected in file path");
-        }
-        
-        return file.getPath();
+
+        File baseDir = new File(filePathName);
+        File validatedFile = PathValidationUtils.validatePath(pdfName, baseDir);
+
+        return validatedFile.getPath();
     }
 
     public static String getIncomingDocumentDeletedFilePath(String queueId, String pdfDir) {
         String filePath;
 
-        filePath = OscarProperties.getInstance().getProperty("INCOMINGDOCUMENT_DIR");
-        if (filePath == null || filePath.isEmpty()) {
+        String basePath = OscarProperties.getInstance().getProperty("INCOMINGDOCUMENT_DIR");
+        if (basePath == null || basePath.isEmpty()) {
             throw new IllegalStateException("INCOMINGDOCUMENT_DIR property not configured");
         }
 
-        if (!filePath.endsWith(File.separator)) {
-            filePath += File.separator;
-        }
-        
-        // Validate queueId to prevent path traversal
-        if (!isValidPathComponent(queueId)) {
-            throw new IllegalArgumentException("Invalid queueId: contains illegal characters or path traversal sequences");
-        }
-        
-        filePath += queueId + File.separator;
+        // Validate queueId as a path component within INCOMINGDOCUMENT_DIR
+        File baseDir = new File(basePath);
+        File queueDir = PathValidationUtils.validatePath(queueId, baseDir);
+        filePath = queueDir.getPath() + File.separator;
         
         // Validate pdfDir and restrict to allowed values
         if (pdfDir != null && (pdfDir.equals("Fax")
@@ -226,11 +158,11 @@ public final class IncomingDocUtil {
                 || pdfDir.equals("Refile"))) {
             
             try {
-                File baseDir = new File(OscarProperties.getInstance().getProperty("INCOMINGDOCUMENT_DIR"));
+                File incomingDir = new File(OscarProperties.getInstance().getProperty("INCOMINGDOCUMENT_DIR"));
                 File deletedPathDir = new File(filePath, pdfDir + "_deleted");
 
                 // Validate path is within bounds using PathValidationUtils
-                PathValidationUtils.validateExistingPath(deletedPathDir, baseDir);
+                PathValidationUtils.validateExistingPath(deletedPathDir, incomingDir);
 
                 File canonicalDeletedDir = deletedPathDir.getCanonicalFile();
 
@@ -250,73 +182,43 @@ public final class IncomingDocUtil {
     }
 
     public static String getIncomingDocumentFilePath(String queueId, String pdfDir) {
-        String filePath;
+        String basePath = OscarProperties.getInstance().getProperty("INCOMINGDOCUMENT_DIR");
 
-        filePath = OscarProperties.getInstance().getProperty("INCOMINGDOCUMENT_DIR");
-        
-        if (filePath == null || filePath.isEmpty()) {
+        if (basePath == null || basePath.isEmpty()) {
             throw new IllegalStateException("INCOMINGDOCUMENT_DIR property not configured");
         }
 
-        if (!filePath.endsWith(File.separator)) {
-            filePath += File.separator;
-        }
-        
-        // Validate queueId to prevent path traversal
-        if (!isValidPathComponent(queueId)) {
-            throw new IllegalArgumentException("Invalid queueId: contains illegal characters or path traversal sequences");
-        }
-
-        filePath += queueId + File.separator;
+        // Validate queueId as a path component within INCOMINGDOCUMENT_DIR
+        File baseDir = new File(basePath);
+        File queueDir = PathValidationUtils.validatePath(queueId, baseDir);
 
         // Validate pdfDir and restrict to allowed values
         if (pdfDir != null && (pdfDir.equals("Fax")
                 || pdfDir.equals("Mail")
                 || pdfDir.equals("File")
                 || pdfDir.equals("Refile"))) {
-            filePath = filePath + pdfDir;
+            return PathValidationUtils.validatePath(pdfDir, queueDir).getPath();
         } else if (pdfDir != null && !pdfDir.isEmpty()) {
-            // If pdfDir is provided but not in allowed list, throw exception
             throw new IllegalArgumentException("Invalid pdfDir: must be one of Fax, Mail, File, or Refile");
         }
 
-        return filePath;
+        return queueDir.getPath();
     }
 
     public static String getAndCreateIncomingDocumentFilePath(String queueId, String pdfDir) {
+        // getIncomingDocumentFilePath already validates via PathValidationUtils.validatePath
         String filePath = getIncomingDocumentFilePath(queueId, pdfDir);
-        
-        // Get the base directory for validation
-        String baseDir = OscarProperties.getInstance().getProperty("INCOMINGDOCUMENT_DIR");
-        if (baseDir == null || baseDir.isEmpty()) {
-            throw new IllegalStateException("INCOMINGDOCUMENT_DIR property not configured");
-        }
-        
-        // Validate the constructed path is within bounds
-        if (!isPathWithinBounds(baseDir, filePath)) {
-            throw new SecurityException("Attempted path traversal detected");
-        }
-        
+
         File filePathDir = new File(filePath);
-        
-        // Validate path is within bounds using PathValidationUtils
-        try {
-            File baseDirFile = new File(baseDir);
-            PathValidationUtils.validateExistingPath(filePathDir, baseDirFile);
 
-            File canonicalDir = filePathDir.getCanonicalFile();
-
-            if (!canonicalDir.exists()) {
-                boolean created = canonicalDir.mkdirs();
-                if (!created) {
-                    logger.warn("Failed to create directory: " + canonicalDir.getPath());
-                }
+        if (!filePathDir.exists()) {
+            boolean created = filePathDir.mkdirs();
+            if (!created) {
+                logger.warn("Failed to create directory: " + filePathDir.getPath());
             }
-
-            return canonicalDir.getPath();
-        } catch (IOException e) {
-            throw new SecurityException("Failed to validate directory path", e);
         }
+
+        return filePathDir.getPath();
     }
 
     public static void rotatePage(String queueId, String myPdfDir, String myPdfName, String MyPdfPageNumber, int degrees) throws Exception {
@@ -325,13 +227,9 @@ public final class IncomingDocUtil {
         int rot;
         int rotatedegrees;
 
-        // Validate myPdfName for temp file
-        if (!isValidPathComponent(myPdfName)) {
-            throw new IllegalArgumentException("Invalid myPdfName: contains illegal characters or path traversal sequences");
-        }
-        
         String basePath = getIncomingDocumentFilePath(queueId, myPdfDir);
-        File tempFile = new File(basePath, "T" + myPdfName);
+        File baseDir = new File(basePath);
+        File tempFile = PathValidationUtils.validatePath("T" + myPdfName, baseDir);
         tempFilePathName = tempFile.getPath();
         filePathName = getIncomingDocumentFilePathName(queueId, myPdfDir, myPdfName);
 
@@ -388,13 +286,9 @@ public final class IncomingDocUtil {
         int rot;
         int rotatedegrees;
 
-        // Validate myPdfName for temp file
-        if (!isValidPathComponent(myPdfName)) {
-            throw new IllegalArgumentException("Invalid myPdfName: contains illegal characters or path traversal sequences");
-        }
-        
         String basePath = getIncomingDocumentFilePath(queueId, myPdfDir);
-        File tempFile = new File(basePath, "T" + myPdfName);
+        File baseDir = new File(basePath);
+        File tempFile = PathValidationUtils.validatePath("T" + myPdfName, baseDir);
         tempFilePathName = tempFile.getPath();
         filePathName = getIncomingDocumentFilePathName(queueId, myPdfDir, myPdfName);
 
@@ -450,13 +344,9 @@ public final class IncomingDocUtil {
         long lastModified;
         String filePathName, tempFilePathName;
 
-        // Validate myPdfName for temp file
-        if (!isValidPathComponent(myPdfName)) {
-            throw new IllegalArgumentException("Invalid myPdfName: contains illegal characters or path traversal sequences");
-        }
-        
         String basePath = getIncomingDocumentFilePath(queueId, myPdfDir);
-        File tempFile = new File(basePath, "T" + myPdfName);
+        File baseDir = new File(basePath);
+        File tempFile = PathValidationUtils.validatePath("T" + myPdfName, baseDir);
         tempFilePathName = tempFile.getPath();
         filePathName = getIncomingDocumentFilePathName(queueId, myPdfDir, myPdfName);
 
@@ -542,13 +432,9 @@ public final class IncomingDocUtil {
         long lastModified;
         String filePathName, tempFilePathName;
 
-        // Validate myPdfName for temp file
-        if (!isValidPathComponent(myPdfName)) {
-            throw new IllegalArgumentException("Invalid myPdfName: contains illegal characters or path traversal sequences");
-        }
-        
         String basePath = getIncomingDocumentFilePath(queueId, myPdfDir);
-        File tempFile = new File(basePath, "T" + myPdfName);
+        File baseDir = new File(basePath);
+        File tempFile = PathValidationUtils.validatePath("T" + myPdfName, baseDir);
         tempFilePathName = tempFile.getPath();
         filePathName = getIncomingDocumentFilePathName(queueId, myPdfDir, myPdfName);
 
@@ -574,11 +460,8 @@ public final class IncomingDocUtil {
         try {
             reader = new PdfReader(filePathName);
             String extractFileName = myPdfNameF + "E" + Integer.toString(reader.getNumberOfPages()) + myPdfNameExt;
-            // Validate the extract filename
-            if (!isValidPathComponent(extractFileName)) {
-                throw new IllegalArgumentException("Invalid extract filename: contains illegal characters or path traversal sequences");
-            }
-            File extractFile = new File(extractBasePath, extractFileName);
+            File extractBaseDir = new File(extractBasePath);
+            File extractFile = PathValidationUtils.validatePath(extractFileName, extractBaseDir);
             extractPath = extractFile.getPath();
 
             for (int pgIndex = 0; pgIndex <= reader.getNumberOfPages(); pgIndex++) {
@@ -696,13 +579,9 @@ public final class IncomingDocUtil {
         filePathName = getIncomingDocumentFilePathName(queueId, myPdfDir, myPdfName);
         File f = new File(filePathName);
 
-        // Validate myPdfName to prevent path traversal
-        if (!isValidPathComponent(myPdfName)) {
-            throw new IllegalArgumentException("Invalid myPdfName: contains illegal characters or path traversal sequences");
-        }
-        
         String deletedPath = getIncomingDocumentDeletedFilePath(queueId, myPdfDir);
-        File deleteFile = new File(deletedPath, myPdfName);
+        File deletedDir = new File(deletedPath);
+        File deleteFile = PathValidationUtils.validatePath(myPdfName, deletedDir);
         String deletePathName = deleteFile.getPath();
 
         File deletef = new File(deletePathName);

--- a/src/main/java/ca/openosp/openo/documentManager/actions/DocumentUpload2Action.java
+++ b/src/main/java/ca/openosp/openo/documentManager/actions/DocumentUpload2Action.java
@@ -255,12 +255,6 @@ public class DocumentUpload2Action extends ActionSupport implements UploadedFile
             return false;
         }
 
-        // Check that filename doesn't contain path traversal sequences
-        if (fileName.contains("..") || fileName.contains("/") || fileName.contains("\\")) {
-            logger.error("Filename contains invalid path characters");
-            return false;
-        }
-
         String parentPath = IncomingDocUtil.getIncomingDocumentFilePath(queueId, PdfDir);
         if (!new File(parentPath).exists()) {
             return false;

--- a/src/main/java/ca/openosp/openo/eform/EFormExportZip.java
+++ b/src/main/java/ca/openosp/openo/eform/EFormExportZip.java
@@ -33,6 +33,7 @@ package ca.openosp.openo.eform;
 
 import org.apache.logging.log4j.Logger;
 import ca.openosp.openo.utility.MiscUtils;
+import ca.openosp.openo.utility.PathValidationUtils;
 import ca.openosp.OscarProperties;
 import ca.openosp.openo.eform.data.EForm;
 import ca.openosp.openo.eform.upload.ImageUpload2Action;
@@ -223,7 +224,7 @@ public class EFormExportZip {
                 _log.debug("going in eform table >" + newEForm.getFormFileName() + "<");
             } else {
                 //store temp files on HD
-                File tempFile = new File(imageTempFolderDir, file.getName());
+                File tempFile = PathValidationUtils.validatePath(file.getName(), imageTempFolderDir);
                 tempFiles.put(file.getName(), tempFile); //reference so we can find it later
                 FileOutputStream fos = new FileOutputStream(tempFile);
                 inputToOutput(zis, fos);
@@ -254,7 +255,7 @@ public class EFormExportZip {
                 //do not save file if eform fails
             } else {
                 FileInputStream fis = new FileInputStream(tempFile.getValue());
-                File imageFile = new File(ImageUpload2Action.getImageFolder(), tempFile.getKey());
+                File imageFile = PathValidationUtils.validatePath(tempFile.getKey(), ImageUpload2Action.getImageFolder());
                 if (imageFile.exists()) {
                     errors.add("Image '" + tempFile.getKey() + "' already exists, skipping image, but the form may still be uploaded.  Please resolve.");
                     _log.info("EForm Import: Image with name '" + tempFile.getKey() + "' already exists, skipping image, but the form may still be uploaded.  Please resolve.");

--- a/src/main/java/ca/openosp/openo/eform/actions/DisplayImage2Action.java
+++ b/src/main/java/ca/openosp/openo/eform/actions/DisplayImage2Action.java
@@ -94,6 +94,9 @@ public class DisplayImage2Action extends ActionSupport {
                 throw new Exception("Directory:  " + home_dir + " does not exist");
             }
             file = PathValidationUtils.validatePath(fileName, directory);
+            if (!file.isFile()) {
+                throw new Exception("Path is not a file: " + fileName);
+            }
         } catch (SecurityException e) {
             MiscUtils.getLogger().error("Error", e);
             throw new Exception("Could not open file " + fileName + ".  Check the file path", e);
@@ -214,20 +217,15 @@ public class DisplayImage2Action extends ActionSupport {
     public static File getImageFile(String imageFileName) throws Exception {
         String home_dir = OscarProperties.getInstance().getEformImageDirectory();
 
-        File file = null;
         try {
             File directory = new File(home_dir);
             if (!directory.exists()) {
                 throw new Exception("Directory:  " + home_dir + " does not exist");
             }
-            file = new File(directory, imageFileName);
-            //String canonicalPath = file.getParentFile().getCanonicalPath(); //absolute path of the retrieved file
-
-            if (!directory.equals(file.getParentFile())) {
-                MiscUtils.getLogger().debug("SECURITY WARNING: Illegal file path detected, client attempted to navigate away from the file directory");
-                throw new Exception("Could not open file " + imageFileName + ".  Check the file path");
-            }
-            return file;
+            return PathValidationUtils.validatePath(imageFileName, directory);
+        } catch (SecurityException e) {
+            MiscUtils.getLogger().error("Error", e);
+            throw new Exception("Could not open file " + imageFileName + ".  Check the file path", e);
         } catch (Exception e) {
             MiscUtils.getLogger().error("Error", e);
             throw new Exception("Could not open file " + home_dir + imageFileName + " does " + home_dir + " exist ?", e);

--- a/src/main/java/ca/openosp/openo/eform/actions/DisplayImage2Action.java
+++ b/src/main/java/ca/openosp/openo/eform/actions/DisplayImage2Action.java
@@ -32,6 +32,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.struts2.ServletActionContext;
 
 import ca.openosp.openo.utility.MiscUtils;
+import ca.openosp.openo.utility.PathValidationUtils;
 import ca.openosp.OscarProperties;
 
 import javax.activation.MimetypesFileTypeMap;
@@ -81,8 +82,8 @@ public class DisplayImage2Action extends ActionSupport {
     public StreamData process() throws Exception {
 
         String fileName = request.getParameter("imagefile");
-        if (fileName.contains("..") || fileName.contains("/") || fileName.contains("\\")) {
-            throw new IllegalArgumentException("Invalid filename");
+        if (fileName == null) {
+            throw new IllegalArgumentException("Missing imagefile parameter");
         }
         String home_dir = OscarProperties.getInstance().getEformImageDirectory();
 
@@ -92,12 +93,10 @@ public class DisplayImage2Action extends ActionSupport {
             if (!directory.exists()) {
                 throw new Exception("Directory:  " + home_dir + " does not exist");
             }
-            file = new File(directory, fileName);
-
-            if (!directory.equals(file.getParentFile())) {
-                MiscUtils.getLogger().debug("SECURITY WARNING: Illegal file path detected, client attempted to navigate away from the file directory");
-                throw new Exception("Could not open file " + fileName + ".  Check the file path");
-            }
+            file = PathValidationUtils.validatePath(fileName, directory);
+        } catch (SecurityException e) {
+            MiscUtils.getLogger().error("Error", e);
+            throw new Exception("Could not open file " + fileName + ".  Check the file path", e);
         } catch (Exception e) {
             MiscUtils.getLogger().error("Error", e);
             throw new Exception("Could not open file " + home_dir + fileName + " does " + home_dir + " exist ?", e);

--- a/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/pageUtil/ConsultationAttachDocs2Action.java
+++ b/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/pageUtil/ConsultationAttachDocs2Action.java
@@ -179,8 +179,13 @@ public class ConsultationAttachDocs2Action extends ActionSupport {
 
         // Validate and sanitize the file path to prevent path traversal attacks
         String documentDir = OscarProperties.getInstance().getProperty("DOCUMENT_DIR");
+        if (documentDir == null || documentDir.trim().isEmpty()) {
+            logger.error("DOCUMENT_DIR property not configured");
+            response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            return;
+        }
         File validatedFile = (fileName != null) ? PathValidationUtils.validatePath(fileName, new File(documentDir)) : null;
-        Path validatedPath = (validatedFile != null && validatedFile.exists()) ? validatedFile.toPath() : null;
+        Path validatedPath = (validatedFile != null && validatedFile.isFile()) ? validatedFile.toPath() : null;
         if (validatedPath == null) {
             logger.error("Invalid file path requested: " + fileName);
             response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
@@ -211,7 +216,8 @@ public class ConsultationAttachDocs2Action extends ActionSupport {
 
         String segmentID = request.getParameter("segmentID");
         if (segmentID == null || !segmentID.matches("^[0-9]+$")) {
-            throw new IllegalArgumentException("Invalid segmentID");
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            return;
         }
         request.setAttribute("segmentID", segmentID);
         try {
@@ -239,14 +245,11 @@ public class ConsultationAttachDocs2Action extends ActionSupport {
         String formId = request.getParameter("formId");
         String formName = request.getParameter("formName");
         String demographicNo = request.getParameter("demographicNo");
-        if (formId == null || !formId.matches("^[0-9]+$")) {
-            throw new IllegalArgumentException("Invalid formId");
-        }
-        if (demographicNo == null || !demographicNo.matches("^[0-9]+$")) {
-            throw new IllegalArgumentException("Invalid demographicNo");
-        }
-        if (formName == null || formName.isEmpty()) {
-            throw new IllegalArgumentException("Invalid formName");
+        if (formId == null || !formId.matches("^[0-9]+$")
+                || demographicNo == null || !demographicNo.matches("^[0-9]+$")
+                || formName == null || formName.isEmpty()) {
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            return;
         }
         // Encode params to prevent path injection in dispatcher URL
         String encodedFormName = java.net.URLEncoder.encode(formName, java.nio.charset.StandardCharsets.UTF_8);

--- a/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/pageUtil/ConsultationAttachDocs2Action.java
+++ b/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/pageUtil/ConsultationAttachDocs2Action.java
@@ -178,7 +178,9 @@ public class ConsultationAttachDocs2Action extends ActionSupport {
         String description = request.getParameter("description");
 
         // Validate and sanitize the file path to prevent path traversal attacks
-        Path validatedPath = validateDocumentPath(fileName);
+        String documentDir = OscarProperties.getInstance().getProperty("DOCUMENT_DIR");
+        File validatedFile = (fileName != null) ? PathValidationUtils.validatePath(fileName, new File(documentDir)) : null;
+        Path validatedPath = (validatedFile != null && validatedFile.exists()) ? validatedFile.toPath() : null;
         if (validatedPath == null) {
             logger.error("Invalid file path requested: " + fileName);
             response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
@@ -237,16 +239,29 @@ public class ConsultationAttachDocs2Action extends ActionSupport {
         String formId = request.getParameter("formId");
         String formName = request.getParameter("formName");
         String demographicNo = request.getParameter("demographicNo");
+        if (formId == null || !formId.matches("^[0-9]+$")) {
+            throw new IllegalArgumentException("Invalid formId");
+        }
+        if (demographicNo == null || !demographicNo.matches("^[0-9]+$")) {
+            throw new IllegalArgumentException("Invalid demographicNo");
+        }
+        if (formName == null || formName.isEmpty()) {
+            throw new IllegalArgumentException("Invalid formName");
+        }
+        // Encode params to prevent path injection in dispatcher URL
+        String encodedFormName = java.net.URLEncoder.encode(formName, java.nio.charset.StandardCharsets.UTF_8);
+        String encodedDemoNo = java.net.URLEncoder.encode(demographicNo, java.nio.charset.StandardCharsets.UTF_8);
+        String encodedFormId = java.net.URLEncoder.encode(formId, java.nio.charset.StandardCharsets.UTF_8);
         LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
         try {
             FormTransportContainer formTransportContainer = new FormTransportContainer(
                     response, request, "/form/forwardshortcutname.jsp"
                     + "?method=fetch&formname="
-                    + formName
+                    + encodedFormName
                     + "&demographic_no="
-                    + demographicNo
+                    + encodedDemoNo
                     + "&formId="
-                    + formId);
+                    + encodedFormId);
             formTransportContainer.setDemographicNo(demographicNo);
             formTransportContainer.setProviderNo(loggedInInfo.getLoggedInProviderNo());
             formTransportContainer.setSubject(formName + " Form ID " + formId);
@@ -305,62 +320,6 @@ public class ConsultationAttachDocs2Action extends ActionSupport {
             return getBase64(Files.readAllBytes(pdfPath));
         } catch (IOException e) {
             logger.error("An error occurred while processing the PDF file: " + e.getMessage(), e);
-            return null;
-        }
-    }
-
-    /**
-     * Validates and sanitizes a document file path to prevent path traversal attacks.
-     * Ensures the file is within the configured DOCUMENT_DIR directory.
-     * 
-     * @param fileName The file name to validate
-     * @return The validated absolute path, or null if invalid
-     */
-    private Path validateDocumentPath(String fileName) {
-        if (fileName == null || fileName.trim().isEmpty()) {
-            logger.error("Invalid file name: null or empty");
-            return null;
-        }
-
-        // Reject any file name containing path traversal sequences
-        if (fileName.contains("..") || fileName.contains(File.separator) || fileName.contains("/") || fileName.contains("\\")) {
-            logger.error("Path traversal attempt detected in file name: " + fileName);
-            return null;
-        }
-
-        try {
-            // Get the configured document directory
-            String documentDir = OscarProperties.getInstance().getProperty("DOCUMENT_DIR");
-            if (documentDir == null || documentDir.trim().isEmpty()) {
-                logger.error("DOCUMENT_DIR not configured in properties");
-                return null;
-            }
-
-            // Validate file path using PathValidationUtils
-            File baseDirFile = new File(documentDir);
-            File validatedFile;
-            try {
-                validatedFile = PathValidationUtils.validatePath(fileName, baseDirFile);
-            } catch (SecurityException e) {
-                logger.error("Path traversal attempt: resolved path escapes base directory");
-                return null;
-            }
-            Path filePath = validatedFile.toPath();
-            
-            // Verify the file exists and is a regular file
-            if (!Files.exists(filePath)) {
-                logger.warn("Document file does not exist: " + fileName);
-                return null;
-            }
-            
-            if (!Files.isRegularFile(filePath)) {
-                logger.error("Path is not a regular file: " + fileName);
-                return null;
-            }
-            
-            return filePath;
-        } catch (Exception e) {
-            logger.error("Error validating document path for file: " + fileName, e);
             return null;
         }
     }

--- a/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/pageUtil/ConsultationAttachDocs2Action.java
+++ b/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/pageUtil/ConsultationAttachDocs2Action.java
@@ -208,6 +208,9 @@ public class ConsultationAttachDocs2Action extends ActionSupport {
         //      to eforms and ticklers
 
         String segmentID = request.getParameter("segmentID");
+        if (segmentID == null || !segmentID.matches("^[0-9]+$")) {
+            throw new IllegalArgumentException("Invalid segmentID");
+        }
         request.setAttribute("segmentID", segmentID);
         try {
             File tempLabPDF = File.createTempFile("lab" + segmentID, "pdf");

--- a/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/pageUtil/ConsultationAttachDocs2Action.java
+++ b/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/pageUtil/ConsultationAttachDocs2Action.java
@@ -184,10 +184,17 @@ public class ConsultationAttachDocs2Action extends ActionSupport {
             response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
             return;
         }
-        File validatedFile = (fileName != null) ? PathValidationUtils.validatePath(fileName, new File(documentDir)) : null;
+        File validatedFile = null;
+        try {
+            validatedFile = (fileName != null) ? PathValidationUtils.validatePath(fileName, new File(documentDir)) : null;
+        } catch (SecurityException e) {
+            logger.warn("Rejected invalid document path request", e);
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            return;
+        }
         Path validatedPath = (validatedFile != null && validatedFile.isFile()) ? validatedFile.toPath() : null;
         if (validatedPath == null) {
-            logger.error("Invalid file path requested: " + fileName);
+            logger.error("Invalid file path requested");
             response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
             return;
         }

--- a/src/main/java/ca/openosp/openo/fax/action/Fax2Action.java
+++ b/src/main/java/ca/openosp/openo/fax/action/Fax2Action.java
@@ -256,7 +256,12 @@ public class Fax2Action extends ActionSupport {
         int page = 1;
         String jobId = request.getParameter("jobId");
         if (jobId != null && !jobId.isEmpty() && !jobId.matches("^[0-9]+$")) {
-            throw new IllegalArgumentException("Invalid jobId");
+            try {
+                response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid jobId");
+            } catch (IOException e) {
+                logger.error("Unable to send error response for invalid jobId", e);
+            }
+            return;
         }
         FaxJob faxJob = null;
 

--- a/src/main/java/ca/openosp/openo/fax/action/Fax2Action.java
+++ b/src/main/java/ca/openosp/openo/fax/action/Fax2Action.java
@@ -255,6 +255,9 @@ public class Fax2Action extends ActionSupport {
         Path outfile = null;
         int page = 1;
         String jobId = request.getParameter("jobId");
+        if (jobId != null && !jobId.isEmpty() && !jobId.matches("^[0-9]+$")) {
+            throw new IllegalArgumentException("Invalid jobId");
+        }
         FaxJob faxJob = null;
 
         if (jobId != null && !jobId.isEmpty()) {

--- a/src/main/java/ca/openosp/openo/fax/core/FaxImporter.java
+++ b/src/main/java/ca/openosp/openo/fax/core/FaxImporter.java
@@ -282,6 +282,8 @@ public class FaxImporter {
         filename = newDoc.getFileName();
         File docDir = new File(DOCUMENT_DIR);
         File validatedDest = PathValidationUtils.validatePath(filename, docDir);
+        filename = validatedDest.getName();
+        newDoc.setFileName(filename);
 
         if (Base64.decodeToFile(faxFile.getDocument(), validatedDest.getPath())) {
 

--- a/src/main/java/ca/openosp/openo/fax/core/FaxImporter.java
+++ b/src/main/java/ca/openosp/openo/fax/core/FaxImporter.java
@@ -55,6 +55,7 @@ import ca.openosp.openo.commn.model.FaxConfig;
 import ca.openosp.openo.commn.model.FaxJob;
 import ca.openosp.openo.commn.model.ProviderLabRoutingModel;
 import ca.openosp.openo.utility.MiscUtils;
+import ca.openosp.openo.utility.PathValidationUtils;
 import ca.openosp.openo.utility.SpringUtils;
 
 import com.itextpdf.text.pdf.codec.Base64;
@@ -279,8 +280,10 @@ public class FaxImporter {
         newDoc.setDocPublic("0");
 
         filename = newDoc.getFileName();
+        File docDir = new File(DOCUMENT_DIR);
+        File validatedDest = PathValidationUtils.validatePath(filename, docDir);
 
-        if (Base64.decodeToFile(faxFile.getDocument(), DOCUMENT_DIR + "/" + filename)) {
+        if (Base64.decodeToFile(faxFile.getDocument(), validatedDest.getPath())) {
 
             newDoc.setContentType("application/pdf");
             newDoc.setNumberOfPages(receivedFax.getNumPages());

--- a/src/main/java/ca/openosp/openo/lab/ca/all/pageUtil/OLISLabPDFCreator.java
+++ b/src/main/java/ca/openosp/openo/lab/ca/all/pageUtil/OLISLabPDFCreator.java
@@ -121,7 +121,7 @@ public class OLISLabPDFCreator extends PdfPageEventHelper {
             LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
 
             String uuidToAdd = request.getParameter("uuid");
-            if (uuidToAdd == null) {
+            if (uuidToAdd == null || uuidToAdd.trim().isEmpty()) {
                 throw new SecurityException("Invalid uuid parameter");
             }
             File tmpDir = new File(System.getProperty("java.io.tmpdir"));

--- a/src/main/java/ca/openosp/openo/lab/ca/all/pageUtil/OLISLabPDFCreator.java
+++ b/src/main/java/ca/openosp/openo/lab/ca/all/pageUtil/OLISLabPDFCreator.java
@@ -53,6 +53,9 @@ import ca.openosp.openo.lab.ca.all.Hl7textResultsData;
 import ca.openosp.openo.lab.ca.all.parsers.Factory;
 import ca.openosp.openo.lab.ca.all.parsers.OLISHL7Handler;
 import ca.openosp.openo.lab.ca.all.util.Utilities;
+import ca.openosp.openo.utility.PathValidationUtils;
+
+import java.io.File;
 
 
 public class OLISLabPDFCreator extends PdfPageEventHelper {
@@ -118,7 +121,12 @@ public class OLISLabPDFCreator extends PdfPageEventHelper {
             LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
 
             String uuidToAdd = request.getParameter("uuid");
-            String fileName = System.getProperty("java.io.tmpdir") + "/olis_" + uuidToAdd + ".response";
+            if (uuidToAdd == null) {
+                throw new SecurityException("Invalid uuid parameter");
+            }
+            File tmpDir = new File(System.getProperty("java.io.tmpdir"));
+            File olisFile = PathValidationUtils.validatePath("olis_" + uuidToAdd + ".response", tmpDir);
+            String fileName = olisFile.getPath();
             String hl7Parsed = "";
             try {
                 if (Files.exists(Paths.get(fileName))) {

--- a/src/main/java/ca/openosp/openo/lab/ca/all/pageUtil/PrintLabs2Action.java
+++ b/src/main/java/ca/openosp/openo/lab/ca/all/pageUtil/PrintLabs2Action.java
@@ -66,15 +66,20 @@ public class PrintLabs2Action extends ActionSupport {
     private SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
 
     public String execute() {
+        String segmentID = request.getParameter("segmentID");
+        if (segmentID == null || !segmentID.matches("^[0-9]+$")) {
+            logger.error("Invalid segmentID parameter");
+            return "error";
+        }
 
         if (!securityInfoManager.hasPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), "_lab", "r", null)) {
             throw new SecurityException("missing required sec object (_lab)");
         }
 
-        LogAction.addLog((String) request.getSession().getAttribute("user"), LogConst.READ, LogConst.CON_HL7_LAB, request.getParameter("segmentID"), request.getRemoteAddr(), "");
+        LogAction.addLog((String) request.getSession().getAttribute("user"), LogConst.READ, LogConst.CON_HL7_LAB, segmentID, request.getRemoteAddr(), "");
 
         try {
-            MessageHandler handler = Factory.getHandler(request.getParameter("segmentID"));
+            MessageHandler handler = Factory.getHandler(segmentID);
             if (handler.getHeaders().get(0).equals("CELLPATHR")) {//if it is a VIHA RTF lab
                 response.setContentType("text/rtf");  //octet-stream
                 response.setHeader("Content-Disposition", "attachment; filename=\"" + handler.getPatientName().replaceAll("\\s", "_") + "_LabReport.rtf\"");
@@ -85,10 +90,6 @@ public class PrintLabs2Action extends ActionSupport {
                 response.setHeader("Content-Disposition", "attachment; filename=\"" + handler.getPatientName().replaceAll("\\s", "_") + "_LabReport.pdf\"");
 
                 //first write to a file
-                String segmentID = request.getParameter("segmentID");
-                if (segmentID == null || !segmentID.matches("^[0-9]+$")) {
-                    throw new IllegalArgumentException("Invalid segmentID");
-                }
                 File f = File.createTempFile("lab" + segmentID, "pdf");
                 FileOutputStream fos = new FileOutputStream(f);
                 LabPDFCreator pdf = new LabPDFCreator(request, fos);

--- a/src/main/java/ca/openosp/openo/lab/ca/all/pageUtil/PrintLabs2Action.java
+++ b/src/main/java/ca/openosp/openo/lab/ca/all/pageUtil/PrintLabs2Action.java
@@ -85,7 +85,11 @@ public class PrintLabs2Action extends ActionSupport {
                 response.setHeader("Content-Disposition", "attachment; filename=\"" + handler.getPatientName().replaceAll("\\s", "_") + "_LabReport.pdf\"");
 
                 //first write to a file
-                File f = File.createTempFile("lab" + request.getParameter("segmentID"), "pdf");
+                String segmentID = request.getParameter("segmentID");
+                if (segmentID == null || !segmentID.matches("^[0-9]+$")) {
+                    throw new IllegalArgumentException("Invalid segmentID");
+                }
+                File f = File.createTempFile("lab" + segmentID, "pdf");
                 FileOutputStream fos = new FileOutputStream(f);
                 LabPDFCreator pdf = new LabPDFCreator(request, fos);
                 pdf.printPdf();

--- a/src/main/java/ca/openosp/openo/lab/ca/all/pageUtil/PrintLabs2Action.java
+++ b/src/main/java/ca/openosp/openo/lab/ca/all/pageUtil/PrintLabs2Action.java
@@ -66,14 +66,14 @@ public class PrintLabs2Action extends ActionSupport {
     private SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
 
     public String execute() {
+        if (!securityInfoManager.hasPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), "_lab", "r", null)) {
+            throw new SecurityException("missing required sec object (_lab)");
+        }
+
         String segmentID = request.getParameter("segmentID");
         if (segmentID == null || !segmentID.matches("^[0-9]+$")) {
             logger.error("Invalid segmentID parameter");
             return "error";
-        }
-
-        if (!securityInfoManager.hasPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), "_lab", "r", null)) {
-            throw new SecurityException("missing required sec object (_lab)");
         }
 
         LogAction.addLog((String) request.getSession().getAttribute("user"), LogConst.READ, LogConst.CON_HL7_LAB, segmentID, request.getRemoteAddr(), "");

--- a/src/main/java/ca/openosp/openo/report/pageUtil/GeneratePatientLetters2Action.java
+++ b/src/main/java/ca/openosp/openo/report/pageUtil/GeneratePatientLetters2Action.java
@@ -144,12 +144,16 @@ public class GeneratePatientLetters2Action extends ActionSupport {
 
                 String description = letterData.get("ID") + "-" + letterData.get("report_name");
                 String type = "others";
-                String fileName = letterData.get("ID") + "-" + StringUtils.replace((String) letterData.get("report_name"), " ", "-") + "-" + demos[i] + ".pdf";
+                String rawFileName = letterData.get("ID") + "-" + StringUtils.replace((String) letterData.get("report_name"), " ", "-") + "-" + demos[i] + ".pdf";
                 String html = "";
                 char status = 'A';
                 String observationDate = UtilDateUtilities.DateToString(new Date());
                 String module = "demographic";
                 String moduleId = demos[i];
+
+                // Validate filename before it enters EDoc
+                File docDir = new File(OscarProperties.getInstance().getProperty("DOCUMENT_DIR"));
+                String fileName = PathValidationUtils.validatePath(rawFileName, docDir).getName();
 
                 EDoc newDoc = new EDoc(description, type, fileName, "", providerNo, providerNo, "", status, observationDate, "", "", module, moduleId);
                 newDoc.setDocPublic("0");
@@ -163,8 +167,8 @@ public class GeneratePatientLetters2Action extends ActionSupport {
                     newDoc.setProgramId(pp.getProgramId().intValue());
                 }
 
+                // Re-validate the timestamped filename from EDoc
                 fileName = newDoc.getFileName();
-                File docDir = new File(OscarProperties.getInstance().getProperty("DOCUMENT_DIR"));
                 File saveFile = PathValidationUtils.validatePath(fileName, docDir);
                 String savePath = saveFile.getPath();
                 if (log.isTraceEnabled()) {

--- a/src/main/java/ca/openosp/openo/report/pageUtil/GeneratePatientLetters2Action.java
+++ b/src/main/java/ca/openosp/openo/report/pageUtil/GeneratePatientLetters2Action.java
@@ -59,6 +59,9 @@ import ca.openosp.openo.prevention.reports.FollowupManagement;
 import ca.openosp.openo.report.data.ManageLetters;
 import ca.openosp.openo.util.ConcatPDF;
 import ca.openosp.openo.util.UtilDateUtilities;
+import ca.openosp.openo.utility.PathValidationUtils;
+
+import java.io.File;
 
 /**
  * @author jay
@@ -161,7 +164,9 @@ public class GeneratePatientLetters2Action extends ActionSupport {
                 }
 
                 fileName = newDoc.getFileName();
-                String savePath = OscarProperties.getInstance().getProperty("DOCUMENT_DIR") + "/" + fileName;
+                File docDir = new File(OscarProperties.getInstance().getProperty("DOCUMENT_DIR"));
+                File saveFile = PathValidationUtils.validatePath(fileName, docDir);
+                String savePath = saveFile.getPath();
                 if (log.isTraceEnabled()) {
                     log.trace("writing report to disk location " + savePath);
                 }

--- a/src/main/java/ca/openosp/openo/utility/DigitalSignatureUtils.java
+++ b/src/main/java/ca/openosp/openo/utility/DigitalSignatureUtils.java
@@ -43,8 +43,8 @@ public class DigitalSignatureUtils {
     }
 
     public static String getTempFilePath(String signatureRequestId) {
-        if (signatureRequestId == null) {
-            throw new SecurityException("Invalid signature request ID");
+        if (signatureRequestId == null || signatureRequestId.trim().isEmpty()) {
+            return null;
         }
         File tmpDir = new File(System.getProperty("java.io.tmpdir"));
         File validatedFile = PathValidationUtils.validatePath(

--- a/src/main/java/ca/openosp/openo/utility/DigitalSignatureUtils.java
+++ b/src/main/java/ca/openosp/openo/utility/DigitalSignatureUtils.java
@@ -23,10 +23,9 @@
 
 package ca.openosp.openo.utility;
 
+import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Date;
 
 import org.apache.logging.log4j.Logger;
@@ -44,9 +43,13 @@ public class DigitalSignatureUtils {
     }
 
     public static String getTempFilePath(String signatureRequestId) {
-        String temppath = System.getProperty("java.io.tmpdir");
-        Path path = Paths.get(temppath, "signature_" + signatureRequestId + ".jpg");
-        return path.toString();
+        if (signatureRequestId == null) {
+            throw new SecurityException("Invalid signature request ID");
+        }
+        File tmpDir = new File(System.getProperty("java.io.tmpdir"));
+        File validatedFile = PathValidationUtils.validatePath(
+                "signature_" + signatureRequestId + ".jpg", tmpDir);
+        return validatedFile.getPath();
     }
 
     /**

--- a/src/main/webapp/billing/CA/ON/viewMOHFiles.jsp
+++ b/src/main/webapp/billing/CA/ON/viewMOHFiles.jsp
@@ -14,6 +14,7 @@
 <%@ page import="ca.openosp.openo.util.FileSortByDate" %>
 <%@ page import="ca.openosp.openo.util.zip" %>
 <%@ page import="ca.openosp.OscarProperties" %>
+<%@ page import="ca.openosp.openo.utility.PathValidationUtils" %>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 <%
@@ -121,6 +122,8 @@
                 String unzipMSG = "";
                 try {
                     if (zname != null && !zname.equals("")) {
+                        File folderDir = new File(folderPath);
+                        PathValidationUtils.validatePath(zname, folderDir);
                         Boolean unzipDone = zip.unzipXML(folderPath, zname);
                         if (!unzipDone) {
                             unzipMSG = "(Cannot unzip)";

--- a/src/main/webapp/billing/CA/ON/viewMOHFiles.jsp
+++ b/src/main/webapp/billing/CA/ON/viewMOHFiles.jsp
@@ -123,8 +123,8 @@
                 try {
                     if (zname != null && !zname.equals("")) {
                         File folderDir = new File(folderPath);
-                        PathValidationUtils.validatePath(zname, folderDir);
-                        Boolean unzipDone = zip.unzipXML(folderPath, zname);
+                        File validatedZip = PathValidationUtils.validatePath(zname, folderDir);
+                        Boolean unzipDone = zip.unzipXML(folderPath, validatedZip.getName());
                         if (!unzipDone) {
                             unzipMSG = "(Cannot unzip)";
                         }

--- a/src/main/webapp/documentManager/documentGetFile.jsp
+++ b/src/main/webapp/documentManager/documentGetFile.jsp
@@ -58,6 +58,10 @@
         filename = request.getParameter("document");
         filetype = request.getParameter("type");
         doc_no = request.getParameter("doc_no");
+        if (filename == null || filename.trim().isEmpty()) {
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Missing document parameter");
+            return;
+        }
         File docDir = new File(docdownload);
         File validatedFile = null;
         try {

--- a/src/main/webapp/documentManager/documentGetFile.jsp
+++ b/src/main/webapp/documentManager/documentGetFile.jsp
@@ -59,7 +59,13 @@
         filetype = request.getParameter("type");
         doc_no = request.getParameter("doc_no");
         File docDir = new File(docdownload);
-        File validatedFile = PathValidationUtils.validatePath(filename, docDir);
+        File validatedFile = null;
+        try {
+            validatedFile = PathValidationUtils.validatePath(filename, docDir);
+        } catch (SecurityException e) {
+            response.sendError(HttpServletResponse.SC_NOT_FOUND);
+            return;
+        }
         filename = validatedFile.getName();
         String filePath = validatedFile.getPath();
         if (filetype.compareTo("active") == 0) {

--- a/src/main/webapp/documentManager/documentGetFile.jsp
+++ b/src/main/webapp/documentManager/documentGetFile.jsp
@@ -30,6 +30,7 @@
 <%@page import="ca.openosp.openo.commn.dao.DocumentDao" %>
 <%@page import="ca.openosp.openo.commn.model.Document" %>
 <%@ page import="ca.openosp.OscarProperties" %>
+<%@ page import="ca.openosp.openo.utility.PathValidationUtils" %>
 
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
@@ -57,7 +58,10 @@
         filename = request.getParameter("document");
         filetype = request.getParameter("type");
         doc_no = request.getParameter("doc_no");
-        String filePath = docdownload + '/' + filename;
+        File docDir = new File(docdownload);
+        File validatedFile = PathValidationUtils.validatePath(filename, docDir);
+        filename = validatedFile.getName();
+        String filePath = validatedFile.getPath();
         if (filetype.compareTo("active") == 0) {
             if (downloadMethod == null) {
                 filePath = request.getContextPath() + "/OscarDocument/document/" + filename;

--- a/src/main/webapp/oscarEncounter/oscarConsultationRequest/documentGetFile.jsp
+++ b/src/main/webapp/oscarEncounter/oscarConsultationRequest/documentGetFile.jsp
@@ -63,6 +63,10 @@
         filename = request.getParameter("document");
         filetype = request.getParameter("type");
         doc_no = request.getParameter("doc_no");
+        if (filename == null || filename.trim().isEmpty()) {
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Missing document parameter");
+            return;
+        }
         File docDir = new File(docdownload);
         File validatedFile = null;
         try {

--- a/src/main/webapp/oscarEncounter/oscarConsultationRequest/documentGetFile.jsp
+++ b/src/main/webapp/oscarEncounter/oscarConsultationRequest/documentGetFile.jsp
@@ -64,7 +64,13 @@
         filetype = request.getParameter("type");
         doc_no = request.getParameter("doc_no");
         File docDir = new File(docdownload);
-        File validatedFile = PathValidationUtils.validatePath(filename, docDir);
+        File validatedFile = null;
+        try {
+            validatedFile = PathValidationUtils.validatePath(filename, docDir);
+        } catch (SecurityException e) {
+            response.sendError(HttpServletResponse.SC_NOT_FOUND);
+            return;
+        }
         filename = validatedFile.getName();
         String filePath = validatedFile.getPath();
         if (filetype.compareTo("active") == 0) {

--- a/src/main/webapp/oscarEncounter/oscarConsultationRequest/documentGetFile.jsp
+++ b/src/main/webapp/oscarEncounter/oscarConsultationRequest/documentGetFile.jsp
@@ -47,6 +47,7 @@
 <%@page import="ca.openosp.openo.commn.dao.DocumentDao" %>
 <%@page import="ca.openosp.openo.commn.model.Document" %>
 <%@ page import="ca.openosp.OscarProperties" %>
+<%@ page import="ca.openosp.openo.utility.PathValidationUtils" %>
 
 <%
     DocumentDao documentDao = SpringUtils.getBean(DocumentDao.class);
@@ -62,7 +63,10 @@
         filename = request.getParameter("document");
         filetype = request.getParameter("type");
         doc_no = request.getParameter("doc_no");
-        String filePath = docdownload + filename;
+        File docDir = new File(docdownload);
+        File validatedFile = PathValidationUtils.validatePath(filename, docDir);
+        filename = validatedFile.getName();
+        String filePath = validatedFile.getPath();
         if (filetype.compareTo("active") == 0) {
             response.setContentType("application/octet-stream");
             response.setHeader("Content-Disposition", "attachment;filename=\"" + filename + "\"");

--- a/src/main/webapp/signature_pad/uploadSignature.jsp
+++ b/src/main/webapp/signature_pad/uploadSignature.jsp
@@ -59,6 +59,10 @@
 
         if (signatureKey != null) {
             String filename = DigitalSignatureUtils.getTempFilePath(signatureKey);
+            if (filename == null || filename.isEmpty()) {
+                response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid signature request ID");
+                return;
+            }
 
             if ("IPAD".equalsIgnoreCase(uploadSource) && imageString != null && !imageString.isEmpty()) {
 


### PR DESCRIPTION
## Summary

  Phase 2 of Path Traversal remeidiation for Snyk Code path traversal (CWE-22) findings by migrating file path operations to use the `PathValidationUtils` class consistently across the codebase.

  ## Problem

  Snyk Code identified multiple path traversal vulnerabilities where user-controlled input (filenames, form parameters) was concatenated directly into file system paths without validation. This could allow attackers to read or write files outside intended directories via `../` sequences in parameters like filenames, document paths, and billing file names.

  ## Solution

  Applied `PathValidationUtils.validatePath()` to all identified file path construction sites where user input flows into file operations. This utility:
  - Sanitizes filenames via `FilenameUtils.getName()` (strips directory components)
  - Validates the resulting path is within the allowed base directory via canonical path comparison

  Additionally:
  - Added input validation (numeric regex) on `jobId`, `segmentID`, `formId`, `demographicNo` parameters
  - URL-encoded dispatcher parameters in `ConsultationAttachDocs2Action` to prevent path injection
  - Simplified `IncomingDocUtil` by replacing wrapper validation methods with direct `PathValidationUtils` calls
  - Added null checks on `uuid` parameter in `OLISLabPDFCreator`

  ### Files modified across 3 batches:

  **Batch 1:** DigitalSignatureUtils, OLISLabPDFCreator, GeneratePatientLetters2Action, FaxImporter, EFormExportZip, documentGetFile.jsp (2 copies), viewMOHFiles.jsp

  **Batch 2:** DocumentTeleplanReportUploadServlet (2 copies), ExtractBean (4 copies), JdbcBillingCreateBillingFile, Document model, EDoc, IncomingDocUtil, DemographicExportAction42Action, DisplayImage2Action, PrintLabs2Action, ConsultationAttachDocs2Action, DocumentUpload2Action

  **Batch 3:** MoveMOHFiles2Action, ConsultationAttachDocs2Action (form parameter validation + URL encoding)

  ## Areas tested manually

  - [x] eForm image display — uploaded image via eForm manager, verified rendering through `DisplayImage2Action`
  - [x] eForm image path traversal — confirmed `../../../etc/passwd` is sanitized to `passwd` (file not found, no leak)
  - [x] Document viewing — viewed documents from patient chart document tab via `documentGetFile.jsp`
  - [x] Consultation document attachments — attached PDF, lab, and form to consultation
  - [x] Incoming documents — browsed Fax/Mail/File queues, filed documents
  - [x] Lab report printing — generated PDF from lab results
  - [x] Fax preview — previewed fax job (PDF and image modes)
  - [x] Document preview — viewed PDF inline via DocumentPreview2Action
  - [x] eForm ZIP import — imported eForm with images from ZIP
  - [x] Demographic export — exported patient demographic data

  ---

## Summary by Sourcery

Harden file path handling and related inputs across documents, billing, eForms, labs, fax, and JSPs to remediate path traversal and injection risks.

Bug Fixes:
- Validate and canonicalize incoming document queue, directory, and filename paths via PathValidationUtils for temp, deleted, and main incoming-doc locations.
- Secure document and image access endpoints by validating filenames against configured base directories and rejecting invalid or non-file paths.
- Ensure billing extract, HTML export, and Teleplan upload file operations resolve filenames through PathValidationUtils rather than string concatenation.
- Lock down lab-related file usage by validating temp file names for HL7/OLIS artifacts and enforcing numeric segmentID parameters.
- Prevent unsafe document generation and storage by validating patient letter filenames, fax-imported document names, and core Document/EDoc file paths via PathValidationUtils.
- Harden JSP-based downloads and MOH ZIP handling by validating requested filenames within their base directories and failing closed on traversal attempts.
- Add input validation for request parameters such as jobId, segmentID, formId, and demographicNo to reject malformed or non-numeric values.

Enhancements:
- Simplify IncomingDocUtil and related callers by centralizing path safety on PathValidationUtils and standard directory-creation logic.
- Standardize error handling and logging for invalid paths and parameters across multiple modules to provide clearer failure modes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Phase 2 of path traversal remediation (CWE-22): replaced unsafe path concatenation with validated paths using `PathValidationUtils`, tightened input checks, and standardized 400/404 responses across billing, documents, eForms, fax, labs, and JSPs.

- **Bug Fixes**
  - Billing: validate filenames in OHIP/MSP extract writes/reads, Teleplan upload servlets, and rename/read in `JdbcBillingCreateBillingFile`; secure `MoveMOHFiles2Action`.
  - Documents: resolve file paths via `PathValidationUtils` in `Document#getDocumentFileFullPath`, `EDoc#getFilePath`, and both `documentGetFile.jsp` variants; validate patient letter filenames in `GeneratePatientLetters2Action`.
  - eForms/images: validate image paths in `DisplayImage2Action`; validate temp and destination image files in `EFormExportZip`.
  - Incoming docs: centralize path safety in `IncomingDocUtil` for incoming/temp/deleted/rotate/extract/delete flows; standardize directory creation.
  - Labs/fax/signature: enforce numeric `segmentID` in `PrintLabs2Action` and `ConsultationAttachDocs2Action`, validate OLIS temp response files and non-empty `uuid` in `OLISLabPDFCreator`, validate `jobId` in `Fax2Action`, decode fax PDFs to a validated destination in `FaxImporter`, and validate digital signature temp paths in `DigitalSignatureUtils`/`DigitalSignature2Action`.
  - JSP/MOH ZIP: validate requested filenames and handle missing params; validate ZIP names in `viewMOHFiles.jsp` before unzip.

- **Refactors**
  - Removed ad‑hoc path checks and custom validators; standardized on `PathValidationUtils` with consistent logging and 400/404 failure modes.
  - Simplified `IncomingDocUtil` APIs and callers to reduce duplication and ensure all paths are created and validated consistently.

<sup>Written for commit 70e3f23f74f9d287dd47810afc4e4936a6e186f0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened file handling security by adding path validation and safer file resolution across uploads, downloads, exports, and temporary-file flows.
  * Improved request-parameter validation to reject malformed or non-numeric inputs early (returning 400) and to return 404 for invalid/missing files.
  * Removed fragile ad-hoc path checks and consolidated path-safety checks to reduce path traversal and file manipulation risks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->