### PR TITLE
Fix: edge cases where session filter removing already saved med stashes were not firing due to redirects directly to SearchDrug3.jsp

### DIFF
--- a/src/main/java/ca/openosp/openo/prescript/pageUtil/RxSessionFilter.java
+++ b/src/main/java/ca/openosp/openo/prescript/pageUtil/RxSessionFilter.java
@@ -30,7 +30,7 @@ public class RxSessionFilter implements Filter {
     private static final Logger logger = MiscUtils.getLogger();
     private static final String LEGACY_KEY = "RxSessionBean";
     private static final String PATIENT_KEY = "Patient";
-    private static final String STAGING_PAGE_SUFFIX = "/oscarRx/SearchDrug3.jsp";
+    private static final String STAGING_PAGE_PATH = "/oscarRx/SearchDrug3.jsp";
 
     /**
      * {@inheritDoc}
@@ -112,7 +112,7 @@ public class RxSessionFilter implements Filter {
             // persisted by a completed save (unsaved drafts, drugId == 0, are kept).
             // Action entries (e.g. choosePatient.do) forward here and reconcile themselves;
             // this REQUEST-scoped filter skips forwards, so there is no double-clear.
-            if (request.getRequestURI().endsWith(STAGING_PAGE_SUFFIX)) {
+            if (STAGING_PAGE_PATH.equals(request.getServletPath())) {
                 RxSessionBean currentBean = (RxSessionBean) session.getAttribute(LEGACY_KEY);
                 if (currentBean != null) {
                     currentBean.removePersistedStashItems();

--- a/src/main/java/ca/openosp/openo/prescript/pageUtil/RxSessionFilter.java
+++ b/src/main/java/ca/openosp/openo/prescript/pageUtil/RxSessionFilter.java
@@ -30,6 +30,7 @@ public class RxSessionFilter implements Filter {
     private static final Logger logger = MiscUtils.getLogger();
     private static final String LEGACY_KEY = "RxSessionBean";
     private static final String PATIENT_KEY = "Patient";
+    private static final String STAGING_PAGE_SUFFIX = "/oscarRx/SearchDrug3.jsp";
 
     /**
      * {@inheritDoc}
@@ -104,6 +105,17 @@ public class RxSessionFilter implements Filter {
                             session.setAttribute(PATIENT_KEY, patient);
                         }
                     }
+                }
+            }
+
+            // On a direct browser load/refresh of the staging page, drop drugs already
+            // persisted by a completed save (unsaved drafts, drugId == 0, are kept).
+            // Action entries (e.g. choosePatient.do) forward here and reconcile themselves;
+            // this REQUEST-scoped filter skips forwards, so there is no double-clear.
+            if (request.getRequestURI().endsWith(STAGING_PAGE_SUFFIX)) {
+                RxSessionBean currentBean = (RxSessionBean) session.getAttribute(LEGACY_KEY);
+                if (currentBean != null) {
+                    currentBean.removePersistedStashItems();
                 }
             }
         }


### PR DESCRIPTION
## Summary

Fix edge case issues where the session filter was not removing already saved med stashes due to redirects directly to SearchDrug3.jsp

## Summary by Sourcery

Bug Fixes:
- Clear already-saved medication stash items on direct requests to the SearchDrug3.jsp staging page while preserving unsaved drafts.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale medication stash when users load or refresh the staging page directly. Direct hits to /oscarRx/SearchDrug3.jsp now clear already-saved meds while keeping unsaved drafts.

- **Bug Fixes**
  - Use request.getServletPath() to match the exact "/oscarRx/SearchDrug3.jsp" path, then call removePersistedStashItems() on the session bean.
  - Applies only to direct requests; forwards are skipped to avoid double-clearing.

<sup>Written for commit ab87ea1a7cc1df99cfde4ce7fb0ef5580dc5d309. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openo-beta/Open-O/pull/2458?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where session data was not properly cleared when directly accessing the drug search staging page, improving data consistency during direct page loads and refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->