### PR TITLE
Fix Rx fax/print: 404, JS error, and collapsed print preview

### DIFF
--- a/dependencies-lock-modern.json
+++ b/dependencies-lock-modern.json
@@ -1445,11 +1445,11 @@
   }, {
     "groupId" : "net.java.dev.jna",
     "artifactId" : "jna",
-    "version" : "5.18.1",
+    "version" : "5.19.0",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:6Fmqe/AyJdrN0EPGf5OeklDj4iPvAxoMtncXl0Ni6d8r0dnXBOe1LnQIIw8B2Ba6t+wadF2c8v6ybr2DmAJsfg=="
+    "integrity" : "sha512:39wcr9Gn/7RBOMYsO3PSpIyW71rpXFEnWplfp31kueAGhvrLltpWXdRFH95prpe+2UHhjr5YzN2bXpC6V2iKDQ=="
   }, {
     "groupId" : "net.minidev",
     "artifactId" : "accessors-smart",

--- a/dependencies-lock.json
+++ b/dependencies-lock.json
@@ -1445,11 +1445,11 @@
   }, {
     "groupId" : "net.java.dev.jna",
     "artifactId" : "jna",
-    "version" : "5.18.1",
+    "version" : "5.19.0",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:6Fmqe/AyJdrN0EPGf5OeklDj4iPvAxoMtncXl0Ni6d8r0dnXBOe1LnQIIw8B2Ba6t+wadF2c8v6ybr2DmAJsfg=="
+    "integrity" : "sha512:39wcr9Gn/7RBOMYsO3PSpIyW71rpXFEnWplfp31kueAGhvrLltpWXdRFH95prpe+2UHhjr5YzN2bXpC6V2iKDQ=="
   }, {
     "groupId" : "net.minidev",
     "artifactId" : "accessors-smart",

--- a/src/main/java/ca/openosp/openo/form/pdfservlet/FrmCustomedPDFServlet.java
+++ b/src/main/java/ca/openosp/openo/form/pdfservlet/FrmCustomedPDFServlet.java
@@ -84,11 +84,7 @@ public class FrmCustomedPDFServlet extends HttpServlet {
 
             if (isFax) {
                 // this fax method shouldn't be here and will be removed in future edits.
-                // The modal Rx flow (PrintPreview.js) opts into a JSON response via __format=json so it
-                // can handle the fax result in-page; the legacy ViewScript2.jsp flow omits the flag and
-                // still receives the original HTML response unchanged.
-                boolean wantsJson = "json".equals(req.getParameter("__format"));
-                res.setContentType(wantsJson ? "application/json" : "text/html");
+                res.setContentType("text/html");
                 String faxNo = req.getParameter("pharmaFax");
                 if (faxNo != null) {
                     faxNo = faxNo.trim().replaceAll("\\D", "");
@@ -101,11 +97,7 @@ public class FrmCustomedPDFServlet extends HttpServlet {
                 String demo = req.getParameter("demographic_no");
 
                 if (faxNo != null && faxNo.length() < 7) {
-                    if (wantsJson) {
-                        writer.print("{\"status\":\"invalid_number\"}");
-                    } else {
-                        writer.println("<div id='fax-failure'><h3>Error: Valid fax number not found!</h3></div>");
-                    }
+                    writer.println("<div id='fax-failure'><h3>Error: Valid fax number not found!</h3></div>");
                 } else {
                     // write to file
                     String pdfid = req.getParameter("pdfId");
@@ -181,13 +173,7 @@ public class FrmCustomedPDFServlet extends HttpServlet {
 
                     if (validFaxNumber) {
                         LogAction.addLog(provider_no, LogConst.SENT, LogConst.CON_FAX, "PRESCRIPTION " + pdfFile);
-                        if (wantsJson) {
-                            writer.print("{\"status\":\"success\"}");
-                        } else {
 						writer.println("<div id='fax-success' style='color:green;'><h3>Fax successfully generated</h3><p>" + Encode.forHtml(pharmaName) + " (" + Encode.forHtml(faxNo) + ")</p><br><p>This window will close in <b>3</b> seconds...</p></div><script>setTimeout(() => window.top.close(), 3000);</script>");
-                        }
-                    } else if (wantsJson) {
-                        writer.print("{\"status\":\"no_fax_config\"}");
                     }
                 }
             } else {

--- a/src/main/java/ca/openosp/openo/form/pdfservlet/FrmCustomedPDFServlet.java
+++ b/src/main/java/ca/openosp/openo/form/pdfservlet/FrmCustomedPDFServlet.java
@@ -648,6 +648,10 @@ public class FrmCustomedPDFServlet extends HttpServlet {
                 listElem += newline;
             }
         }
+        // flush the final prescription; without this the last line (e.g. Qty/Repeats) is dropped when it has no trailing boundary token
+        if (!listElem.isEmpty()) {
+            listRx.add(listElem);
+        }
 
         // A0-A10, LEGAL, LETTER, HALFLETTER, _11x17, LEDGER, NOTE, B0-B5, ARCH_A-ARCH_E, FLSA
         // and FLSE

--- a/src/main/java/ca/openosp/openo/form/pdfservlet/FrmCustomedPDFServlet.java
+++ b/src/main/java/ca/openosp/openo/form/pdfservlet/FrmCustomedPDFServlet.java
@@ -84,7 +84,11 @@ public class FrmCustomedPDFServlet extends HttpServlet {
 
             if (isFax) {
                 // this fax method shouldn't be here and will be removed in future edits.
-                res.setContentType("text/html");
+                // The modal Rx flow (PrintPreview.js) opts into a JSON response via __format=json so it
+                // can handle the fax result in-page; the legacy ViewScript2.jsp flow omits the flag and
+                // still receives the original HTML response unchanged.
+                boolean wantsJson = "json".equals(req.getParameter("__format"));
+                res.setContentType(wantsJson ? "application/json" : "text/html");
                 String faxNo = req.getParameter("pharmaFax");
                 if (faxNo != null) {
                     faxNo = faxNo.trim().replaceAll("\\D", "");
@@ -97,7 +101,11 @@ public class FrmCustomedPDFServlet extends HttpServlet {
                 String demo = req.getParameter("demographic_no");
 
                 if (faxNo != null && faxNo.length() < 7) {
-                    writer.println("<div id='fax-failure'><h3>Error: Valid fax number not found!</h3></div>");
+                    if (wantsJson) {
+                        writer.print("{\"status\":\"invalid_number\"}");
+                    } else {
+                        writer.println("<div id='fax-failure'><h3>Error: Valid fax number not found!</h3></div>");
+                    }
                 } else {
                     // write to file
                     String pdfid = req.getParameter("pdfId");
@@ -173,7 +181,13 @@ public class FrmCustomedPDFServlet extends HttpServlet {
 
                     if (validFaxNumber) {
                         LogAction.addLog(provider_no, LogConst.SENT, LogConst.CON_FAX, "PRESCRIPTION " + pdfFile);
+                        if (wantsJson) {
+                            writer.print("{\"status\":\"success\"}");
+                        } else {
 						writer.println("<div id='fax-success' style='color:green;'><h3>Fax successfully generated</h3><p>" + Encode.forHtml(pharmaName) + " (" + Encode.forHtml(faxNo) + ")</p><br><p>This window will close in <b>3</b> seconds...</p></div><script>setTimeout(() => window.top.close(), 3000);</script>");
+                        }
+                    } else if (wantsJson) {
+                        writer.print("{\"status\":\"no_fax_config\"}");
                     }
                 }
             } else {

--- a/src/main/java/ca/openosp/openo/rx/RxPrintPreview2Action.java
+++ b/src/main/java/ca/openosp/openo/rx/RxPrintPreview2Action.java
@@ -338,8 +338,9 @@ public class RxPrintPreview2Action extends ActionSupport {
                     .replaceAll("\\\\n", "<br>");
         }
 
-        // Separate prescription lines with newlines so the PDF servlet renders each on its own line.
-        request.setAttribute("strRx", strRx.toString().replace(";", "\n"));
+        // Separate prescription lines with the platform line separator so the PDF servlet,
+        // which splits on System.getProperty("line.separator"), renders each on its own line.
+        request.setAttribute("strRx", strRx.toString().replace(";", System.lineSeparator()));
         request.setAttribute("strRxNoNewLines", strRxNoNewLines.toString());
         request.setAttribute("rxFullOutLines", rxFullOutLines);
     }

--- a/src/main/java/ca/openosp/openo/rx/RxPrintPreview2Action.java
+++ b/src/main/java/ca/openosp/openo/rx/RxPrintPreview2Action.java
@@ -338,7 +338,8 @@ public class RxPrintPreview2Action extends ActionSupport {
                     .replaceAll("\\\\n", "<br>");
         }
 
-        request.setAttribute("strRx", strRx.toString().replaceAll("\\\\n", "<br>"));
+        // Separate prescription lines with newlines so the PDF servlet renders each on its own line.
+        request.setAttribute("strRx", strRx.toString().replace(";", "\n"));
         request.setAttribute("strRxNoNewLines", strRxNoNewLines.toString());
         request.setAttribute("rxFullOutLines", rxFullOutLines);
     }

--- a/src/main/webapp/oscarRx/printRx/PreviewContent.jsp
+++ b/src/main/webapp/oscarRx/printRx/PreviewContent.jsp
@@ -121,6 +121,7 @@
                                        value="<%= Encode.forHtml((String)request.getAttribute("patientDOBStr")) %>"/>
                                 <input type="hidden" name="pharmaFax" value="${requestScope.pharmacyFax}"/>
                                 <input type="hidden" name="pharmaName" value="${requestScope.pharmacyName}"/>
+                                <input type="hidden" name="pharmacyInfo" value="<c:out value='${requestScope.prefPharmacyId}'/>"/>
                                 <input type="hidden" name="pracNo"
                                        value="<%= Encode.forHtml((String)request.getAttribute("pracNo")) %>"/>
                                 <input type="hidden" name="showPatientDOB" value="${requestScope.showPatientDOB}"/>

--- a/src/main/webapp/oscarRx/printRx/PreviewContent.jsp
+++ b/src/main/webapp/oscarRx/printRx/PreviewContent.jsp
@@ -136,7 +136,7 @@
                                        value="<%=Encode.forHtml((String)request.getAttribute("patientChartNo"))%>"/>
                                 <input type="hidden" name="bandNumber" value="${requestScope.bandNumber}"/>
                                 <input type="hidden" name="patientPhone"
-                                       value="<fmt:message key="RxPreview.msgTel"/>: <%=StringEscapeUtils.escapeHtml((String)request.getAttribute("patientPhone")) %>"/>
+                                       value="<fmt:message key="RxPreview.msgTel"/>: <%=Encode.forHtml((String)request.getAttribute("patientPhone")) %>"/>
                                 <input type="hidden" name="rxDate"
                                        value="<%= Encode.forHtml((String)request.getAttribute("rxDateFormatted")) %>"/>
                                 <input type="hidden" name="sigDoctorName"

--- a/src/main/webapp/oscarRx/printRx/PreviewContent.jsp
+++ b/src/main/webapp/oscarRx/printRx/PreviewContent.jsp
@@ -84,7 +84,7 @@
 <body>
     <div topmargin="0" leftmargin="0" vlink="#0000FF" id="printableContent">
 
-    <form action="/form/formname" id="preview2Form">
+    <form action="${pageContext.request.contextPath}/form/formname.do" method="post" id="preview2Form">
         <input type="hidden" name="demographic_no" value="${sessionScope.RxSessionBean.demographicNo}"/>
         <table>
             <tr>
@@ -219,7 +219,8 @@
                                        value="${requestScope.signatureRequestId}"/>
                                 <img id="signature" style="width:260px; height:130px; object-fit: contain;"
                                      src="${requestScope.startimageUrl}" alt="digital_signature"/>
-                                <input type="hidden" name="imgFile" id="imgFile" value=""/>
+                                <input type="hidden" name="imgFile" id="imgFile" value=""
+                                       data-temp-path="<%= Encode.forHtmlAttribute(String.valueOf(request.getAttribute("tempPath"))) %>"/>
 
                                 <script type="text/javascript">
                                     var POLL_TIME = 2500;

--- a/src/main/webapp/oscarRx/printRx/PreviewContent.jsp
+++ b/src/main/webapp/oscarRx/printRx/PreviewContent.jsp
@@ -136,7 +136,7 @@
                                        value="<%=Encode.forHtml((String)request.getAttribute("patientChartNo"))%>"/>
                                 <input type="hidden" name="bandNumber" value="${requestScope.bandNumber}"/>
                                 <input type="hidden" name="patientPhone"
-                                       value="<fmt:message key="RxPreview.msgTel"/><%=Encode.forHtml((String)request.getAttribute("patientPhone")) %>"/>
+                                       value="<fmt:message key="RxPreview.msgTel"/>: <%=StringEscapeUtils.escapeHtml((String)request.getAttribute("patientPhone")) %>"/>
                                 <input type="hidden" name="rxDate"
                                        value="<%= Encode.forHtml((String)request.getAttribute("rxDateFormatted")) %>"/>
                                 <input type="hidden" name="sigDoctorName"

--- a/src/main/webapp/oscarRx/printRx/PreviewContent.jsp
+++ b/src/main/webapp/oscarRx/printRx/PreviewContent.jsp
@@ -84,7 +84,7 @@
 <body>
     <div topmargin="0" leftmargin="0" vlink="#0000FF" id="printableContent">
 
-    <form action="/form/formname" styleId="preview2Form">
+    <form action="/form/formname" id="preview2Form">
         <input type="hidden" name="demographic_no" value="${sessionScope.RxSessionBean.demographicNo}"/>
         <table>
             <tr>

--- a/src/main/webapp/oscarRx/printRx/PreviewContent.jsp
+++ b/src/main/webapp/oscarRx/printRx/PreviewContent.jsp
@@ -121,7 +121,7 @@
                                        value="<%= Encode.forHtml((String)request.getAttribute("patientDOBStr")) %>"/>
                                 <input type="hidden" name="pharmaFax" value="${requestScope.pharmacyFax}"/>
                                 <input type="hidden" name="pharmaName" value="${requestScope.pharmacyName}"/>
-                                <input type="hidden" name="pharmacyInfo" value="<c:out value='${requestScope.prefPharmacyId}'/>"/>
+                                <input type="hidden" name="pharmacyInfo" value="<%= Encode.forHtmlAttribute(request.getAttribute("prefPharmacyId") != null ? request.getAttribute("prefPharmacyId").toString() : "") %>"/>
                                 <input type="hidden" name="pracNo"
                                        value="<%= Encode.forHtml((String)request.getAttribute("pracNo")) %>"/>
                                 <input type="hidden" name="showPatientDOB" value="${requestScope.showPatientDOB}"/>
@@ -221,7 +221,7 @@
                                 <img id="signature" style="width:260px; height:130px; object-fit: contain;"
                                      src="${requestScope.startimageUrl}" alt="digital_signature"/>
                                 <input type="hidden" name="imgFile" id="imgFile" value=""
-                                       data-temp-path="<%= Encode.forHtmlAttribute(String.valueOf(request.getAttribute("tempPath"))) %>"/>
+                                       data-temp-path="<%= Encode.forHtmlAttribute(request.getAttribute("tempPath") != null ? request.getAttribute("tempPath").toString() : "") %>"/>
 
                                 <script type="text/javascript">
                                     var POLL_TIME = 2500;

--- a/src/main/webapp/oscarRx/printRx/PrintPreview.js
+++ b/src/main/webapp/oscarRx/printRx/PrintPreview.js
@@ -350,7 +350,13 @@ function onPrint2(method, scriptId, useSC, scAddress, ctx) {
     const rxPageSize = $('printPageSize').value;
     console.log("rxPagesize  " + rxPageSize);
 
-    let action = ctx + "/form/createcustomedpdf?__title=Rx&__method=" + method + "&useSC=" + useSC + "&scAddress=" + scAddress + "&rxPageSize=" + rxPageSize + "&scriptId=" + scriptId;
+    let action = ctx
+        + "/form/createcustomedpdf?__title=Rx"
+        + "&__method=" + encodeURIComponent(method)
+        + "&useSC=" + encodeURIComponent(useSC)
+        + "&scAddress=" + encodeURIComponent(scAddress)
+        + "&rxPageSize=" + encodeURIComponent(rxPageSize)
+        + "&scriptId=" + encodeURIComponent(scriptId);
     document.getElementById("preview2Form").action = action;
     if (method !== "oscarRxFax") {
         document.getElementById("preview2Form").target = "_blank";

--- a/src/main/webapp/oscarRx/printRx/PrintPreview.js
+++ b/src/main/webapp/oscarRx/printRx/PrintPreview.js
@@ -52,11 +52,26 @@ function updateCurrentInteractions(myDrugRefEnabled) {
     }
 }
 
-function resetReRxDrugList(ctx) {
+/**
+ * Resolves the application context path used to build absolute request URLs.
+ * When a context path is supplied (typically threaded from the JSP via
+ * ${pageContext.request.contextPath}) it is returned unchanged; otherwise it is
+ * derived from the current location so callers that cannot inject it still produce
+ * absolute, deployment-correct URLs.
+ *
+ * @param {string} ctx the context path to use, if already known
+ * @returns {string} an absolute context path (origin + first path segment when derived)
+ */
+function resolveContextPath(ctx) {
     if (!ctx) {
         const contextPath = window.location.pathname.split('/')[1];
         ctx = window.location.origin + '/' + contextPath;
     }
+    return ctx;
+}
+
+function resetReRxDrugList(ctx) {
+    ctx = resolveContextPath(ctx);
     const url = ctx + "/oscarRx/deleteRx.do?parameterValue=clearReRxDrugList";
     const data = "";
     fetch(url, {
@@ -219,10 +234,7 @@ function writeToEncounter(ctx, print, text, prefPharmacy, providerNo, demographi
 }
 
 function openEncounter(providerNo, demographicNo, curProviderNo, userName, ctx) {
-    if (!ctx) {
-        const contextPath = window.location.pathname.split('/')[1];
-        ctx = window.location.origin + '/' + contextPath;
-    }
+    ctx = resolveContextPath(ctx);
     const windowProps = "height=710,width=1024,location=no,scrollbars=yes,menubars=no,toolbars=no,resizable=yes,screenX=50,screenY=50,top=20,left=20";
     const currentDate = new Date().toISOString().substring(0, 10);
     const url = ctx + "/oscarEncounter/IncomingEncounter.do?providerNo=" + providerNo + "&demographicNo=" + demographicNo + "&curProviderNo=" + curProviderNo + "&userName=" + userName + "&curDate=" + currentDate;
@@ -326,11 +338,12 @@ function closeRxPreviewBootstrapModal() {
     }
 }
 
-function onPrint2(method, scriptId, useSC, scAddress) {
+function onPrint2(method, scriptId, useSC, scAddress, ctx) {
+    ctx = resolveContextPath(ctx);
     const rxPageSize = $('printPageSize').value;
     console.log("rxPagesize  " + rxPageSize);
 
-    let action = "../form/createcustomedpdf?__title=Rx&__method=" + method + "&useSC=" + useSC + "&scAddress=" + scAddress + "&rxPageSize=" + rxPageSize + "&scriptId=" + scriptId;
+    let action = ctx + "/form/createcustomedpdf?__title=Rx&__method=" + method + "&useSC=" + useSC + "&scAddress=" + scAddress + "&rxPageSize=" + rxPageSize + "&scriptId=" + scriptId;
     document.getElementById("preview2Form").action = action;
     if (method !== "oscarRxFax") {
         document.getElementById("preview2Form").target = "_blank";
@@ -340,7 +353,7 @@ function onPrint2(method, scriptId, useSC, scAddress) {
     return true;
 }
 
-function sendFax(scriptId, signatureRequestId, useSC, scAddress) {
+function sendFax(scriptId, signatureRequestId, useSC, scAddress, ctx) {
     if ('function' === typeof window.onbeforeunload) {
         window.onbeforeunload = null;
     }
@@ -348,7 +361,7 @@ function sendFax(scriptId, signatureRequestId, useSC, scAddress) {
     document.getElementById('finalFax').value = faxNumber.options[faxNumber.selectedIndex].value;
     document.getElementById('pdfId').value = signatureRequestId;
 
-    onPrint2('oscarRxFax', scriptId, useSC, scAddress);
+    onPrint2('oscarRxFax', scriptId, useSC, scAddress, ctx);
 }
 
 function printPasteToParent(ctx, rxPasteAsterisk, prefPharmacy, demographicNo, providerName, providerNo, pharmacyName,

--- a/src/main/webapp/oscarRx/printRx/PrintPreview.js
+++ b/src/main/webapp/oscarRx/printRx/PrintPreview.js
@@ -271,7 +271,12 @@ function refreshImage(imgURL, signatureImg) {
     if (document.getElementById("signature") != null) {
         document.getElementById("signature").src = imgURL;
     }
-    document.getElementById('imgFile').value = signatureImg;
+    // The PDF servlet loads the signature via Image.getInstance(imgFile), which expects a
+    // local file path (or absolute URL) - not the context-relative preview servlet URL.
+    // Submit the signature's temp file path (rendered server-side as data-temp-path),
+    // mirroring the working ViewScript2.jsp flow; fall back to the preview URL if absent.
+    const imgFileElement = document.getElementById('imgFile');
+    imgFileElement.value = imgFileElement.dataset.tempPath || signatureImg;
 }
 
 function unloadMess() {
@@ -343,14 +348,116 @@ function onPrint2(method, scriptId, useSC, scAddress, ctx) {
     const rxPageSize = $('printPageSize').value;
     console.log("rxPagesize  " + rxPageSize);
 
-    let action = ctx + "/form/createcustomedpdf?__title=Rx&__method=" + method + "&useSC=" + useSC + "&scAddress=" + scAddress + "&rxPageSize=" + rxPageSize + "&scriptId=" + scriptId;
-    document.getElementById("preview2Form").action = action;
-    if (method !== "oscarRxFax") {
-        document.getElementById("preview2Form").target = "_blank";
+    const action = ctx + "/form/createcustomedpdf?__title=Rx&__method=" + method + "&useSC=" + useSC + "&scAddress=" + scAddress + "&rxPageSize=" + rxPageSize + "&scriptId=" + scriptId;
+    const form = document.getElementById("preview2Form");
+
+    if (method === "oscarRxFax") {
+        // The preview is now inlined into the host page (it used to be its own iframe). Rather than
+        // navigate the window with a form POST, submit the fax via AJAX and handle the result in-page.
+        // URLSearchParams keeps the body application/x-www-form-urlencoded so the servlet's getParameter
+        // still reads the fields. The servlet returns JSON when asked with __format=json; the legacy
+        // ViewScript2.jsp flow omits the flag and still receives its original HTML response, so this
+        // change does not affect that path.
+        const modalBody = document.getElementById("rxPreviewBootstrapModalBody");
+        // Disable the fax buttons while the request is in flight so a second click cannot queue a
+        // duplicate fax. They are re-enabled in showFaxResult only if the fax fails.
+        toggleFaxButtons(true);
+        fetch(action + "&__format=json", {method: "POST", body: new URLSearchParams(new FormData(form))})
+            .then(response => response.json())
+            .then(result => showFaxResult(result, form, modalBody))
+            .catch(() => showFaxResult({status: "error"}, form, modalBody));
+        return true;
     }
-    document.getElementById("preview2Form").submit();
+
+    form.action = action;
+    form.target = "_blank";
+    form.submit();
 
     return true;
+}
+
+/**
+ * Renders the fax result inside the Rx preview modal.
+ *
+ * On success it replaces the preview with the confirmation (filling the same area) and closes the window
+ * after a short delay, matching the previous behaviour. On failure it leaves the preview - and its fax
+ * controls - visible, re-enables the fax buttons, and shows the reason inline so the user can correct it
+ * and retry without reopening the preview.
+ *
+ * @param result    {{status: string}} the JSON response from the fax servlet
+ * @param form      the preview form, used as the source of the pharmacy name/fax for the message
+ * @param modalBody the modal body element the preview was rendered into
+ */
+function showFaxResult(result, form, modalBody) {
+    const status = result && result.status;
+
+    if (status === "success") {
+        // Replace the preview with the confirmation, filling the area the preview occupied so the modal
+        // does not shrink, and leave the message in normal top-left document flow. Capture the height
+        // before hiding the preview (the result is plain DOM now, not the old fixed-height iframe).
+        const previewHeight = modalBody.clientHeight;
+        Array.from(modalBody.children).forEach(el => el.style.display = "none");
+
+        const confirmation = document.createElement("div");
+        confirmation.id = "rxFaxResult";
+        confirmation.style.minHeight = previewHeight + "px";
+        confirmation.style.color = "green";
+        modalBody.appendChild(confirmation);
+
+        const heading = document.createElement("h3");
+        heading.textContent = "Fax successfully generated";
+        // Pharmacy name/fax are read from the submitted form and rendered via textContent (never innerHTML).
+        const pharmaName = (form.querySelector("[name='pharmaName']") || {}).value || "";
+        const pharmaFax = (form.querySelector("[name='pharmaFax']") || {}).value || "";
+        const recipient = document.createElement("p");
+        recipient.textContent = pharmaName + " (" + pharmaFax + ")";
+        const closing = document.createElement("p");
+        const countdown = document.createElement("b");
+        countdown.textContent = "3";
+        closing.append("This window will close in ", countdown, " seconds...");
+        confirmation.append(heading, recipient, document.createElement("br"), closing);
+
+        // Match the legacy behaviour: close the window once the fax is confirmed.
+        setTimeout(() => window.top.close(), 3000);
+        return;
+    }
+
+    // Failure: keep the preview and its controls visible, re-enable the fax buttons (disabled on submit),
+    // and surface the reason inline so the user can correct it and retry.
+    toggleFaxButtons(false);
+
+    let message;
+    if (status === "invalid_number") {
+        message = "Error: Valid fax number not found!";
+    } else if (status === "no_fax_config") {
+        message = "Error: No matching fax line is configured.";
+    } else {
+        message = "Error: The fax could not be sent. Please try again.";
+    }
+    showFaxError(message);
+}
+
+/**
+ * Shows (or updates) an inline fax error next to the fax button without disturbing the preview. Reuses a
+ * single error element so repeated failures replace the message rather than stacking.
+ *
+ * @param message the error text to display
+ */
+function showFaxError(message) {
+    const faxButton = document.getElementById("faxButton");
+    if (!faxButton) {
+        return;
+    }
+    let errorNote = document.getElementById("rxFaxError");
+    if (!errorNote) {
+        errorNote = document.createElement("div");
+        errorNote.id = "rxFaxError";
+        errorNote.style.color = "red";
+        errorNote.style.fontWeight = "bold";
+        errorNote.style.margin = "6px 0";
+        faxButton.parentNode.insertBefore(errorNote, faxButton);
+    }
+    errorNote.textContent = message;
 }
 
 function sendFax(scriptId, signatureRequestId, useSC, scAddress, ctx) {

--- a/src/main/webapp/oscarRx/printRx/PrintPreview.js
+++ b/src/main/webapp/oscarRx/printRx/PrintPreview.js
@@ -276,7 +276,9 @@ function refreshImage(imgURL, signatureImg) {
     // Submit the signature's temp file path (rendered server-side as data-temp-path),
     // mirroring the working ViewScript2.jsp flow; fall back to the preview URL if absent.
     const imgFileElement = document.getElementById('imgFile');
-    imgFileElement.value = imgFileElement.dataset.tempPath || signatureImg;
+    if (imgFileElement) {
+        imgFileElement.value = imgFileElement.dataset.tempPath || signatureImg;
+    }
 }
 
 function unloadMess() {

--- a/src/main/webapp/oscarRx/printRx/PrintPreview.js
+++ b/src/main/webapp/oscarRx/printRx/PrintPreview.js
@@ -348,116 +348,14 @@ function onPrint2(method, scriptId, useSC, scAddress, ctx) {
     const rxPageSize = $('printPageSize').value;
     console.log("rxPagesize  " + rxPageSize);
 
-    const action = ctx + "/form/createcustomedpdf?__title=Rx&__method=" + method + "&useSC=" + useSC + "&scAddress=" + scAddress + "&rxPageSize=" + rxPageSize + "&scriptId=" + scriptId;
-    const form = document.getElementById("preview2Form");
-
-    if (method === "oscarRxFax") {
-        // The preview is now inlined into the host page (it used to be its own iframe). Rather than
-        // navigate the window with a form POST, submit the fax via AJAX and handle the result in-page.
-        // URLSearchParams keeps the body application/x-www-form-urlencoded so the servlet's getParameter
-        // still reads the fields. The servlet returns JSON when asked with __format=json; the legacy
-        // ViewScript2.jsp flow omits the flag and still receives its original HTML response, so this
-        // change does not affect that path.
-        const modalBody = document.getElementById("rxPreviewBootstrapModalBody");
-        // Disable the fax buttons while the request is in flight so a second click cannot queue a
-        // duplicate fax. They are re-enabled in showFaxResult only if the fax fails.
-        toggleFaxButtons(true);
-        fetch(action + "&__format=json", {method: "POST", body: new URLSearchParams(new FormData(form))})
-            .then(response => response.json())
-            .then(result => showFaxResult(result, form, modalBody))
-            .catch(() => showFaxResult({status: "error"}, form, modalBody));
-        return true;
+    let action = ctx + "/form/createcustomedpdf?__title=Rx&__method=" + method + "&useSC=" + useSC + "&scAddress=" + scAddress + "&rxPageSize=" + rxPageSize + "&scriptId=" + scriptId;
+    document.getElementById("preview2Form").action = action;
+    if (method !== "oscarRxFax") {
+        document.getElementById("preview2Form").target = "_blank";
     }
-
-    form.action = action;
-    form.target = "_blank";
-    form.submit();
+    document.getElementById("preview2Form").submit();
 
     return true;
-}
-
-/**
- * Renders the fax result inside the Rx preview modal.
- *
- * On success it replaces the preview with the confirmation (filling the same area) and closes the window
- * after a short delay, matching the previous behaviour. On failure it leaves the preview - and its fax
- * controls - visible, re-enables the fax buttons, and shows the reason inline so the user can correct it
- * and retry without reopening the preview.
- *
- * @param result    {{status: string}} the JSON response from the fax servlet
- * @param form      the preview form, used as the source of the pharmacy name/fax for the message
- * @param modalBody the modal body element the preview was rendered into
- */
-function showFaxResult(result, form, modalBody) {
-    const status = result && result.status;
-
-    if (status === "success") {
-        // Replace the preview with the confirmation, filling the area the preview occupied so the modal
-        // does not shrink, and leave the message in normal top-left document flow. Capture the height
-        // before hiding the preview (the result is plain DOM now, not the old fixed-height iframe).
-        const previewHeight = modalBody.clientHeight;
-        Array.from(modalBody.children).forEach(el => el.style.display = "none");
-
-        const confirmation = document.createElement("div");
-        confirmation.id = "rxFaxResult";
-        confirmation.style.minHeight = previewHeight + "px";
-        confirmation.style.color = "green";
-        modalBody.appendChild(confirmation);
-
-        const heading = document.createElement("h3");
-        heading.textContent = "Fax successfully generated";
-        // Pharmacy name/fax are read from the submitted form and rendered via textContent (never innerHTML).
-        const pharmaName = (form.querySelector("[name='pharmaName']") || {}).value || "";
-        const pharmaFax = (form.querySelector("[name='pharmaFax']") || {}).value || "";
-        const recipient = document.createElement("p");
-        recipient.textContent = pharmaName + " (" + pharmaFax + ")";
-        const closing = document.createElement("p");
-        const countdown = document.createElement("b");
-        countdown.textContent = "3";
-        closing.append("This window will close in ", countdown, " seconds...");
-        confirmation.append(heading, recipient, document.createElement("br"), closing);
-
-        // Match the legacy behaviour: close the window once the fax is confirmed.
-        setTimeout(() => window.top.close(), 3000);
-        return;
-    }
-
-    // Failure: keep the preview and its controls visible, re-enable the fax buttons (disabled on submit),
-    // and surface the reason inline so the user can correct it and retry.
-    toggleFaxButtons(false);
-
-    let message;
-    if (status === "invalid_number") {
-        message = "Error: Valid fax number not found!";
-    } else if (status === "no_fax_config") {
-        message = "Error: No matching fax line is configured.";
-    } else {
-        message = "Error: The fax could not be sent. Please try again.";
-    }
-    showFaxError(message);
-}
-
-/**
- * Shows (or updates) an inline fax error next to the fax button without disturbing the preview. Reuses a
- * single error element so repeated failures replace the message rather than stacking.
- *
- * @param message the error text to display
- */
-function showFaxError(message) {
-    const faxButton = document.getElementById("faxButton");
-    if (!faxButton) {
-        return;
-    }
-    let errorNote = document.getElementById("rxFaxError");
-    if (!errorNote) {
-        errorNote = document.createElement("div");
-        errorNote.id = "rxFaxError";
-        errorNote.style.color = "red";
-        errorNote.style.fontWeight = "bold";
-        errorNote.style.margin = "6px 0";
-        faxButton.parentNode.insertBefore(errorNote, faxButton);
-    }
-    errorNote.textContent = message;
 }
 
 function sendFax(scriptId, signatureRequestId, useSC, scAddress, ctx) {

--- a/src/main/webapp/oscarRx/printRx/PrintPreview.jsp
+++ b/src/main/webapp/oscarRx/printRx/PrintPreview.jsp
@@ -184,7 +184,7 @@
                                         <button type="button"
                                                 class="btn btn-secondary mb-2 w-100"
                                                 id="faxButton"
-                                                onClick="sendFax(${e:forJavaScript(param.scriptId)},
+                                                onClick="sendFax('${e:forJavaScript(param.scriptId)}',
                                                     '${requestScope.signatureRequestId}',
                                                     ${requestScope.useSC != null ? requestScope.useSC : false},
                                                     '${e:forJavaScript(requestScope.selectedAddress != null ? requestScope.selectedAddress : '')}',
@@ -208,7 +208,7 @@
                                                     '${requestScope.pharmacyName}',
                                                     '${requestScope.pharmacyFax}',
                                                     '${requestScope.prescribedBy}');
-                                                        sendFax(${e:forJavaScript(param.scriptId)},
+                                                        sendFax('${e:forJavaScript(param.scriptId)}',
                                                     '${requestScope.signatureRequestId}',
                                                     ${requestScope.useSC != null ? requestScope.useSC : false},
                                                     '${e:forJavaScript(requestScope.selectedAddress != null ? requestScope.selectedAddress : '')}',
@@ -235,9 +235,9 @@
                                 <div class="form-group">
                                     <label for="additionalNotes"></label>
                                     <textarea id="additionalNotes" class="form-control mb-2"
-                                              onchange="addNotes(${e:forJavaScript(param.scriptId)});"></textarea>
+                                              onchange="addNotes('${e:forJavaScript(param.scriptId)}');"></textarea>
                                     <button type="button" class="btn btn-primary"
-                                            onclick="addNotes(${e:forJavaScript(param.scriptId)});">
+                                            onclick="addNotes('${e:forJavaScript(param.scriptId)}');">
                                         Additional Rx Notes
                                     </button>
                                 </div>

--- a/src/main/webapp/oscarRx/printRx/PrintPreview.jsp
+++ b/src/main/webapp/oscarRx/printRx/PrintPreview.jsp
@@ -208,7 +208,7 @@
                                                     '${requestScope.pharmacyName}',
                                                     '${requestScope.pharmacyFax}',
                                                     '${requestScope.prescribedBy}');
-                                                        sendFax(${e:forHtml(param.scriptId)},
+                                                        sendFax(${e:forJavaScript(param.scriptId)},
                                                     '${requestScope.signatureRequestId}',
                                                     ${requestScope.useSC != null ? requestScope.useSC : false},
                                                     '${e:forJavaScript(requestScope.selectedAddress != null ? requestScope.selectedAddress : '')}',

--- a/src/main/webapp/oscarRx/printRx/PrintPreview.jsp
+++ b/src/main/webapp/oscarRx/printRx/PrintPreview.jsp
@@ -185,9 +185,10 @@
                                                 class="btn btn-secondary mb-2 w-100"
                                                 id="faxButton"
                                                 onClick="sendFax(${e:forJavaScript(param.scriptId)},
-                                                    ${requestScope.signatureRequestId},
+                                                    '${requestScope.signatureRequestId}',
                                                     ${requestScope.useSC != null ? requestScope.useSC : false},
-                                                    ${requestScope.selectedAddress != null ? requestScope.selectedAddress : ''}
+                                                    '${e:forJavaScript(requestScope.selectedAddress != null ? requestScope.selectedAddress : '')}',
+                                                    '${ctx}'
                                                         );"
                                                 <c:if test="${requestScope.isFaxDisabled}">
                                                     disabled="disabled"
@@ -208,9 +209,10 @@
                                                     '${requestScope.pharmacyFax}',
                                                     '${requestScope.prescribedBy}');
                                                         sendFax(${e:forHtml(param.scriptId)},
-                                                    ${requestScope.signatureRequestId},
+                                                    '${requestScope.signatureRequestId}',
                                                     ${requestScope.useSC != null ? requestScope.useSC : false},
-                                                    ${requestScope.selectedAddress != null ? requestScope.selectedAddress : ''}
+                                                    '${e:forJavaScript(requestScope.selectedAddress != null ? requestScope.selectedAddress : '')}',
+                                                    '${ctx}'
                                                         );"
                                                 <c:if test="${requestScope.isFaxDisabled}">
                                                     disabled="disabled"


### PR DESCRIPTION
## Summary

Restores the ability to **fax and print a prescription** end-to-end. The faxing flow was failing at several points: a 404 before the PDF could even be generated, a JavaScript type error in the preview, and — most visibly — a print preview / faxed PDF that rendered with prescription lines collapsed together, the **Qty/Repeats** line missing, and the pharmacy **"ATTENTION:"** header absent.

This PR fixes each defect at its root and keeps the PDF output faithful to the pre-refactor layout.

Fixes #2454 

## Problem

Faxing/printing an Rx was broken by a chain of issues, each unmasking the next:

1. **404 on fax** — a relative fax path was resolved without the application context path, so the request 404'd from the JSP before the servlet ran.
2. **JS type error** — a leftover Struts 1 `styleId` usage produced a JavaScript type error when initiating the fax.
3. **Collapsed preview / PDF** — even once the PDF generated, its content was wrong:
   - prescription lines ran together instead of breaking onto separate lines;
   - the **Qty/Repeats** line (the last line of each prescription) was silently dropped;
   - the pharmacy **"ATTENTION:"** block never appeared on the faxed Rx.

## Solution

### 1. Context path resolution (404)
Resolve the fax path against the application context path, with a defensive fallback, so the request reaches the PDF servlet instead of 404'ing. Shared into a small helper to avoid duplication.

### 2. Struts 1 `styleId` removal (JS error)
Drop the legacy `styleId` usage that triggered the JavaScript type error in the preview.

### 3. Collapsed preview / PDF — three root-cause fixes

- **Prescription line breaks** (`RxPrintPreview2Action.java`)
  `strRx` is the input to the **PDF** servlet, which separates lines on real newline characters. A refactor had swapped its transform for the **HTML preview's** treatment (`\n → <br>`), which (a) produces markup the PDF can't use and (b) was a no-op against the actual data — leaving `strRx` semicolon-delimited with zero newlines, so the PDF couldn't break lines.
  **Fix:** restore the correct PDF transform, converting the `;` delimiters back into real newlines (`replace(";", "\n")`). The HTML-preview attributes (`<br>`-based) are left untouched.

- **Dropped trailing line — Qty/Repeats** (`FrmCustomedPDFServlet.java`)
  The servlet's prescription parser only moves an accumulated line block into the render list when it hits a boundary token, and it had **no flush after the loop ends**. The whole feature was accidentally relying on a trailing separator (`;;`) to emit that final boundary. A later refactor switched to `StringJoiner(";;")`, which drops the trailing separator — so the **last line of each prescription (Qty/Repeats) was never flushed** and silently disappeared from the PDF.
  **Fix:** add a guarded final flush after the parse loop. It's safe for every caller (if the input already ended on a boundary, the buffer is empty and nothing is added — no duplicates), and it removes the dependency on the fragile trailing-token behavior. This also protects the legacy live-fax path that shares the same servlet.

- **Pharmacy "ATTENTION:" block** (`PreviewContent.jsp`)
  The ATTENTION header is rendered by the PDF servlet from a `pharmacyInfo` id. That field historically lived only in the legacy `ViewScript2.jsp` flow (JS-injected when a pharmacy is selected). When the modern print/fax preview was extracted into `PreviewContent.jsp`, the field was never ported — a migration gap, not a deleted line.
  **Fix:** add the `pharmacyInfo` hidden field to the modern preview (OWASP-encoded via `<c:out>`). It is empty when no pharmacy is associated, in which case the servlet simply skips the block.

> An earlier commit experimented with submitting the fax via AJAX and containing the confirmation inside the preview modal; this was **reverted** per a team decision, so the net behavior here is unchanged on that front.

## Files changed (Rx fax/print)

- `src/main/java/ca/openosp/openo/form/pdfservlet/FrmCustomedPDFServlet.java` — final flush so the last prescription line (Qty/Repeats) renders.
- `src/main/java/ca/openosp/openo/rx/RxPrintPreview2Action.java` — restore `strRx` `;`→newline transform for the PDF.
- `src/main/webapp/oscarRx/printRx/PreviewContent.jsp` — port the `pharmacyInfo` field for the ATTENTION block.
- `src/main/webapp/oscarRx/printRx/PrintPreview.js`, `PrintPreview.jsp`, `WEB-INF/classes/struts.xml` — context-path resolution (404) and Struts 1 `styleId` removal (JS error).

## Testing

- Faxed and printed prescriptions render correctly: each prescription on its own line, **Qty/Repeats** present, and the pharmacy **"ATTENTION:"** header shown when a pharmacy is associated.
- Verified the parse-loop fix does not duplicate output for callers that still send a trailing separator (legacy `ViewScript2.jsp` / `Preview2.jsp` live-fax path), keeping the faxed layout consistent with the pre-refactor output.

## Summary by Sourcery

Fix prescription fax/print so requests reach the PDF servlet and the generated output matches the expected Rx layout.

Bug Fixes:
- Resolve fax/print URLs against the application context path so PDF generation no longer 404s.
- Remove legacy Struts styleId usage and correct JavaScript wiring to prevent preview-time errors.
- Ensure prescription text sent to the PDF servlet uses proper line separators so each prescription line renders separately.
- Flush the final parsed prescription block in the PDF servlet so trailing lines like Qty/Repeats are no longer dropped.
- Provide the correct signature image path to the PDF servlet so it can reliably load the signed image.
- Pass pharmacy information through the modern preview form so the ATTENTION header appears on faxed/printed prescriptions.

Enhancements:
- Centralize context-path resolution in the print preview JavaScript to reuse consistent URL construction.
- Align the modern preview form action and method with the PDF servlet endpoint, improving robustness across deployments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the last prescription segment was being dropped during PDF document generation.

* **New Features**
  * Added pharmacy information capture in prescription preview forms.
  * Enhanced signature image path handling in prescriptions.
  * Improved URL path resolution for print and fax operations.

* **Improvements**
  * Updated prescription preview formatting for better display consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->