### PR TITLE
Fix: extra filter dropdown on tickler manager page

### DIFF
--- a/src/main/webapp/tickler/ticklerMain.jsp
+++ b/src/main/webapp/tickler/ticklerMain.jsp
@@ -741,14 +741,16 @@
                 </div>
 
             </c:if>
-            <div class="pull-left" style="margin-bottom:10px;">
-                <label for="ticklerview">Filter</label>
-                <select id="ticklerview" class="form-control" name="ticklerview">
-                    <option value="A" <%=ticklerview.equals("A") ? "selected" : ""%>><fmt:setBundle basename="oscarResources"/><fmt:message key="tickler.ticklerMain.formActive"/></option>
-                    <option value="C" <%=ticklerview.equals("C") ? "selected" : ""%>><fmt:setBundle basename="oscarResources"/><fmt:message key="tickler.ticklerMain.formCompleted"/></option>
-                    <option value="D" <%=ticklerview.equals("D") ? "selected" : ""%>><fmt:setBundle basename="oscarResources"/><fmt:message key="tickler.ticklerMain.formDeleted"/></option>
-                </select>
-            </div>
+            <c:if test="${not empty param.demoview}">
+                <div class="pull-left" style="margin-bottom:10px;">
+                    <label for="ticklerview">Filter</label>
+                    <select id="ticklerview" class="form-control" name="ticklerview">
+                        <option value="A" <%=ticklerview.equals("A") ? "selected" : ""%>><fmt:setBundle basename="oscarResources"/><fmt:message key="tickler.ticklerMain.formActive"/></option>
+                        <option value="C" <%=ticklerview.equals("C") ? "selected" : ""%>><fmt:setBundle basename="oscarResources"/><fmt:message key="tickler.ticklerMain.formCompleted"/></option>
+                        <option value="D" <%=ticklerview.equals("D") ? "selected" : ""%>><fmt:setBundle basename="oscarResources"/><fmt:message key="tickler.ticklerMain.formDeleted"/></option>
+                    </select>
+                </div>
+            </c:if>
         </form>
 
         <form name="ticklerform" method="post" action="dbTicklerMain.jsp">


### PR DESCRIPTION
## Summary

A regression was found relating to a missing tickler manager change in this PR: https://github.com/openo-beta/Open-O/pull/2268, where an added conditional around the patient-specific tickler manager UI filter dropdown was removed, resulting in a duplicate filter dropdown that should only show in patient-specific tickler manager pages.

<img width="995" height="541" alt="image" src="https://github.com/user-attachments/assets/5edd4687-e617-422b-bb4e-5b2e17e91028" />

Fixes #2392 

## Problem

A conditional check for a patient-specific tickler manager dropdown has been removed, causing the dropdown to always show on the page, this is an issue as there is already a filter option for non-patients AND this duplicate filter doesn't work in that context, causing potential user confusion as to why one of the filter dropdowns is broken.

## Solution

Re-add the missing conditional that conditionally shows the filter dropdown on patient-specific tickler manager pages

## Manual testing steps
1. Login to the EMR
2. Click the "Tickler" option at the top section
3. **If testing the branches behaviour:** Observe that there is only 1 filter dropdown available, and that the dropdown works
4. **If testing the develop behaviour:** Observe that there is 2 filter dropdowns, and that the filter dropdown closer to the tickler entries does not work inside of the main tickler manager page

## Summary by Sourcery

Bug Fixes:
- Prevent duplicate, non-functional filter dropdown from appearing on non–patient-specific tickler manager pages by gating it on the patient context parameter.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a regression that showed a duplicate filter dropdown on the Tickler Manager. Re-wraps the "ticklerview" select in `ticklerMain.jsp` with `<c:if test="${not empty param.demoview}">` so it only renders on patient-specific pages.

<sup>Written for commit 3739743078b3d646d2d3fe7652ba456347399566. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Bug Fixes:
- Prevent duplicate, non-functional filter dropdown from rendering on non–patient-specific tickler manager pages by conditioning it on the patient context parameter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed filter control display logic to render conditionally based on specific conditions, improving UI consistency and preventing the filter from appearing in unintended scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->