### PR TITLE
SQL security fixes  

### DIFF
--- a/src/main/java/ca/openosp/openo/PMmodule/utility/MigrateStaffAssignments.java
+++ b/src/main/java/ca/openosp/openo/PMmodule/utility/MigrateStaffAssignments.java
@@ -23,6 +23,7 @@
 
 package ca.openosp.openo.PMmodule.utility;
 
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.Statement;
 
@@ -62,47 +63,51 @@ public class MigrateStaffAssignments {
     }
 
     public boolean programExists(long programId) throws Exception {
-        Statement stmt = DbConnectionFilter.getThreadLocalDbConnection().createStatement();
-        stmt.execute("SELECT count(*) as num FROM program where program_id =" + programId);
-        ResultSet rs = stmt.getResultSet();
-        rs.next();
-        long num = rs.getInt("num");
-        if (num > 0) {
-            return true;
+        try (PreparedStatement ps = DbConnectionFilter.getThreadLocalDbConnection()
+                .prepareStatement("SELECT count(*) as num FROM program where program_id = ?")) {
+            ps.setLong(1, programId);
+            try (ResultSet rs = ps.executeQuery()) {
+                rs.next();
+                return rs.getInt("num") > 0;
+            }
         }
-        return false;
     }
 
     public boolean providerExists(long providerNo) throws Exception {
-        Statement stmt = DbConnectionFilter.getThreadLocalDbConnection().createStatement();
-        stmt.execute("SELECT count(*) as num FROM provider where provider_no =" + providerNo);
-        ResultSet rs = stmt.getResultSet();
-        rs.next();
-        long num = rs.getInt("num");
-        if (num > 0) {
-            return true;
+        try (PreparedStatement ps = DbConnectionFilter.getThreadLocalDbConnection()
+                .prepareStatement("SELECT count(*) as num FROM provider where provider_no = ?")) {
+            ps.setLong(1, providerNo);
+            try (ResultSet rs = ps.executeQuery()) {
+                rs.next();
+                return rs.getInt("num") > 0;
+            }
         }
-        return false;
     }
 
     public long getRoleId(String name) throws Exception {
-        Statement stmt = DbConnectionFilter.getThreadLocalDbConnection().createStatement();
-        stmt.execute("SELECT * FROM caisi_role where name = '" + name + "'");
-        ResultSet rs = stmt.getResultSet();
-        if (rs.next()) {
-            return rs.getInt("role_id");
-        } else {
-            throw new Exception("no Nurse role defined");
+        try (PreparedStatement ps = DbConnectionFilter.getThreadLocalDbConnection()
+                .prepareStatement("SELECT * FROM caisi_role where name = ?")) {
+            ps.setString(1, name);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    return rs.getInt("role_id");
+                } else {
+                    throw new Exception("no Nurse role defined");
+                }
+            }
         }
     }
 
     public void addProgramProvider(long programId, long providerNo, long groupNo) throws Exception {
-        Statement stmt = DbConnectionFilter.getThreadLocalDbConnection().createStatement();
-        long roleId = doctorRoleId;
-        if (groupNo == 9) {
-            roleId = nurseRoleId;
+        long roleId = groupNo == 9 ? nurseRoleId : doctorRoleId;
+        try (PreparedStatement ps = DbConnectionFilter.getThreadLocalDbConnection()
+                .prepareStatement("insert into program_provider (program_id,provider_no,role_id,team_id) values (?,?,?,?)")) {
+            ps.setLong(1, programId);
+            ps.setLong(2, providerNo);
+            ps.setLong(3, roleId);
+            ps.setLong(4, 0);
+            ps.executeUpdate();
         }
-        stmt.executeUpdate("insert into program_provider (program_id,provider_no,role_id,team_id) values (" + programId + "," + providerNo + "," + roleId + "," + "0)");
     }
 
     public static void main(String args[]) throws Exception {

--- a/src/main/java/ca/openosp/openo/PMmodule/utility/MigrateStaffAssignments.java
+++ b/src/main/java/ca/openosp/openo/PMmodule/utility/MigrateStaffAssignments.java
@@ -92,7 +92,7 @@ public class MigrateStaffAssignments {
                 if (rs.next()) {
                     return rs.getInt("role_id");
                 } else {
-                    throw new Exception("no Nurse role defined");
+                    throw new Exception("Role not defined: " + name);
                 }
             }
         }

--- a/src/main/java/ca/openosp/openo/daos/security/SecroleDaoImpl.java
+++ b/src/main/java/ca/openosp/openo/daos/security/SecroleDaoImpl.java
@@ -45,7 +45,7 @@ public class SecroleDaoImpl extends HibernateDaoSupport implements SecroleDao {
             throw new IllegalArgumentException();
         }
 
-        List lst = this.getHibernateTemplate().find("from Secrole r where r.roleName='" + roleName + "'");
+        List lst = this.getHibernateTemplate().find("from Secrole r where r.roleName = ?0", roleName);
         if (lst != null && lst.size() > 0)
             result = (Secrole) lst.get(0);
 

--- a/src/main/java/ca/openosp/openo/daos/security/SecuserroleDaoImpl.java
+++ b/src/main/java/ca/openosp/openo/daos/security/SecuserroleDaoImpl.java
@@ -164,13 +164,13 @@ public class SecuserroleDaoImpl extends HibernateDaoSupport implements Secuserro
         Session session = currentSession();
         ;
         try {
-            String queryString = "update Secuserrole as model set model.activeyn ='" + instance.getActiveyn()
-                    + "' , lastUpdateDate=now() "
-                    + " where model.providerNo ='" + instance.getProviderNo() + "'"
-                    + " and model.roleName ='" + instance.getRoleName() + "'"
-                    + " and model.orgcd ='" + instance.getOrgcd() + "'";
+            String queryString = "update Secuserrole as model set model.activeyn = :activeyn, lastUpdateDate=now() where model.providerNo = :providerNo and model.roleName = :roleName and model.orgcd = :orgcd";
 
             Query queryObject = session.createQuery(queryString);
+            queryObject.setParameter("activeyn", instance.getActiveyn());
+            queryObject.setParameter("providerNo", instance.getProviderNo());
+            queryObject.setParameter("roleName", instance.getRoleName());
+            queryObject.setParameter("orgcd", instance.getOrgcd());
 
             return queryObject.executeUpdate();
 
@@ -266,18 +266,16 @@ public class SecuserroleDaoImpl extends HibernateDaoSupport implements Secuserro
          *
          */
         logger.debug("Find staff instance .");
+        Session session = currentSession();
         try {
-
-            String queryString = "select a from Secuserrole a, LstOrgcd b, SecProvider p"
-                    + " where a.providerNo=p.providerNo and b.code ='" + orgcd + "'";
+            String queryString = "select a from Secuserrole a, LstOrgcd b, SecProvider p where a.providerNo=p.providerNo and b.code = :orgcd";
             if (activeOnly)
                 queryString += " and p.status='1'";
+            queryString += " and b.codecsv like '%' || a.orgcd || ',%' and not (a.orgcd like 'R%' or a.orgcd like 'O%')";
 
-            queryString = queryString
-                    + " and b.codecsv like '%' || a.orgcd || ',%'"
-                    + " and not (a.orgcd like 'R%' or a.orgcd like 'O%')";
-
-            return this.getHibernateTemplate().find(queryString);
+            Query query = session.createQuery(queryString);
+            query.setParameter("orgcd", orgcd);
+            return query.list();
 
         } catch (RuntimeException re) {
             logger.error("Find staff failed", re);
@@ -290,31 +288,26 @@ public class SecuserroleDaoImpl extends HibernateDaoSupport implements Secuserro
     public List searchByCriteria(StaffForm staffForm) {
 
         logger.debug("Search staff instance .");
+        Session session = currentSession();
         try {
-
-            String AND = " and ";
-            // String OR = " or ";
-
-            String orgcd = staffForm.getOrgcd();
-
-            String queryString = "select a from Secuserrole a, LstOrgcd b"
-                    + " where b.code ='" + orgcd + "'"
-                    + " and b.codecsv like '%' || a.orgcd || ',%'"
-                    + " and not (a.orgcd like 'R%' or a.orgcd like 'O%')";
+            String queryString = "select a from Secuserrole a, LstOrgcd b where b.code = :orgcd and b.codecsv like '%' || a.orgcd || ',%' and not (a.orgcd like 'R%' or a.orgcd like 'O%')";
 
             String fname = staffForm.getFirstName();
             String lname = staffForm.getLastName();
 
-            if (fname != null && fname.length() > 0) {
-                fname = fname.toLowerCase();
-                queryString = queryString + AND + "lower(a.providerFName) like '%" + fname + "%'";
-            }
-            if (lname != null && lname.length() > 0) {
-                lname = lname.toLowerCase();
-                queryString = queryString + AND + "lower(a.providerLName) like '%" + lname + "%'";
-            }
+            if (fname != null && fname.length() > 0)
+                queryString += " and lower(a.providerFName) like :fname";
+            if (lname != null && lname.length() > 0)
+                queryString += " and lower(a.providerLName) like :lname";
 
-            return this.getHibernateTemplate().find(queryString);
+            Query query = session.createQuery(queryString);
+            query.setParameter("orgcd", staffForm.getOrgcd());
+            if (fname != null && fname.length() > 0)
+                query.setParameter("fname", "%" + fname.toLowerCase() + "%");
+            if (lname != null && lname.length() > 0)
+                query.setParameter("lname", "%" + lname.toLowerCase() + "%");
+
+            return query.list();
 
         } catch (RuntimeException re) {
             logger.error("Search staff failed", re);

--- a/src/main/java/ca/openosp/openo/dashboard/handler/AbstractQueryHandler.java
+++ b/src/main/java/ca/openosp/openo/dashboard/handler/AbstractQueryHandler.java
@@ -314,17 +314,22 @@ public abstract class AbstractQueryHandler extends HibernateDaoSupport {
      * in a SQL query. Single quotes in values are escaped to prevent injection.
      */
     private static String parseParameterValue(String[] values) {
+        if (values == null || values.length == 0) {
+            return "";
+        }
         if (values.length > 1) {
             StringBuilder sb = new StringBuilder("(");
             for (int i = 0; i < values.length; i++) {
-                String escaped = values[i].trim().replace("'", "''");
+                String val = values[i];
+                String escaped = (val == null) ? "" : val.trim().replace("'", "''");
                 sb.append("'").append(escaped).append("'");
                 if (i < values.length - 1) sb.append(",");
             }
             sb.append(")");
             return sb.toString();
         } else {
-            return values[0].trim().replace("'", "''");
+            String val = values[0];
+            return (val == null) ? "" : val.trim().replace("'", "''");
         }
     }
 

--- a/src/main/java/ca/openosp/openo/dashboard/handler/AbstractQueryHandler.java
+++ b/src/main/java/ca/openosp/openo/dashboard/handler/AbstractQueryHandler.java
@@ -25,6 +25,7 @@
 package ca.openosp.openo.dashboard.handler;
 
 import java.util.List;
+import java.util.regex.Matcher;
 
 import org.apache.logging.log4j.Logger;
 import org.hibernate.*;
@@ -241,7 +242,8 @@ public abstract class AbstractQueryHandler extends HibernateDaoSupport {
         }
 
         String pattern = getPattern(addPattern);
-        return patternReplace(pattern, query, range.getValue());
+        String safeValue = range.getValue().replace("'", "''");
+        return patternReplace(pattern, query, safeValue);
     }
 
     /**
@@ -299,33 +301,31 @@ public abstract class AbstractQueryHandler extends HibernateDaoSupport {
 
     /*
      * Replaces all given patterns in the given string with the given value.
+     * Uses Matcher.quoteReplacement to prevent regex replacement injection
+     * via $ or \ characters in the value.
      */
     private String patternReplace(String pattern, String query, String value) {
-        logger.debug("Inserting pattern " + pattern + " with a value of " + value);
-        return query.replaceAll(pattern, value);
+        logger.debug("Inserting pattern {} with value {}", pattern, value);
+        return query.replaceAll(pattern, Matcher.quoteReplacement(value));
     }
 
     /**
-     * parses a parameter value array into a comma delimited string for use
-     * in a SQL query.
+     * Parses a parameter value array into a comma-delimited string for use
+     * in a SQL query. Single quotes in values are escaped to prevent injection.
      */
     private static String parseParameterValue(String[] values) {
-        String value = "";
-
         if (values.length > 1) {
-            StringBuilder stringBuilder = new StringBuilder();
-            stringBuilder.append("(");
+            StringBuilder sb = new StringBuilder("(");
             for (int i = 0; i < values.length; i++) {
-                stringBuilder.append("'").append(values[i]).append("',");
+                String escaped = values[i].trim().replace("'", "''");
+                sb.append("'").append(escaped).append("'");
+                if (i < values.length - 1) sb.append(",");
             }
-            stringBuilder.deleteCharAt(stringBuilder.length() - 1);
-            stringBuilder.append(")");
-            value = stringBuilder.toString();
+            sb.append(")");
+            return sb.toString();
         } else {
-            value = values[0].trim();
+            return values[0].trim().replace("'", "''");
         }
-
-        return value;
     }
 
     /**


### PR DESCRIPTION
## Changes made
- Use positional parameters instead of parameter concatenation in getRoleByName() in `SecroleDaoImpl.java`.
- Use named HQL parameters instead of parameter concatenation in update/findByOrgcd/searchByCriteria `SecuserroleDaoImpl.java`.
- Use PreparedStatement with try-with-resources across 4 methods in `MigrateStaffAssignments.java`.
- Matcher.quoteReplacement() plus single-quote escaping in `AbstractQueryHandler.java`.

## Summary by Sourcery

Harden SQL and HQL usage across security- and dashboard-related components to reduce injection risk and improve query safety.

Bug Fixes:
- Replace string-concatenated SQL in MigrateStaffAssignments with parameterized PreparedStatements and proper resource handling for existence checks and inserts.
- Update SecroleDaoImpl.getRoleByName to use a positional parameter instead of concatenating the role name into the HQL string.
- Refactor SecuserroleDaoImpl update and search queries to use named parameters instead of direct string concatenation of user-supplied values.
- Escape single quotes and use safe regex replacements in AbstractQueryHandler when interpolating range and list values into SQL fragments to prevent injection via special characters.

Enhancements:
- Simplify role selection logic in MigrateStaffAssignments.addProgramProvider while switching to parameterized inserts.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened SQL paths by replacing string-concatenated queries with parameterized bindings and safer template substitution. Added input null checks and error handling to close injection vectors and reduce resource leak risk.

- **Bug Fixes**
  - `SecroleDaoImpl`: use HQL positional parameter (`?0`) in `getRoleByName()`.
  - `SecuserroleDaoImpl`: switch to named HQL params in `update`, `findByOrgcd`, and `searchByCriteria`; bind `orgcd`, `providerNo`, `roleName`, `activeyn`, `firstName`, `lastName`.
  - `MigrateStaffAssignments`: replace `Statement` with `PreparedStatement` and try-with-resources; parameterize selects/inserts; keep role selection logic; clarify exception in `getRoleId()`.
  - `AbstractQueryHandler`: escape single quotes in `addRange`/`parseParameterValue`, add null/empty checks, and use `Matcher.quoteReplacement()` in `patternReplace()`.

<sup>Written for commit bc53a74a58fc1f93184528adb2b841705ffefacb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Harden SQL and HQL usage in security- and dashboard-related components to reduce injection risk and improve query safety.

Bug Fixes:
- Replace string-concatenated JDBC queries in MigrateStaffAssignments with parameterized PreparedStatements and proper resource handling for existence checks, role lookups, and inserts.
- Update SecuserroleDaoImpl update and search queries to use named HQL parameters instead of concatenating user-supplied values, including org code and name filters.
- Switch SecroleDaoImpl.getRoleByName to use a positional parameter instead of embedding the role name directly in the HQL string.
- Escape single quotes and use safe regex replacements in AbstractQueryHandler when interpolating range and list values into SQL fragments to prevent injection via special characters.

Enhancements:
- Clarify error reporting in MigrateStaffAssignments.getRoleId when a role is not defined.