### PR TITLE
Fix: The Instructions Field Reference popup in the Rx module cannot be closed

### DIFF
--- a/src/main/webapp/oscarRx/SearchDrug3.jsp
+++ b/src/main/webapp/oscarRx/SearchDrug3.jsp
@@ -1572,6 +1572,7 @@
     };
   }
   let mb = new modalBox();
+  window.mb = mb; // exposed for iframe close buttons (parent.mb.hide())
 
   function displayMedHistory(randomId) {
     let data = "randomId=" + randomId;


### PR DESCRIPTION
## Summary
                                                                                                                                                      
  Fixes the "X" close button on the Instructions Field Reference popup in the Rx module, which has been non-functional since the de82590af5 commit.
                                                                                                                                                      
  Fixes https://github.com/openo-beta/Open-O/issues/2391                                                                                              
                                                                                                                                                      
##  Problem                                                                                                                                             
                  
  In de82590af5, var mb = new modalBox() was changed to let mb = new modalBox() as part of a var → let cleanup. Variables declared with var at the top level are added as properties of window, but let variables are not. The Instructions Field Reference popup (and Med History popup) are rendered in iframes that close themselves by calling parent.mb.hide() — which resolves to window.mb on the parent frame. With let, window.mb is undefined, so clicking the close button throws a console error and does nothing.

##  Solution
  - Kept the let mb declaration (block-scoped, modern style) and explicitly assigned window.mb = mb so iframes can continue to access the modal instance via parent.mb.hide().
  - This also restores close functionality in displayMedHistory.jsp, which uses the same parent.mb.hide() pattern in 5 places.                        
                                                                                                                                                      
##  Manual Testing Steps                                                                                                                                                                                                                                                                                  
  1. Login to the EMR                                                                                                                                 
  2. Search for a patient and open their Rx module
  3. Stage a medication (search and add a drug)
  4. Click the "?" icon next to the instructions field to open the "Instructions Field Reference" popup                                               
  5. **If testing the branch's behaviour:** Click the "X" in the top right corner and observe the popup closes                                            
  6. **If testing develop's behaviour:** Click the "X" and observe nothing happens (console error)                                                        
  7. Reopen the popup and verify it can be dragged around the page                                                                                    
  8. Close the popup again via the "X" to confirm repeatable behavior                                                                                 
  9. Click the red asterisk "*" next to the instructions field to open the Med History popup                                                          
  10. Verify the "X" close button works on that popup as well                                                                                         
  11. Verify no console errors during the above steps

## Summary by Sourcery

Bug Fixes:
- Allow the Instructions Field Reference popup in the Rx module to be closed from iframe-based close buttons.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed an issue where modal dialogs could not be properly closed when opened from within iframe or embedded window contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the Instructions Field Reference popup in the Rx module so it can be closed from iframe-based buttons. Exposed the modalBox instance as window.mb to enable parent.mb.hide() calls.

<sup>Written for commit a6be8fe529844e08b6e5181b08def7bbc8a19620. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

