### PR TITLE
Enhancement: package prs devcontainer tool

### DIFF
--- a/.devcontainer/development/scripts/help-dev
+++ b/.devcontainer/development/scripts/help-dev
@@ -86,6 +86,7 @@ GIT WORKFLOW:
   git diff                View uncommitted changes
   git log --oneline -10   Recent commits
   gh pr create            Create pull request
+  package-prs --help      Cherry-pick PR merge commits into a package branch
 
 =============================================================
 Type 'make help' for build options or 'server help' for server management

--- a/.devcontainer/development/scripts/package-prs
+++ b/.devcontainer/development/scripts/package-prs
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+#
+# package-prs — Build a "package" branch by cherry-picking the merge commits
+# of multiple source PRs into a single branch.
+#
+# Cherry-picks each PR's merge commit (using -m 1) instead of its individual
+# feature commits. This avoids conflicts that arise when feature commits
+# assume an older base than the package branch's target.
+#
+# See package-prs.md for full documentation.
+
+set -euo pipefail
+
+# ------------------------------------------------------------------- defaults
+SOURCE_BRANCH="develop"
+SOURCE_REMOTE="origin"
+DRY_RUN=0
+FORCE=0
+PR_LIST=""
+SOURCE_REPO=""
+TARGET_BASE=""
+BRANCH=""
+
+# --------------------------------------------------------------------- usage
+usage() {
+  cat <<'EOF'
+Usage: package-prs --pr <N,N,...> --source-repo <owner/repo>
+                   --target-base <ref> --branch <name> [options]
+
+Required:
+  --pr <N,N,...>           Comma-separated PR numbers from source repo
+  --source-repo <repo>     Source repo (e.g., openo-beta/Open-O)
+  --target-base <ref>      Base ref for new branch (e.g., upstream-base/main)
+  --branch <name>          Name of the new local branch
+
+Options:
+  --source-branch <ref>    Source branch to search for merges (default: develop)
+  --source-remote <name>   Local git remote for source repo (default: origin)
+  --dry-run                Print the plan without making changes
+  --force                  Overwrite the local branch if it exists
+  -h, --help               Show this help
+
+Example:
+  package-prs --pr 2343,2344,2345,2414,2404,2413,2415,2417,2261 \
+              --source-repo openo-beta/Open-O \
+              --target-base upstream-base/main \
+              --branch rx-bugfixes/20260428
+EOF
+}
+
+err()  { printf 'Error: %s\n' "$*" >&2; }
+info() { printf '==> %s\n' "$*"; }
+
+# --------------------------------------------------------------- arg parsing
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --pr)            PR_LIST="$2"; shift 2 ;;
+    --source-repo)   SOURCE_REPO="$2"; shift 2 ;;
+    --source-branch) SOURCE_BRANCH="$2"; shift 2 ;;
+    --source-remote) SOURCE_REMOTE="$2"; shift 2 ;;
+    --target-base)   TARGET_BASE="$2"; shift 2 ;;
+    --branch)        BRANCH="$2"; shift 2 ;;
+    --dry-run)       DRY_RUN=1; shift ;;
+    --force)         FORCE=1; shift ;;
+    -h|--help)       usage; exit 0 ;;
+    *) err "unknown option: $1"; usage >&2; exit 2 ;;
+  esac
+done
+
+# Validate required flags
+required_vars=(PR_LIST SOURCE_REPO TARGET_BASE BRANCH)
+required_flags=(--pr --source-repo --target-base --branch)
+for i in "${!required_vars[@]}"; do
+  if [[ -z "${!required_vars[$i]}" ]]; then
+    err "missing required flag: ${required_flags[$i]}"
+    usage >&2
+    exit 2
+  fi
+done
+
+# Tool availability
+command -v gh  >/dev/null || { err "gh (GitHub CLI) is required";  exit 1; }
+command -v git >/dev/null || { err "git is required";               exit 1; }
+
+# Working tree must be clean (we'll be checking out a new branch)
+if ! git diff-index --quiet HEAD -- 2>/dev/null; then
+  err "working tree has uncommitted changes; commit or stash before running"
+  exit 1
+fi
+
+# Strip whitespace from PR list
+PR_LIST="${PR_LIST// /}"
+
+# Source-repo owner is the part before "/"
+SOURCE_OWNER="${SOURCE_REPO%%/*}"
+
+# ---------------------------------------------------------------- resolution
+info "Fetching ${SOURCE_REMOTE}/${SOURCE_BRANCH}"
+if ! git fetch "$SOURCE_REMOTE" "$SOURCE_BRANCH" >/dev/null 2>&1; then
+  err "failed to fetch ${SOURCE_REMOTE}/${SOURCE_BRANCH}"
+  err "verify that --source-remote='$SOURCE_REMOTE' tracks $SOURCE_REPO"
+  exit 1
+fi
+
+# Resolve one PR -> merge SHA, with subject sanity check
+# Echoes a single line: "<sha>|<subject>|<stats>"
+resolve_one() {
+  local pr="$1"
+  local subject sha stat
+
+  # Look up by PR number in the merge commit subject
+  sha=$(git log --merges \
+        --grep="^Merge pull request #${pr} " \
+        --pretty=%H "${SOURCE_REMOTE}/${SOURCE_BRANCH}" \
+        2>/dev/null | head -1)
+
+  if [[ -z "$sha" ]]; then
+    err "PR #${pr}: no merge commit found on ${SOURCE_REMOTE}/${SOURCE_BRANCH}"
+    err "  (looked for 'Merge pull request #${pr} ...' — was it merged via squash/rebase?)"
+    return 1
+  fi
+
+  subject=$(git show --no-patch --format='%s' "$sha")
+
+  # Verify subject mentions the right PR (exact, with trailing space)
+  if [[ "$subject" != *"Merge pull request #${pr} "* ]]; then
+    err "PR #${pr}: SHA ${sha:0:10} subject doesn't match expected PR"
+    err "  got: $subject"
+    return 1
+  fi
+
+  # Optional: verify owner matches (catches wrong source repo)
+  if [[ "$subject" != *"from ${SOURCE_OWNER}/"* ]]; then
+    err "PR #${pr}: SHA ${sha:0:10} not from owner '${SOURCE_OWNER}'"
+    err "  got: $subject"
+    return 1
+  fi
+
+  # Stats: parse `git diff --shortstat`
+  stat=$(git diff --shortstat "${sha}^1..${sha}" 2>/dev/null \
+         | sed 's/^[[:space:]]*//')
+  : "${stat:=(no diff)}"
+
+  printf '%s|%s|%s\n' "$sha" "$subject" "$stat"
+}
+
+info "Resolving merge SHAs for PRs: ${PR_LIST}"
+
+IFS=',' read -ra PRS <<< "$PR_LIST"
+declare -a SHAS=() SUBJECTS=() STATS=()
+
+for pr in "${PRS[@]}"; do
+  if ! line=$(resolve_one "$pr"); then
+    err "aborting; resolution failed for PR #${pr}"
+    exit 1
+  fi
+  SHAS+=("${line%%|*}")
+  rest="${line#*|}"
+  SUBJECTS+=("${rest%%|*}")
+  STATS+=("${rest#*|}")
+done
+
+# --------------------------------------------------------------- print plan
+echo
+printf '%-6s  %-10s  %-55s  %s\n' "PR" "SHA" "SUBJECT" "STATS"
+printf -- '-%.0s' {1..120}; echo
+for i in "${!PRS[@]}"; do
+  short_subj="${SUBJECTS[$i]}"
+  if (( ${#short_subj} > 55 )); then
+    short_subj="${short_subj:0:52}..."
+  fi
+  printf '%-6s  %-10s  %-55s  %s\n' \
+    "${PRS[$i]}" "${SHAS[$i]:0:10}" "$short_subj" "${STATS[$i]}"
+done
+echo
+
+if [[ $DRY_RUN -eq 1 ]]; then
+  info "Dry-run complete. No changes made."
+  exit 0
+fi
+
+# ------------------------------------------------------- create new branch
+if git show-ref --verify --quiet "refs/heads/${BRANCH}"; then
+  if [[ $FORCE -eq 0 ]]; then
+    err "branch '${BRANCH}' already exists; pass --force to overwrite"
+    exit 1
+  fi
+  info "deleting existing branch '${BRANCH}' (--force)"
+  # Move off the branch first if we're on it
+  if [[ "$(git rev-parse --abbrev-ref HEAD)" == "${BRANCH}" ]]; then
+    git checkout --detach >/dev/null
+  fi
+  git branch -D "${BRANCH}" >/dev/null
+fi
+
+info "creating '${BRANCH}' off '${TARGET_BASE}'"
+if ! git checkout -b "${BRANCH}" "${TARGET_BASE}" >/dev/null 2>&1; then
+  err "failed to create branch from '${TARGET_BASE}' (does the ref exist locally?)"
+  exit 1
+fi
+
+# ------------------------------------------------------- cherry-pick loop
+for i in "${!PRS[@]}"; do
+  pr="${PRS[$i]}"
+  sha="${SHAS[$i]}"
+  info "cherry-picking PR #${pr} (${sha:0:10})"
+  if ! git cherry-pick -m 1 "$sha"; then
+    err "cherry-pick failed for PR #${pr} (${sha})"
+    git cherry-pick --abort 2>/dev/null || true
+    err "branch '${BRANCH}' is at the state before the failed cherry-pick"
+    err "options:"
+    err "  - delete and retry: git branch -D '${BRANCH}'"
+    err "  - resolve manually: git cherry-pick -m 1 ${sha}, fix conflicts,"
+    err "    then 'git cherry-pick --continue' and re-pick the remaining PRs"
+    exit 1
+  fi
+done
+
+# --------------------------------------------------------------- summary
+N="${#PRS[@]}"
+echo
+info "Done. Branch '${BRANCH}' has ${N} commits on top of '${TARGET_BASE}'."
+echo
+echo "Suggested next steps:"
+echo "  git log --oneline ${TARGET_BASE}..HEAD"
+echo "  git push -u <remote> HEAD:<remote-branch>"
+echo "  gh pr create --base <base> --head <remote-branch> --repo <target-repo>"

--- a/.devcontainer/development/scripts/package-prs
+++ b/.devcontainer/development/scripts/package-prs
@@ -51,15 +51,20 @@ EOF
 err()  { printf 'Error: %s\n' "$*" >&2; }
 info() { printf '==> %s\n' "$*"; }
 
+# Guard $2 access: under `set -u`, a missing flag value would crash the script.
+need_val() {
+  [[ -n "${2-}" ]] || { err "flag '$1' requires a value"; usage >&2; exit 2; }
+}
+
 # --------------------------------------------------------------- arg parsing
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --pr)            PR_LIST="$2"; shift 2 ;;
-    --source-repo)   SOURCE_REPO="$2"; shift 2 ;;
-    --source-branch) SOURCE_BRANCH="$2"; shift 2 ;;
-    --source-remote) SOURCE_REMOTE="$2"; shift 2 ;;
-    --target-base)   TARGET_BASE="$2"; shift 2 ;;
-    --branch)        BRANCH="$2"; shift 2 ;;
+    --pr)            need_val "$1" "${2-}"; PR_LIST="$2"; shift 2 ;;
+    --source-repo)   need_val "$1" "${2-}"; SOURCE_REPO="$2"; shift 2 ;;
+    --source-branch) need_val "$1" "${2-}"; SOURCE_BRANCH="$2"; shift 2 ;;
+    --source-remote) need_val "$1" "${2-}"; SOURCE_REMOTE="$2"; shift 2 ;;
+    --target-base)   need_val "$1" "${2-}"; TARGET_BASE="$2"; shift 2 ;;
+    --branch)        need_val "$1" "${2-}"; BRANCH="$2"; shift 2 ;;
     --dry-run)       DRY_RUN=1; shift ;;
     --force)         FORCE=1; shift ;;
     -h|--help)       usage; exit 0 ;;
