### PR TITLE
fix: disable Struts COOP interceptor - breaks named-popup window reuse

### DIFF
--- a/src/main/webapp/WEB-INF/classes/struts.xml
+++ b/src/main/webapp/WEB-INF/classes/struts.xml
@@ -61,8 +61,17 @@
                     <param name="enforcingMode">false</param>
                     <param name="exemptedPaths"/>
                 </interceptor-ref>
+                <!--
+                    COOP disabled. The Struts 6.8 default emits
+                    "Cross-Origin-Opener-Policy: same-origin" on every .do response,
+                    which isolates the popup from its opener JSP and breaks the
+                    named-window pattern window.open(url, "encounter", ...).
+                    Result: clicking E / Rx / T / C on patient search opens a new
+                    window every time instead of reusing the existing popup.
+                    Re-enable only when openers (JSPs) also send a compatible COOP.
+                -->
                 <interceptor-ref name="coop">
-                    <param name="disabled">false</param>
+                    <param name="disabled">true</param>
                     <param name="exemptedPaths"/>
                     <param name="mode">same-origin</param>
                 </interceptor-ref>


### PR DESCRIPTION
## Issue

On the patient search results page, clicking **E** (encounter) used to open a popup window; clicking **E** again reused that same window. After the Struts 6.8 upgrade in `3d8341dcb4` (CVE-2024-53677 mitigation), every click opens a brand-new window instead. Same regression affects **Rx**, **T**, **C**, and any other popup workflow that uses `window.open(url, "<name>", …)`.

## Cause

The Struts 6.8 `defaultStack` adopted in that commit bundles a `coop` interceptor that emits `Cross-Origin-Opener-Policy: same-origin` on every `.do` response. Once the popup carries that header, the browser puts it in a different browsing context group than its opener (the search page JSP, which has no COOP header), so the opener can no longer resolve the popup by its window name. Every subsequent `window.open(url, "encounter", …)` then spawns a fresh window.

## Fix

Disable the coop interceptor in struts.xml so .do responses stop sending the header. 

### What this does NOT change

- CVE-2024-53677 mitigation is intact. The fileUpload name is still rebound to ActionFileUploadInterceptor in the same <interceptors> block, and the redefined defaultStack still uses it.

## Summary by Sourcery

Bug Fixes:
- Stop Struts from sending Cross-Origin-Opener-Policy headers on .do responses so named popup windows can be reused instead of opening a new window each time.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disables the Struts COOP interceptor to stop sending COOP headers on `.do` responses, restoring reuse of named popup windows on the patient search page (E, Rx, T, C). Fixes the regression introduced by the Struts 6.8 upgrade.

- **Bug Fixes**
  - Set the `coop` interceptor `disabled` to `true` in `struts.xml`.
  - Stops `Cross-Origin-Opener-Policy: same-origin` so `window.open(url, "<name>", ...)` reuses the existing popup.
  - CVE-2024-53677 mitigation remains in place via `ActionFileUploadInterceptor`.

<sup>Written for commit 990c2cfe7c558ac803fc7f0d96e6f45549236a38. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openo-beta/Open-O/pull/2444?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled COOP (Cross-Origin-Opener-Policy) header emission to resolve compatibility issues with certain browser environments and application configurations. This change includes documentation for future re-enablement when compatible behavior is restored.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openo-beta/Open-O/pull/2444?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->