### PR TITLE
fix: stop third-party scripts from overwriting prototype's $ on the encounter window

### DIFF
--- a/src/main/webapp/casemgmt/ChartNotes.jsp
+++ b/src/main/webapp/casemgmt/ChartNotes.jsp
@@ -146,6 +146,44 @@
 </script>
 <link rel="stylesheet" type="text/css" href="<c:out value="${ctx}"/>/library/jquery/jquery-ui-1.12.1.min.css">
 <script src="<c:out value="${ctx}"/>/share/javascript/prototype.js" type="text/javascript"></script>
+<script type="text/javascript">
+    // Lock prototype.js's `$` and `$F` so nothing on the page can
+    // overwrite them after this point.
+    //
+    // Why: third-party integrations loaded into this page (browser
+    // extensions, userscripts, or embedded toolbars) sometimes pull in
+    // their own copy of jQuery and effectively run `window.$ = jQuery`.
+    // That overwrites prototype's `$`, so when prototype's own methods
+    // later call `$(element)` internally they receive a jQuery wrapper
+    // instead of a DOM node and throw inside `Form.Element.getValue`
+    // / `_getElementsByXPath`. In the encounter window this silently
+    // kills Sign & Save and Sign Save & Bill -- the button click does
+    // nothing and the user has to refresh. It happens only when the
+    // third-party script wins the race to assign `$` before the user
+    // clicks, which is why the failure looks random in practice.
+    // The fix is to stop those overwrites at the source: lock the
+    // global so the rogue assignment is a no-op.
+    //
+    // Why `writable: false` and not a get/set accessor: prototype
+    // declares `function $()` at the top of a classic script, which
+    // in modern engines creates a non-configurable global binding.
+    // Converting a non-configurable data property into an accessor
+    // is not allowed and would throw. Tightening `writable: true ->
+    // false` IS allowed on a non-configurable property, and it is
+    // enough: subsequent `window.$ = ...` assignments silently fail
+    // in non-strict callers (or throw in strict ones), and prototype's
+    // `$` survives either way.
+    (function () {
+        if (typeof window.$ === 'function') {
+            try { Object.defineProperty(window, '$', { writable: false }); }
+            catch (e) { /* property may already be locked; safe to ignore */ }
+        }
+        if (typeof window.$F === 'function') {
+            try { Object.defineProperty(window, '$F', { writable: false }); }
+            catch (e) { /* property may already be locked; safe to ignore */ }
+        }
+    })();
+</script>
 <script src="<c:out value="${ctx}"/>/share/javascript/scriptaculous.js" type="text/javascript"></script>
 <script type="text/javascript" src="<c:out value="${ctx}/js/newCaseManagementView.js.jsp"/>"></script>
 <script type="text/javascript">

--- a/src/main/webapp/casemgmt/newEncounterLayout.jsp
+++ b/src/main/webapp/casemgmt/newEncounterLayout.jsp
@@ -93,6 +93,44 @@
         </script>
 
         <script src="<c:out value="${ctx}"/>/share/javascript/prototype.js" type="text/javascript"></script>
+        <script type="text/javascript">
+            // Lock prototype.js's `$` and `$F` so nothing on the page can
+            // overwrite them after this point.
+            //
+            // Why: third-party integrations loaded into this page (browser
+            // extensions, userscripts, or embedded toolbars) sometimes pull in
+            // their own copy of jQuery and effectively run `window.$ = jQuery`.
+            // That overwrites prototype's `$`, so when prototype's own methods
+            // later call `$(element)` internally they receive a jQuery wrapper
+            // instead of a DOM node and throw inside `Form.Element.getValue`
+            // / `_getElementsByXPath`. In the encounter window this silently
+            // kills Sign & Save and Sign Save & Bill -- the button click does
+            // nothing and the user has to refresh. It happens only when the
+            // third-party script wins the race to assign `$` before the user
+            // clicks, which is why the failure looks random in practice.
+            // The fix is to stop those overwrites at the source: lock the
+            // global so the rogue assignment is a no-op.
+            //
+            // Why `writable: false` and not a get/set accessor: prototype
+            // declares `function $()` at the top of a classic script, which
+            // in modern engines creates a non-configurable global binding.
+            // Converting a non-configurable data property into an accessor
+            // is not allowed and would throw. Tightening `writable: true ->
+            // false` IS allowed on a non-configurable property, and it is
+            // enough: subsequent `window.$ = ...` assignments silently fail
+            // in non-strict callers (or throw in strict ones), and prototype's
+            // `$` survives either way.
+            (function () {
+                if (typeof window.$ === 'function') {
+                    try { Object.defineProperty(window, '$', { writable: false }); }
+                    catch (e) { /* property may already be locked; safe to ignore */ }
+                }
+                if (typeof window.$F === 'function') {
+                    try { Object.defineProperty(window, '$F', { writable: false }); }
+                    catch (e) { /* property may already be locked; safe to ignore */ }
+                }
+            })();
+        </script>
         <script src="<c:out value="${ctx}"/>/share/javascript/scriptaculous.js" type="text/javascript"></script>
 
         <script type="text/javascript" src="<c:out value="${ctx}"/>/js/messenger/messenger.js"></script>


### PR DESCRIPTION
## Issue

  `Sign & Save` and `Sign Save & Bill` in the encounter window randomly do nothing for some users. Clicking the button does not save the note and no AJAX request is sent. Refreshing the page usually makes it work again.

<img width="3034" height="1354" alt="image" src="https://github.com/user-attachments/assets/b20f4340-ba82-4564-885a-3574490c75fe" />


  ## Root cause

  Third-party integrations loaded into the encounter page (browser extensions, userscripts, embedded toolbars) bring along their own copy of jQuery and effectively run `window.$ = jQuery`. That replaces prototype.js's `$`. When prototype's own methods later call `$(element)` internally they get back a jQuery wrapper instead of a DOM node and throw inside `Form.Element.getValue` (prototype.js:2816) and `_getElementsByXPath` (prototype.js:1292) - which is exactly what shows up in the affected users' console:

```
  TypeError: element.tagName is undefined
     getValue       prototype.js:2816
     saveNoteAjax   newCaseManagementView.js.jsp:...
     onclick        ...

```
  The failure happens only when the third-party script wins the race to overwrite `$` before the user clicks, which is why it appears random.

  ## Fix

  Lock `window.$` and `window.$F` immediately after `prototype.js` loads, so later `window.$ = ...` assignments are silent no-ops and prototype's `$` survives.

## Summary by Sourcery

Bug Fixes:
- Ensure Sign & Save actions in the encounter window continue to work even when third-party scripts attempt to overwrite Prototype’s global `$` and `$F` helpers.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent third-party scripts from overwriting Prototype’s $/$F in the encounter window, fixing the random “Sign & Save” and “Sign Save & Bill” no-op clicks. We lock these globals right after prototype.js loads so injected jQuery can’t break Prototype internals.

- **Bug Fixes**
  - Lock `window.$` and `window.$F` (writable: false) immediately after prototype.js loads to block reassignment.
  - Applied in ChartNotes.jsp and newEncounterLayout.jsp to stop clicks doing nothing when no AJAX was sent.

<sup>Written for commit 9ca61dad98950082eb03d85f3d8cd80c5bde0df6. Summary will update on new commits. <a href="https://cubic.dev/pr/openo-beta/Open-O/pull/2439?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced application stability by adding protection against third-party script interference that could impact core UI functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openo-beta/Open-O/pull/2439?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->