@@ -79,8 +84,7 @@ for i in "${!required_vars[@]}"; do
 done
 
 # Tool availability
-command -v gh  >/dev/null || { err "gh (GitHub CLI) is required";  exit 1; }
-command -v git >/dev/null || { err "git is required";               exit 1; }
+command -v git >/dev/null || { err "git is required"; exit 1; }
 
 # Working tree must be clean (we'll be checking out a new branch)
 if ! git diff-index --quiet HEAD -- 2>/dev/null; then
@@ -102,8 +106,23 @@ if ! git fetch "$SOURCE_REMOTE" "$SOURCE_BRANCH" >/dev/null 2>&1; then
   exit 1
 fi
 
-# Resolve one PR -> merge SHA, with subject sanity check
-# Echoes a single line: "<sha>|<subject>|<stats>"
+# If TARGET_BASE looks like <remote>/<branch> and the remote is configured,
+# fetch it so the new branch isn't created off a stale local ref.
+if [[ "$TARGET_BASE" == */* ]]; then
+  target_remote="${TARGET_BASE%%/*}"
+  target_branch="${TARGET_BASE#*/}"
+  if git remote get-url "$target_remote" >/dev/null 2>&1; then
+    info "Fetching ${TARGET_BASE}"
+    git fetch "$target_remote" "$target_branch" >/dev/null 2>&1 \
+      || info "warning: failed to fetch ${TARGET_BASE}; using local state"
+  else
+    info "note: --target-base='${TARGET_BASE}' is not a known remote; using local state"
+  fi
+fi
+
+# Resolve one PR -> merge SHA, with subject sanity check.
+# Echoes a single tab-separated line: "<sha>\t<subject>\t<stats>".
+# Tab is used because subjects can theoretically contain '|'.
 resolve_one() {
   local pr="$1"
   local subject sha stat
@@ -129,11 +148,11 @@ resolve_one() {
     return 1
   fi
 
-  # Optional: verify owner matches (catches wrong source repo)
+  # Note (don't fail) if owner doesn't match — fork PRs legitimately carry a
+  # contributor's username instead of the source repo owner in the subject.
   if [[ "$subject" != *"from ${SOURCE_OWNER}/"* ]]; then
-    err "PR #${pr}: SHA ${sha:0:10} not from owner '${SOURCE_OWNER}'"
-    err "  got: $subject"
-    return 1
+    info "PR #${pr}: merge subject not 'from ${SOURCE_OWNER}/...' (likely a fork PR)"
+    info "  got: $subject"
   fi
 
   # Stats: parse `git diff --shortstat`
@@ -141,23 +160,26 @@ resolve_one() {
          | sed 's/^[[:space:]]*//')
   : "${stat:=(no diff)}"
 
-  printf '%s|%s|%s\n' "$sha" "$subject" "$stat"
+  printf '%s\t%s\t%s\n' "$sha" "$subject" "$stat"
 }
 
 info "Resolving merge SHAs for PRs: ${PR_LIST}"
 
-IFS=',' read -ra PRS <<< "$PR_LIST"
-declare -a SHAS=() SUBJECTS=() STATS=()
+IFS=',' read -ra RAW_PRS <<< "$PR_LIST"
+declare -a PRS=() SHAS=() SUBJECTS=() STATS=()
 
-for pr in "${PRS[@]}"; do
+for pr in "${RAW_PRS[@]}"; do
+  # Skip empty elements from a stray comma in --pr (e.g., "1,,2" or ",1").
+  [[ -z "$pr" ]] && continue
   if ! line=$(resolve_one "$pr"); then
     err "aborting; resolution failed for PR #${pr}"
     exit 1
   fi
-  SHAS+=("${line%%|*}")
-  rest="${line#*|}"
-  SUBJECTS+=("${rest%%|*}")
-  STATS+=("${rest#*|}")
+  IFS=$'\t' read -r sha subject stat <<< "$line"
+  PRS+=("$pr")
+  SHAS+=("$sha")
+  SUBJECTS+=("$subject")
+  STATS+=("$stat")
 done
 
 # --------------------------------------------------------------- print plan
@@ -224,4 +246,8 @@ echo
 echo "Suggested next steps:"
 echo "  git log --oneline ${TARGET_BASE}..HEAD"
 echo "  git push -u <remote> HEAD:<remote-branch>"
-echo "  gh pr create --base <base> --head <remote-branch> --repo <target-repo>"
+if command -v gh >/dev/null 2>&1; then
+  echo "  gh pr create --base <base> --head <remote-branch> --repo <target-repo>"
+else
+  echo "  open a PR on GitHub via the web UI"
+fi

--- a/.devcontainer/development/scripts/package-prs.md
+++ b/.devcontainer/development/scripts/package-prs.md
@@ -60,7 +60,7 @@ package-prs --pr 2343,2344,2261 \
 
 You'll get a table like:
 
-```
+```text
 PR      SHA         SUBJECT                                                  STATS
 ------------------------------------------------------------------------------------------------------------------------
 2343    92c6707963  Merge pull request #2343 from openo-beta/...             2 files changed, 47 insertions(+), 106 deletions(-)

--- a/.devcontainer/development/scripts/package-prs.md
+++ b/.devcontainer/development/scripts/package-prs.md
@@ -1,0 +1,136 @@
+# package-prs
+
+Build a "package" branch by cherry-picking the merge commits of multiple source PRs into a single branch.
+
+## What it does
+
+Given a list of PR numbers from a source repo (e.g., `openo-beta/Open-O`), the script:
+
+1. Fetches the source repo's branch
+2. Resolves each PR to its merge commit on that branch via `git log` (not GitHub's API — see *Why* below)
+3. Sanity-checks each commit's subject matches `Merge pull request #NNNN from <owner>/...`
+4. Creates a fresh local branch off your specified base
+5. Cherry-picks each merge commit using `git cherry-pick -m 1`
+6. Aborts cleanly if any cherry-pick conflicts
+
+## Why this approach
+
+When packaging multiple PRs into a single branch (e.g., to sync `openo-beta/Open-O` fixes back to `open-osp/Open-O`), cherry-picking a PR's individual feature commits is fragile. Long-lived feature branches often have WIP commits authored against an older base, and cherry-picking those onto a different base produces conflicts that resolve toward stale code.
+
+Cherry-picking the **merge commit** with `-m 1` (mainline = parent 1) captures only the PR's net contribution — exactly what landed on the source branch — without the intermediate WIP states.
+
+The script also avoids two real bugs we hit doing this manually:
+
+- **`gh pr view --json mergeCommit` can return wrong SHAs** when PRs merge close together (returns a sibling PR's SHA). The script uses `git log --grep` against the source branch instead, which is authoritative.
+- **`git show <merge-sha>` shows a misleading combined diff** that includes inherited changes from the other parent. The script doesn't rely on `git show` for verification.
+
+## Usage
+
+```bash
+package-prs --pr 2343,2344,2345 \
+            --source-repo openo-beta/Open-O \
+            --target-base upstream-base/main \
+            --branch rx-bugfixes/20260428
+```
+
+### Flags
+
+| Flag | Required | Default | Description |
+|---|---|---|---|
+| `--pr <N,N,...>` | yes | — | Comma-separated PR numbers from source repo |
+| `--source-repo <owner/repo>` | yes | — | Source repo (e.g., `openo-beta/Open-O`) |
+| `--target-base <ref>` | yes | — | Base for the new branch (e.g., `upstream-base/main`) |
+| `--branch <name>` | yes | — | Name of the new local branch |
+| `--source-branch <ref>` | no | `develop` | Source branch to search for merge commits |
+| `--source-remote <name>` | no | `origin` | Local remote name for the source repo |
+| `--dry-run` | no | off | Print the plan and exit without changes |
+| `--force` | no | off | Overwrite the local branch if it already exists |
+| `-h`, `--help` | — | — | Show usage |
+
+### Dry-run
+
+Always run with `--dry-run` first to verify the plan:
+
+```bash
+package-prs --pr 2343,2344,2261 \
+            --source-repo openo-beta/Open-O \
+            --target-base upstream-base/main \
+            --branch test --dry-run
+```
+
+You'll get a table like:
+
+```
+PR      SHA         SUBJECT                                                  STATS
+------------------------------------------------------------------------------------------------------------------------
+2343    92c6707963  Merge pull request #2343 from openo-beta/...             2 files changed, 47 insertions(+), 106 deletions(-)
+2344    4667eb4ab0  Merge pull request #2344 from openo-beta/...             4 files changed, 8 insertions(+), 15 deletions(-)
+2261    b2765f4e4b  Merge pull request #2261 from openo-beta/...             15 files changed, 492 insertions(+), 45 deletions(-)
+```
+
+Verify each row's `#NNNN` matches the PR you intended. If a SHA looks suspicious (e.g., wrong subject), abort and investigate before re-running without `--dry-run`.
+
+## What it doesn't do
+
+- **Canary checks** — package-specific verification (e.g., "function X should still exist after these PRs apply") is your responsibility. Run them after.
+- **Conflict resolution** — if a cherry-pick conflicts, the script aborts and exits non-zero. You resolve manually.
+- **Push** — pushes are deliberate. The script prints suggested commands at the end; run them yourself.
+- **Build/test** — invoke `make install --run-tests` (or similar) separately.
+
+## Recovering from a failed cherry-pick
+
+If the script aborts mid-run:
+
+1. The branch exists with only the cherry-picks that succeeded (the failed one was aborted automatically).
+2. Two paths forward:
+   - **Abandon and retry**: `git branch -D <branch>` and re-run after fixing the underlying issue.
+   - **Resolve manually**: re-run the failed cherry-pick yourself (`git cherry-pick -m 1 <sha>`), resolve conflicts, `git cherry-pick --continue`, then continue with the remaining PRs from the dry-run table.
+
+## Examples
+
+### Build the rx-bugfixes package
+
+```bash
+package-prs --pr 2343,2344,2345,2414,2404,2413,2415,2417,2261 \
+            --source-repo openo-beta/Open-O \
+            --target-base upstream-base/main \
+            --branch rx-bugfixes/20260428
+```
+
+### Tickler package, dry-run first
+
+```bash
+# Preview
+package-prs --pr 2410,2411,2412 \
+            --source-repo openo-beta/Open-O \
+            --target-base upstream-base/main \
+            --branch tickler-bugfixes/20260428 \
+            --dry-run
+
+# Verify the table looks right, then re-run without --dry-run
+```
+
+### Different source remote
+
+If your local remote for the source repo isn't named `origin`:
+
+```bash
+package-prs --pr 2343,2344 \
+            --source-repo someorg/some-repo \
+            --source-remote someorg \
+            --target-base upstream-base/main \
+            --branch fix-package
+```
+
+## Limitations
+
+- **Devcontainer-only.** The script lives in `.devcontainer/development/scripts/` and is invokable as a bare command (`package-prs`) only inside the devcontainer. Outside the devcontainer, invoke via the explicit path.
+- **GitHub merge-commit format only.** The script searches for subjects like `Merge pull request #NNNN from owner/branch`. PRs merged via "squash" or "rebase" strategies won't have that format and won't be findable. Use a different cherry-pick approach for those.
+- **Owner check.** The script verifies merge subjects contain `from <owner>/...` to catch wrong-repo lookups. If your source repo uses unusual merge-commit formatting (e.g., merge messages edited manually), the check may fail; either adjust the merge messages or run cherry-picks manually.
+- **No build/test integration.** This is intentional — packaging is a maintenance task, not a deploy task.
+
+## When to use something else
+
+- **Just one or two PRs**: usually faster to cherry-pick by hand.
+- **Squash-merged PRs**: `git cherry-pick <squash-sha>` directly, no `-m 1` needed. The script's merge-commit subject lookup won't find squashed PRs.
+- **Conflict-heavy package**: you're going to be resolving conflicts anyway; the script's value is on the happy path.


### PR DESCRIPTION
> Note: This tool is a work in progress, it was created to make an easier and more streamlined way to send package or branches in general to other repos (such as OpenOSP, or MagentaHealth). This functionality needs to be tested and isn't very important to be added into the project currently

## Summary by Sourcery

Introduce a devcontainer-only CLI for assembling package branches from multiple source PRs and document its usage and limitations.

New Features:
- Add a package-prs devcontainer script to build a package branch by cherry-picking merge commits from multiple PRs.

Documentation:
- Add package-prs.md documenting usage, flags, workflow, recovery steps, and limitations of the new packaging tool.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `package-prs`, a devcontainer CLI to build a single “package” branch by cherry‑picking merge commits from multiple PRs. Includes docs, a `help-dev` entry, and fixes for safer arg handling and remote fetching.

- **New Features**
  - Resolves PRs to merge SHAs via `git log` and cherry‑picks with `-m 1` onto a branch from `--target-base`.
  - Supports `--dry-run`, `--force`, `--source-branch`, and `--source-remote`; checks clean working tree and verifies merge subjects (warns on owner mismatch).
  - Prints a plan table and suggested next steps; aborts cleanly on conflicts.
  - Added `package-prs.md` with usage and recovery steps; `help-dev` now lists `package-prs --help`.

- **Bug Fixes**
  - Removed hard `gh` requirement; only suggests `gh pr create` if available.
  - Guarded missing flag values and empty entries in `--pr`; warn on fork PRs rather than fail.
  - Fetches `--target-base` remote when specified to avoid stale refs; more robust plan output; fixed code fences in docs.

<sup>Written for commit 4a1c77a93e931c33c2eca85f1497baea5a1fc3f5. Summary will update on new commits. <a href="https://cubic.dev/pr/openo-beta/Open-O/pull/2427?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI tool to build “package” branches by cherry-picking merge commits from a supplied list of PRs, with input validation, dry-run and force options, conflict recovery guidance, and suggested follow-up commands.

* **Documentation**
  * Added a comprehensive guide covering the cherry-pick workflow, usage examples, dry-run output, recovery steps after conflicts, and supported/unsupported behaviors.


<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openo-beta/Open-O/pull/2427?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->