### PR TITLE
Fix: "Reprint" button in Rx module no longer works

### DIFF
--- a/src/main/webapp/oscarRx/SearchDrug3.jsp
+++ b/src/main/webapp/oscarRx/SearchDrug3.jsp
@@ -249,6 +249,7 @@
   <script type="text/javascript" src="<c:out value="${ctx}/share/javascript/Oscar.js"/>"></script>
   <script type="text/javascript" src="<c:out value="${ctx}/share/javascript/dragiframe.js"/>"></script>
   <script type="text/javascript" src="<c:out value="${ctx}/js/checkDate.js"/>"></script>
+  <script src="${pageContext.request.contextPath}/csrfguard"></script>
 
   <link rel="stylesheet" type="text/css" href="<c:out value="${ctx}/share/yui/css/autocomplete.css"/>">
   <script type="text/javascript" src="<c:out value="${ctx}/share/yui/js/yahoo-dom-event.js"/>"></script>
@@ -891,7 +892,6 @@
       height: 150px;
       overflow: auto;
       border: thin solid #DCDCDC;
-      display: none;
     }
 
     .text-indent-5 {
@@ -1141,7 +1141,7 @@
                         basename="oscarResources"/><fmt:message key="SearchDrug.Print"/></a>
 
                       <%if (securityManager.hasWriteAccess("_rx", roleName2$, true)) {%>
-                      <a href="javascript:void(0);"  class="btn btn-link"  onclick="$('reprint').toggle();return false;"><fmt:setBundle
+                      <a href="javascript:void(0);"  class="btn btn-link"  onclick="document.getElementById('reprint').toggleAttribute('hidden');return false;"><fmt:setBundle
                         basename="oscarResources"/><fmt:message key="SearchDrug.Reprint"/></a>
 
                       <a href="javascript:void(0);"  class="btn btn-link"  id="cmdRePrescribe" onclick="RePrescribeLongTerm();"><fmt:setBundle basename="oscarResources"/><fmt:message
@@ -1157,7 +1157,8 @@
                   </td>
                 </tr>
                 <tr>
-                  <td id="reprint">
+                  <%-- hidden attribute is toggled by JS via toggleAttribute('hidden') — do not move to CSS or the reprint section will not open --%>
+                  <td id="reprint" hidden>
 
 
                       <% for (int i = 0; prescribedDrugs.length > i; i++) {

--- a/src/main/webapp/oscarRx/SearchDrug3.jsp
+++ b/src/main/webapp/oscarRx/SearchDrug3.jsp
@@ -1170,7 +1170,7 @@
                                                     %>
 
 
-                    <div class="btn btn-link text-indent-5">
+                    <div class="text-indent-5">
                       <a href="javascript:void(0);" onclick="reprint2('<%=drug.getScript_no()%>')">
                         <%=drug.getRxDisplay()%>
                       </a>

--- a/src/main/webapp/oscarRx/SearchDrug3.jsp
+++ b/src/main/webapp/oscarRx/SearchDrug3.jsp
@@ -1190,7 +1190,7 @@
     </div>
     <div>
       <a href="javascript:void(0)" onclick="showPreviousPrints(<%=drug.getScript_no() %>);return false;">
-        <%=drug.getNumPrints()%>Print(s)
+        <%=drug.getNumPrints()%> Print(s)
       </a>
     </div>
   </div>

--- a/src/main/webapp/oscarRx/SearchDrug3.jsp
+++ b/src/main/webapp/oscarRx/SearchDrug3.jsp
@@ -240,6 +240,7 @@
   <link href="${pageContext.request.contextPath}/library/DataTables/DataTables-1.13.4/css/jquery.dataTables.css" rel="stylesheet" type="text/css"/>
 
   <script type="text/javascript" src="${ctx}/js/global.js"></script>
+  <script src="${ctx}/csrfguard"></script>
   <script type="text/javascript" src="<c:out value="${ctx}/share/javascript/prototype.js"/>"></script>
   <script type="text/javascript" src="<c:out value="${ctx}/share/javascript/screen.js"/>"></script>
   <script type="text/javascript" src="<c:out value="${ctx}/share/javascript/rx.js"/>"></script>
@@ -249,7 +250,6 @@
   <script type="text/javascript" src="<c:out value="${ctx}/share/javascript/Oscar.js"/>"></script>
   <script type="text/javascript" src="<c:out value="${ctx}/share/javascript/dragiframe.js"/>"></script>
   <script type="text/javascript" src="<c:out value="${ctx}/js/checkDate.js"/>"></script>
-  <script src="${pageContext.request.contextPath}/csrfguard"></script>
 
   <link rel="stylesheet" type="text/css" href="<c:out value="${ctx}/share/yui/css/autocomplete.css"/>">
   <script type="text/javascript" src="<c:out value="${ctx}/share/yui/js/yahoo-dom-event.js"/>"></script>


### PR DESCRIPTION
## Summary

  Fixes the "Reprint" button in the Rx module which has been non-functional since the de82590af5 commit.

Fixes https://github.com/openo-beta/Open-O/issues/2397

##  Problem

  In de82590af5, the `display: none` on `<td id="reprint">` was moved from an inline style to a CSS rule in the `<style>` block. Prototype.js's show() works by clearing the inline style.display to '', which falls back to the default display value. With the inline style, that fallback was table-cell (visible). With a CSS rule, the fallback is the rule's display: none (still hidden). So toggling appeared to do nothing.

##  Solution

  - Replaced $('reprint').toggle() (Prototype.js) with document.getElementById('reprint').toggleAttribute('hidden') (vanilla JS). The hidden HTML attribute avoids the inline-vs-CSS display conflict entirely and reduces Prototype.js dependency.
  - Added a comment on the hidden attribute explaining not to move it to CSS.

##  Additional fixes

  - Restored the csrfguard script include that was removed in f5eb92f235, ensuring CSRF tokens are injected into AJAX requests on this page.
  - Restored missing space between print count and "Print(s)" label (e.g. "1Print(s)" → "1 Print(s)").

##  Manual Testing Steps

  1. Login to the EMR
  2. Open the Rx module for a patient with past prescriptions
  3. Click on "Reprint" in the drug profile section
  4. **If testing the branch's behaviour:** Observe the reprint section appears with a list of past Rx's grouped by date
  5. **If testing develop's behaviour:** Observe nothing happens when clicking "Reprint"
  6. Click "Reprint" again to confirm the section hides
  7. Click "Reprint" to reopen, then click a drug entry in the list
  8. Observe a print preview modal opens
  9. Verify the print count next to each Rx shows a space (e.g. "1 Print(s)" not "1Print(s)")
  10. Verify no console errors during the above steps

## Summary by Sourcery

Fix the Rx module reprint section so it can be shown and hidden correctly from the UI.

Bug Fixes:
- Restore functionality of the Reprint button in the Rx module by toggling the visibility of the reprint section via the hidden attribute instead of Prototype.js display manipulation.
- Fix the missing space between the print count and the Print(s) label in the previous prints link.
- Reinstate the csrfguard script on the Rx page so CSRF tokens are correctly applied to related requests.

Enhancements:
- Reduce dependency on Prototype.js for UI toggling in the Rx module by using vanilla JavaScript and the hidden attribute.

## Summary by Sourcery

Restore the Rx module reprint section’s visibility toggle and related UI behaviour.

Bug Fixes:
- Fix the Reprint button so the reprint section can be shown and hidden reliably in the Rx module.
- Ensure the previous prints link label displays a space between the print count and the "Print(s)" text.
- Reinstate the CSRF protection script on the Rx page so CSRF tokens are injected into relevant requests.

Enhancements:
- Use a hidden attribute with vanilla JavaScript for toggling the reprint section, reducing reliance on Prototype.js.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Reprint toggle on the drug search page and adjusted how the reprint section is hidden.
  * Corrected Print count label spacing and removed unintended button styling in reprint list items.

* **Chores**
  * Enhanced CSRF protection on the drug search page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore the "Reprint" button in the Rx module using the HTML hidden attribute. Re-enable CSRF protection, fix print count spacing, and clean up medication list styling.

- **Bug Fixes**
  - Toggle reprint section with the hidden attribute (vanilla JS), avoiding CSS display conflicts and reducing reliance on `prototype.js`.
  - Load CSRF guard from `${ctx}/csrfguard` next to `global.js` so tokens apply to related requests.
  - Add a space between the print count and "Print(s)" (e.g., "1 Print(s)").
  - Fix reprint list styling so each medication shows on a new line and remove unintended underline when only one item is present.

<sup>Written for commit e755185109c79ad92d5e546442759d9bd056a14e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

