### PR TITLE
Fix: Rx encounter note sometimes contains unrendered linebreak characters

### DIFF
--- a/src/main/java/ca/openosp/openo/prescript/pageUtil/RxWriteToEncounter2Action.java
+++ b/src/main/java/ca/openosp/openo/prescript/pageUtil/RxWriteToEncounter2Action.java
@@ -49,8 +49,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Locale;
 
-import org.owasp.encoder.Encode;
-
 import org.apache.struts2.ActionSupport;
 import org.apache.struts2.ServletActionContext;
 
@@ -83,7 +81,8 @@ public class RxWriteToEncounter2Action extends ActionSupport {
         CaseManagementTmpSave tmpSave = caseManagementMgr.getTmpSave(loggedInInfo.getLoggedInProviderNo(), demographicNo, programNo);
         Date today = new Date();
         if (tmpSave != null) {
-            String noteBody = generateNote(loggedInInfo, Encode.forJavaScript(request.getParameter("body")), false);
+            // Store the body raw, like the branches below; encoding it here leaked literal \n and \/ into the saved note (issue #2452).
+            String noteBody = generateNote(loggedInInfo, request.getParameter("body"), false);
 
             if (tmpSave.getNoteId() > 0) {
                 note = caseManagementMgr.getNote(String.valueOf(tmpSave.getNoteId()));

--- a/src/main/webapp/casemgmt/ChartNotesAjax.jsp
+++ b/src/main/webapp/casemgmt/ChartNotesAjax.jsp
@@ -1124,7 +1124,7 @@ EmailComposeManager emailComposeManager = SpringUtils.getBean(EmailComposeManage
             encounterText = "\n[" + apptDate + " .: " + reason + "]\n";
         }
 
-        encounterText = Encode.forJavaScript(encounterText);
+        // Return raw; the sole caller JS-encodes at the output point.
         return encounterText;
     }
 


### PR DESCRIPTION
## Summary

Encounter notes sometimes displayed raw escape sequences — literal `\n` where line breaks should be, and `\/` / `\-` instead of `/` / `-`. This PR fixes the two independent causes:

1. **Rx → "Print/Fax & Add to encounter note"** wrongly JS-encoded the note body before persisting it (the reported #2452 bug).
2. **eChart "New Note"** double JS-encoded the date header it seeds the note with (a develop-only regression found while verifying `#1`).

Both stem from the same anti-pattern: applying `Encode.forJavaScript(...)` to text that is stored/displayed as **data**, not consumed as JavaScript source.

Fixes #2452

## Problem

### 1. Rx note body (issue #2452)

When a prescription was pasted via **Save & Print → "Print & Add to encounter note"** or **"Fax & Add to encounter note"**, the note sometimes contained literal `\n` and `\/`.

- Root cause: in `RxWriteToEncounter2Action`, the `tmpSave != null` branch wrapped the note body in `Encode.forJavaScript(request.getParameter("body"))` before saving it. The other two branches stored the body raw. Since the body is persisted note text (never parsed as JS), the escapes rendered literally — newline → `\n`, `/` → `\/`.
- Intermittent because it required **both**: the server-side paste path (Rx opened standalone, not from an open eChart that acts as the window opener) **and** an existing `tmpSave` draft (an auto-saved, unsaved encounter note) for that provider/demographic/program. The paste then consumes the `tmpSave`, so the next paste often looked clean — hence the "sometimes."

### 2. New Note date header (develop-only)

Clicking **"New Note"** in the eChart produced a header like `\n[08\-Jun\-2026 .: ] \n` (literal `\n` and escaped dashes).

- Path: `casemgmt/ChartNotes.jsp` → AJAX `casemgmt/ChartNotesAjax.jsp` → `insertReason(request)` builds the `[date .: reason]` header → assigned to the JS `reason` var → seeds the new note textarea.
- Root cause: **double `Encode.forJavaScript`** — once inside `insertReason()` and again at the call site. The JS literal only unescapes one level, leaving literal `\n`/`\-` in the textarea.

## Solution

- **`RxWriteToEncounter2Action.java`** — removed the `Encode.forJavaScript(...)` wrapper on the note body in the `tmpSave` branch so all three branches persist the raw body identically (matching the other branches and the legacy action). Removed the now-unused `Encode` import.
- **`casemgmt/ChartNotesAjax.jsp`** — removed the redundant **inner** `Encode.forJavaScript` in `insertReason()`, keeping the single encode at the JSP output point. Result: the header is encoded exactly once for the JS-string context and unescapes to real newlines in the textarea.

These are data, not JavaScript. Output/display layers already encode appropriately (e.g. notes are HTML-encoded at render time in `casemgmt/viewNotes.jsp`), so storing the raw text is correct and not an XSS regression.

## Develop-specific note (do not cherry-pick fix `#2` to release)

The two fixes have different branch profiles:

- **Fix `#1` (Rx body)** — the buggy action is **identical on `develop` and `release/2026-03-17`**, so this fix applies to both branches and should port directly.
- **Fix `#2` (New Note header)** — **`develop`-only.** `release/2026-03-17` already encodes the header exactly once (`<%=insertReason(request)%>` raw call site + the inner encode) and renders correctly. The double-encode on `develop` was introduced by a more recent encoder/output-encoding sweep that added the call-site `Encode.forJavaScript(...)` without noticing `insertReason()` already encoded internally.

  **When backporting to `release`, cherry-pick only the Rx fix — do not include the `ChartNotesAjax.jsp` change**, or you will remove release's single (correct) encode and re-introduce a raw output.

## Testing

Reliable repro (both work the same on `develop`; only fix `#1` is reproducible on `release`):

**Rx body (#2452):**
1. Open a patient's eChart, type into a note but **don't save/sign** it (creates the `tmpSave` draft).
2. Close the eChart window (forces the standalone/server paste path).
3. From the patient, open **Rx** → prescribe a med (include a `/`, e.g. `1/2 tab`) → **Save & Print → "Print & Add to encounter note"**.
4. Reopen the note → before: literal `\n` and `\/`; after: real line breaks and plain `/`.

**New Note header (develop-only):**
1. In the eChart, click **"New Note"**.
2. Before: header shows `\n[…\-…] \n`; after: header renders on its own lines with normal dashes.

## Summary by Sourcery

Prevent encounter notes from storing JavaScript-encoded text so line breaks and punctuation render correctly in Rx-derived notes and new eChart notes.

Bug Fixes:
- Ensure Rx 'Print/Fax & Add to encounter note' saves the raw note body instead of a JavaScript-encoded string, avoiding literal escape sequences like \n and \/ in encounter notes.
- Return the new-note header text unencoded from ChartNotesAjax so it is only JavaScript-encoded once by the caller and displays real line breaks and characters.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes notes showing literal \n, \/ and \- by removing incorrect JS encoding when writing Rx notes and seeding the “New Note” header. Notes now render real line breaks and characters (fixes #2452).

- **Bug Fixes**
  - Rx → “Print/Fax & Add to encounter note”: in `RxWriteToEncounter2Action`, stop JS-encoding `body` in the `tmpSave` branch; persist raw text consistently.
  - eChart “New Note” (develop only): in `casemgmt/ChartNotesAjax.jsp`, remove the inner `Encode.forJavaScript(...)`; the caller encodes once at output.

- **Migration**
  - When backporting to release, cherry-pick only the Rx fix; do not change `ChartNotesAjax.jsp`.

<sup>Written for commit 9c8624fb27a74eac2ea3e96f3a4c2f5366b1abb1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openo-beta/Open-O/pull/2462?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated note processing to handle text encoding at the output stage instead of during data processing.
  * Notes will no longer contain escaped character sequences from encoding operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->