### PR TITLE
Fix: Rx module - 404 when using "Print & Add to encounter note" button

### DIFF
--- a/src/main/webapp/oscarRx/printRx/PrintPreview.js
+++ b/src/main/webapp/oscarRx/printRx/PrintPreview.js
@@ -106,7 +106,7 @@ function addNotes(scriptId) {
     document.getElementsByName('additNotes')[0].value = document.getElementById('additionalNotes').value.replace(/\n/g, "\r\n");
 }
 
-function printIframe(ctx, providerNo, demographicNo, userName) {
+function printIframe(providerNo, demographicNo, userName, ctx) {
     const browserName = navigator.appName;
     if (browserName === "Microsoft Internet Explorer") {
         alert("Use of Microsoft Internet Explorer is not permitted")
@@ -120,7 +120,7 @@ function printIframe(ctx, providerNo, demographicNo, userName) {
         self.onfocus = function () {
             self.setTimeout(function () {
                 if (demographicNo) {
-                    openEncounter(ctx, providerNo, demographicNo, providerNo, userName);
+                    openEncounter(providerNo, demographicNo, providerNo, userName, ctx);
                 }
                 self.parent.close();
             }, 1000);
@@ -204,13 +204,13 @@ function writeToEncounter(ctx, print, text, prefPharmacy, providerNo, demographi
         })
             .then(() => {
                 if (print) {
-                    printIframe(ctx, providerNo, demographicNo, userName);
+                    printIframe(providerNo, demographicNo, userName, ctx);
                 }
             })
             .catch((e) => {
                 alert("ERROR: could not paste to EMR" + e);
                 if (print) {
-                    printIframe(ctx, providerNo, demographicNo, userName);
+                    printIframe(providerNo, demographicNo, userName, ctx);
                 }
             });
     } catch (e) {
@@ -218,7 +218,11 @@ function writeToEncounter(ctx, print, text, prefPharmacy, providerNo, demographi
     }
 }
 
-function openEncounter(ctx, providerNo, demographicNo, curProviderNo, userName) {
+function openEncounter(providerNo, demographicNo, curProviderNo, userName, ctx) {
+    if (!ctx) {
+        const contextPath = window.location.pathname.split('/')[1];
+        ctx = window.location.origin + '/' + contextPath;
+    }
     const windowProps = "height=710,width=1024,location=no,scrollbars=yes,menubars=no,toolbars=no,resizable=yes,screenX=50,screenY=50,top=20,left=20";
     const currentDate = new Date().toISOString().substring(0, 10);
     const url = ctx + "/oscarEncounter/IncomingEncounter.do?providerNo=" + providerNo + "&demographicNo=" + demographicNo + "&curProviderNo=" + curProviderNo + "&userName=" + userName + "&curDate=" + currentDate;

--- a/src/main/webapp/oscarRx/printRx/PrintPreview.js
+++ b/src/main/webapp/oscarRx/printRx/PrintPreview.js
@@ -106,7 +106,7 @@ function addNotes(scriptId) {
     document.getElementsByName('additNotes')[0].value = document.getElementById('additionalNotes').value.replace(/\n/g, "\r\n");
 }
 
-function printIframe(providerNo, demographicNo, userName) {
+function printIframe(ctx, providerNo, demographicNo, userName) {
     const browserName = navigator.appName;
     if (browserName === "Microsoft Internet Explorer") {
         alert("Use of Microsoft Internet Explorer is not permitted")
@@ -120,7 +120,7 @@ function printIframe(providerNo, demographicNo, userName) {
         self.onfocus = function () {
             self.setTimeout(function () {
                 if (demographicNo) {
-                    openEncounter(providerNo, demographicNo, providerNo, userName);
+                    openEncounter(ctx, providerNo, demographicNo, providerNo, userName);
                 }
                 self.parent.close();
             }, 1000);
@@ -204,13 +204,13 @@ function writeToEncounter(ctx, print, text, prefPharmacy, providerNo, demographi
         })
             .then(() => {
                 if (print) {
-                    printIframe(providerNo, demographicNo, userName);
+                    printIframe(ctx, providerNo, demographicNo, userName);
                 }
             })
             .catch((e) => {
                 alert("ERROR: could not paste to EMR" + e);
                 if (print) {
-                    printIframe(providerNo, demographicNo, userName);
+                    printIframe(ctx, providerNo, demographicNo, userName);
                 }
             });
     } catch (e) {
@@ -218,10 +218,10 @@ function writeToEncounter(ctx, print, text, prefPharmacy, providerNo, demographi
     }
 }
 
-function openEncounter(providerNo, demographicNo, curProviderNo, userName) {
+function openEncounter(ctx, providerNo, demographicNo, curProviderNo, userName) {
     const windowProps = "height=710,width=1024,location=no,scrollbars=yes,menubars=no,toolbars=no,resizable=yes,screenX=50,screenY=50,top=20,left=20";
     const currentDate = new Date().toISOString().substring(0, 10);
-    const url = "../oscarEncounter/IncomingEncounter.do?providerNo=" + providerNo + "&demographicNo=" + demographicNo + "&curProviderNo=" + curProviderNo + "&userName=" + userName + "&curDate=" + currentDate;
+    const url = ctx + "/oscarEncounter/IncomingEncounter.do?providerNo=" + providerNo + "&demographicNo=" + demographicNo + "&curProviderNo=" + curProviderNo + "&userName=" + userName + "&curDate=" + currentDate;
 
     if (window.parent.opener && window.parent.opener.document.forms["caseManagementEntryForm"] !== undefined) {
         // redirect if encounter window open


### PR DESCRIPTION
## Summary

`openEncounter` in `PrintPreview.js` builds the URL for the encounter window using a relative path (`"../oscarEncounter/IncomingEncounter.do?..."`). When the eChart popup that originally launched the Rx window is closed before the user clicks **Print & Add to encounter note**, the fallback branch calls `window.open(url, "encounter", windowProps)` with that relative URL. The browser resolves it against the current document's URL, which yields a path without the `/oscar` context prefix, so the new encounter window lands on a 404.

This PR threads the context path (`ctx`) through `printIframe` into `openEncounter` and builds an absolute URL, matching what `writeToEncounter` already does for `/oscarRx/WriteToEncounter.do`.

Fixes https://github.com/openo-beta/Open-O/issues/2441

## Problem

Steps to reproduce on `develop` or a `release` branch:

1. Open a patient's eChart, open the Rx module from it.
2. Close the eChart window (leaving the Rx window open) OR if for example, opening through the Search > Rx, this doesn't matter.
3. In the Rx window, add a med and click **Save and Print**.
4. In the print preview modal, click **Print & Add to encounter note**.
5. Print or cancel when prompted.

Observed: a new "encounter" window opens to a 404 (URL missing the `/oscar` context segment). The Rx note IS saved correctly — only the encounter window URL is broken.

Why it only repros when the eChart is closed:

- In `printPaste2Parent` (PrintPreview.js), when the eChart opener is present and exposes `caseManagementEntryForm` / `encForm` / `noteEditor`, the note is pasted directly into the parent and `printIframe()` is called with **no arguments**. With no `demographicNo`, `printIframe`'s `if (demographicNo) { openEncounter(...) }` guard is skipped, so `openEncounter` never runs and the bad relative URL is never used.
- When the eChart is closed, the flow falls through to `writeToEncounter(ctx, print, text, prefPharmacy, providerNo, demographicNo, curDate, providerName)`, which after the POST calls `printIframe(providerNo, demographicNo, userName)` with real args. That hits `openEncounter`, which `window.open`s the relative URL and 404s.

## Solution

In `src/main/webapp/oscarRx/printRx/PrintPreview.js`:

- `openEncounter` now takes `ctx` as its first argument and constructs `ctx + "/oscarEncounter/IncomingEncounter.do?..."` instead of `"../oscarEncounter/IncomingEncounter.do?..."`.
- `printIframe` takes `ctx` as its first argument and forwards it to `openEncounter`.
- The two `printIframe(...)` calls inside `writeToEncounter` (in the `.then` and `.catch` of the save POST) pass `ctx` along. `ctx` is already plumbed all the way from the JSP button's `onClick` (`printPasteToParent('${ctx}', ...)` where `${ctx}` = `${pageContext.request.contextPath}`) through `printPaste2Parent` and `writeToEncounter`, so no JSP change is needed.
- The four no-argument `printIframe()` calls in `printPaste2Parent` (eChart-open / encForm / noteEditor / catch branches) are intentionally left unchanged. They rely on the existing `if (demographicNo)` guard inside `printIframe` to skip `openEncounter` — print still fires, and the note paste has already happened in-place against the open eChart, so there's nothing to open.

## Summary by Sourcery

Ensure Rx print preview encounter links use a context-aware absolute URL to prevent 404s when opening encounters from the Rx module.

Bug Fixes:
- Fix 404 errors when opening the encounter window from the Rx print preview after the original eChart window is closed by building the encounter URL with a context path instead of a fragile relative path.

Enhancements:
- Propagate the application context path into print preview logic and provide a fallback derivation from the current location when it is missing, improving robustness of encounter window launches.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a 404 when clicking Print & Add to encounter note in the Rx print preview after the eChart window is closed. Encounter windows now open with an absolute, context-aware URL and a safe fallback.

- **Bug Fixes**
  - Build the encounter URL using `ctx` (or a derived fallback) instead of a relative path.
  - Pass `ctx` as the last parameter to `printIframe` and `openEncounter`; update `writeToEncounter` call sites.
  - Keep no-arg `printIframe()` flows unchanged so nothing opens when the eChart is present.

<sup>Written for commit 81f8408091bd730add222d78feecad390a450a98. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openo-beta/Open-O/pull/2443?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of print preview and encounter opening functionality by enhancing URL construction to properly utilize context information, ensuring consistent behavior across different system environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openo-beta/Open-O/pull/2443?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->