### PR TITLE
Fix: discontinue not working correctly when clicked + adjacent drug-list display fixes

### DIFF
--- a/src/main/webapp/oscarRx/ListDrugs.jsp
+++ b/src/main/webapp/oscarRx/ListDrugs.jsp
@@ -191,7 +191,7 @@
             data-is-current="<%= prescriptDrug.isCurrent() %>"
             data-is-external="<%= prescriptDrug.isExternal() %>">
 
-        <td><a id="createDate_<%=Encode.forHtmlAttribute(String.valueOf(prescriptIdInt))%>" <%=styleColor%> href="<%= request.getContextPath() %>/oscarRx/StaticScript2.jsp?regionalIdentifier=<%=Encode.forUriComponent(prescriptDrug.getRegionalIdentifier())%>&amp;cn=<%=Encode.forUriComponent(prescriptDrug.getCustomName())%>&amp;bn=<%=Encode.forUriComponent(bn)%>&amp;atc=<%=Encode.forUriComponent(prescriptDrug.getAtc())%>"><%=Encode.forHtml(String.valueOf(DateToString(prescriptDrug.getCreateDate())))%></a></td>
+        <td><a id="createDate_<%=Encode.forHtmlAttribute(String.valueOf(prescriptIdInt))%>" class="<%=Encode.forHtmlAttribute(String.valueOf(styleColor))%>" href="<%= request.getContextPath() %>/oscarRx/StaticScript2.jsp?regionalIdentifier=<%=Encode.forUriComponent(prescriptDrug.getRegionalIdentifier())%>&amp;cn=<%=Encode.forUriComponent(prescriptDrug.getCustomName())%>&amp;bn=<%=Encode.forUriComponent(bn)%>&amp;atc=<%=Encode.forUriComponent(prescriptDrug.getAtc())%>"><%=Encode.forHtml(String.valueOf(DateToString(prescriptDrug.getCreateDate())))%></a></td>
             <%-- data-order: DataTables sorts this column by the attribute value instead of the cell
                  content. When start date is unknown the cell renders empty, so we fall back to
                  createDate to maintain parity with the previous server-side sort, which used
@@ -204,7 +204,7 @@
                     String startDate = UtilDateUtilities.DateToString(prescriptDrug.getRxDate());
                     startDate = partialDateDao.getDatePartial(startDate, PartialDate.DRUGS, prescriptDrug.getId(), PartialDate.DRUGS_STARTDATE);
                 %>
-                <a id="rxDate_<%=Encode.forHtmlAttribute(String.valueOf(prescriptIdInt))%>"   <%=Encode.forHtml(String.valueOf(styleColor))%>
+                <a id="rxDate_<%=Encode.forHtmlAttribute(String.valueOf(prescriptIdInt))%>"   class="<%=Encode.forHtmlAttribute(String.valueOf(styleColor))%>"
                    href="<%= request.getContextPath() %>/oscarRx/StaticScript2.jsp?regionalIdentifier=<%=Encode.forUriComponent(prescriptDrug.getRegionalIdentifier())%>&amp;cn=<%=Encode.forUriComponent(prescriptDrug.getCustomName())%>&amp;bn=<%=Encode.forUriComponent(bn)%>"><%=Encode.forHtml(String.valueOf(startDate))%>
                 </a>
                 <% } %>
@@ -238,7 +238,7 @@
 			}
 			
 			%>
-            <td><a id="prescrip_<%=Encode.forHtmlAttribute(String.valueOf(prescriptIdInt))%>" <%=styleColor%> href="<%= request.getContextPath() %>/oscarRx/StaticScript2.jsp?regionalIdentifier=<%=Encode.forUriComponent(prescriptDrug.getRegionalIdentifier())%>&amp;cn=<%=Encode.forUriComponent(prescriptDrug.getCustomName())%>&amp;bn=<%=Encode.forUriComponent(bn)%>&amp;atc=<%=Encode.forUriComponent(prescriptDrug.getAtc())%>"   <%=tComment%>   ><%=Encode.forHtml(String.valueOf(RxPrescriptionData.getFullOutLine(prescriptDrug.getSpecial()).replaceAll(";", " ")))%></a></td>
+            <td><a id="prescrip_<%=Encode.forHtmlAttribute(String.valueOf(prescriptIdInt))%>" class="<%=Encode.forHtmlAttribute(String.valueOf(styleColor))%>" href="<%= request.getContextPath() %>/oscarRx/StaticScript2.jsp?regionalIdentifier=<%=Encode.forUriComponent(prescriptDrug.getRegionalIdentifier())%>&amp;cn=<%=Encode.forUriComponent(prescriptDrug.getCustomName())%>&amp;bn=<%=Encode.forUriComponent(bn)%>&amp;atc=<%=Encode.forUriComponent(prescriptDrug.getAtc())%>"   <%=tComment%>   ><%=Encode.forHtml(String.valueOf(RxPrescriptionData.getFullOutLine(prescriptDrug.getSpecial()).replaceAll(";", " ")))%></a></td>
 			<%            			
 	           	if(securityManager.hasWriteAccess("_rx",roleName$,true)) {            		
            	%>
@@ -266,7 +266,7 @@
             <td>
 
                 <%if (prescriptDrug.getRemoteFacilityName() == null) {%>
-                <a id="del_<%=Encode.forHtmlAttribute(String.valueOf(prescriptIdInt))%>" name="delete" <%=Encode.forHtml(String.valueOf(styleColor))%> href="javascript:void(0);"
+                <a id="del_<%=Encode.forHtmlAttribute(String.valueOf(prescriptIdInt))%>" name="delete" class="<%=Encode.forHtmlAttribute(String.valueOf(styleColor))%>" href="javascript:void(0);"
                    onclick="Delete2(this);">Del</a>
                 <%}%>
             </td>
@@ -283,7 +283,7 @@
 					if(securityManager.hasWriteAccess("_rx",roleName$,true)) {            		
 				
                 %>
-                	<a id="discont_<%=Encode.forHtmlAttribute(String.valueOf(prescriptIdInt))%>" href="javascript:void(0);" onclick="Discontinue(event,this);" <%=Encode.forHtml(String.valueOf(styleColor))%> >Discon</a>                
+                	<a id="discont_<%=Encode.forHtmlAttribute(String.valueOf(prescriptIdInt))%>" href="javascript:void(0);" onclick="Discontinue(event,this);" class="<%=Encode.forHtmlAttribute(String.valueOf(styleColor))%>" >Discon</a>                
                 <% }
                	 }
                 }else{%>
@@ -492,7 +492,12 @@
     }
 
     String getClassColour(Drug drug, long referenceTime, long durationToSoon) {
-        StringBuilder sb = new StringBuilder("class=\"");
+        // Returns only the space-separated CSS class tokens (e.g. "currentDrug expireInReference"),
+        // or "" when none apply. Callers wrap this in class="..." and OWASP-encode it as an
+        // attribute value (Encode.forHtmlAttribute). Do NOT re-add the class="..." wrapper here:
+        // emitting a full attribute fragment and then running it through Encode.forHtml() double-
+        // encodes the quotes (class=&#34;...&#34;) and breaks the drug row styling.
+        StringBuilder sb = new StringBuilder();
 
         if (!drug.isLongTerm() && (drug.isCurrent() && drug.getEndDate() != null && (drug.getEndDate().getTime() - referenceTime <= durationToSoon))) {
             sb.append("expireInReference ");
@@ -524,20 +529,12 @@
         }
 
         if (drug.getOutsideProviderName() != null && !drug.getOutsideProviderName().equals("")) {
-            sb = new StringBuilder("class=\"");
-            sb.append("external ");
+            sb = new StringBuilder("external ");
         }
         if (drug.getRemoteFacilityName() != null) {
-            sb = new StringBuilder("class=\"");
-            sb.append("external ");
+            sb = new StringBuilder("external ");
         }
-        String retval = sb.toString();
-
-        if (retval.equals("class=\"")) {
-            return "";
-        }
-
-        return retval.substring(0, retval.length()) + "\"";
+        return sb.toString().trim();
 
     }
     

--- a/src/main/webapp/oscarRx/SearchDrug3.jsp
+++ b/src/main/webapp/oscarRx/SearchDrug3.jsp
@@ -1023,7 +1023,6 @@
 
     #discontinueUI {
       position: absolute;
-      display: none;
       width: 500px;
       height: 200px;
       background-color: white;
@@ -1491,7 +1490,8 @@
 
 
 <div id="dragifm"></div>
-<div id="discontinueUI">
+<%-- hidden attribute is toggled by JS (hidden = true/false) — do not move to CSS as display:none or the discontinue popup will not open (Prototype show() cannot override a stylesheet rule) --%>
+<div id="discontinueUI" hidden>
   <h3>Discontinue :<span id="disDrug"></span></h3>
   <input type="hidden" name="disDrugId" id="disDrugId"/>
   <fmt:setBundle basename="oscarResources"/><fmt:message key="oscarRx.discontinuedReason.msgReason"/>
@@ -1535,7 +1535,7 @@
   <br/>
   <fmt:setBundle basename="oscarResources"/><fmt:message key="oscarRx.discontinuedReason.msgComment"/><br/>
   <textarea id="disComment" rows="3" cols="45"></textarea><br/>
-  <input type="button" onclick="$('discontinueUI').hide();" value="Cancel"/>
+  <input type="button" onclick="document.getElementById('discontinueUI').hidden = true;" value="Cancel"/>
   <input type="button"
          onclick="Discontinue2($('disDrugId').value,$('disReason').value,$('disComment').value,$('disDrug').innerHTML);"
          value="Discontinue"/>
@@ -2112,7 +2112,7 @@
     let drugName = prescripElement ? prescripElement.textContent : '';
     $('discontinueUI').setStyle(styleStr);
     safeSetText('disDrug', drugName);
-    $('discontinueUI').show();
+    document.getElementById('discontinueUI').hidden = false;
     $('disDrugId').value = id;
   }
 
@@ -2125,7 +2125,7 @@
       onSuccess: function (transport) {
         try {
           let json = JSON.parse(transport.responseText);
-          $('discontinueUI').hide();
+          document.getElementById('discontinueUI').hidden = true;
           $('rxDate_' + json.id).style.textDecoration = 'line-through';
           $('reRx_' + json.id).style.textDecoration = 'line-through';
           $('del_' + json.id).style.textDecoration = 'line-through';
@@ -2137,7 +2137,7 @@
       },
       onFailure: function (transport) {
         console.error('Discontinue request failed with status: ' + (transport.status || 'unknown'));
-        $('discontinueUI').hide();
+        document.getElementById('discontinueUI').hidden = true;
       }
     });
   }

--- a/src/main/webapp/oscarRx/SearchDrug3.jsp
+++ b/src/main/webapp/oscarRx/SearchDrug3.jsp
@@ -1030,6 +1030,12 @@
       border: 1px solid grey;
     }
 
+    /* Bootstrap added to this page resets h1-h6 to font-weight:500,
+       which un-bolds the popup heading vs the pre-Bootstrap look. Restore bold here. */
+    #discontinueUI h3 {
+      font-weight: bold;
+    }
+
     #drugProfile {
       padding-top: 0;
     }


### PR DESCRIPTION
## Summary

The "Discon" action in the Rx module did nothing — clicking it produced no popup and no error, so meds couldn't be discontinued (#2463). Root cause is a CSS/JS interaction regression. While fixing it and verifying the discontinue flow end-to-end, two adjacent display regressions in the same area were also corrected: broken drug-row styling (double-encoded `class` attribute) and an un-bolded popup heading.

Fixes #2463.

## Problem

**1. Discontinue popup never opens (the reported bug)**
The popup (`#discontinueUI`) is shown by Prototype's `$('discontinueUI').show()`. In `de82590af5` the element's `display:none` was moved from an inline style into a `<head>` stylesheet rule. Prototype's `.show()` only clears the *inline* `display`, so it can no longer override the stylesheet rule — the popup stays hidden. `Discontinue()` runs to completion without throwing, so there's no error; nothing just appears to happen. (Same root cause and family as #2413, which fixed the Reprint toggle but not this popup.)

**2. Drug-row styling broken (double-encoded class) , develop only issue**
`getClassColour()` returned a full attribute fragment (`class="currentDrug "`). Three row links wrapped it in `Encode.forHtml(...)`, which encodes the quotes → `class=&#34;…&#34;` → the browser can't parse the class → no bold/colour on the rxDate/Del/Discon links (while two other links emitted it raw and stayed styled — inconsistent).

**3. Popup heading no longer bold**
Bootstrap was added to this page in `0cc29caedf`; its reset `h1–h6 { font-weight: 500 }` overrides the default bold `<h3>`, so the "Discontinue: …" heading renders medium-weight.

## Solution

- **Popup visibility** (`SearchDrug3.jsp`): hide via the HTML `hidden` attribute and toggle it from JS (`el.hidden = false/true`) instead of stylesheet `display:none` + Prototype `.show()`. Explicit set (not `toggleAttribute`) since there's one show site and three hide sites. Mirrors the pattern from #2413, with a "do not move to CSS" comment.
- **Drug-row styling** (`ListDrugs.jsp`): `getClassColour()` now returns only the class tokens (`"currentDrug expireInReference"`); all five row links use the idiomatic `class="<%=Encode.forHtmlAttribute(String.valueOf(styleColor))%>"` (structure in the template, value encoded). Renders correctly *and* satisfies security scanners, ending the encode/re-flag cycle.
- **Heading weight** (`SearchDrug3.jsp`): added `#discontinueUI h3 { font-weight: bold; }` to restore the pre-Bootstrap appearance.

## Develop vs. release note

| Fix | develop | release/2026-03-17 | release/2026-01-19 |
|---|---|---|---|
| Popup visibility | needed | needed (identical bug) | n/a (predates `de82590af5`) |
| Heading bold | needed | needed (has Bootstrap) | n/a (no Bootstrap) |
| Double-encode | **fixes a real bug** | **not broken** — emits `styleColor` raw | n/a |

The popup and heading fixes port cleanly to `release/2026-03-17`. The **double-encode fix is develop-specific**: on `release/2026-03-17` those sites emit `styleColor` un-encoded, so there's no visible breakage to fix. The same refactor can still be ported there as a hardening/consistency improvement (it adds proper `forHtmlAttribute` encoding the raw version lacks), but it's optional, not a bug fix.

## Summary by Sourcery

Fix the Rx discontinue popup so it opens and closes correctly and restore consistent styling for drug list links and the discontinue dialog.

Bug Fixes:
- Ensure the discontinue popup is no longer permanently hidden by switching to toggling the HTML hidden attribute instead of relying on CSS display rules overridden by Prototype.
- Correct drug-row link styling by returning plain CSS class tokens from getClassColour() and applying them via encoded class attributes, avoiding double-encoded attribute fragments.

Enhancements:
- Restore bold styling of the discontinue popup heading to match the pre-Bootstrap appearance.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Rx “Discon” action so the discontinue popup opens and closes properly, and restores correct styling in the drug list and popup header. Resolves a regression that hid the popup and broke link styles.

- **Bug Fixes**
  - Discontinue popup: use the HTML `hidden` attribute and toggle it via JS (`hidden = true/false`) instead of CSS `display:none` and Prototype `.show()`. Fixes #2463.
  - Drug-row styling: `getClassColour()` now returns only class tokens; all links set `class="<%=Encode.forHtmlAttribute(...)%>"`, fixing double-encoded attributes and restoring bold/color on action links.
  - Popup heading: added `#discontinueUI h3 { font-weight: bold; }` to restore the pre-Bootstrap bold heading.

<sup>Written for commit f7c7c1ac80d21332073523939410bae61329a73f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openo-beta/Open-O/pull/2466?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of the Discontinue popup in the drug search interface by updating how the interface is shown and hidden.
  * Enhanced CSS class handling in the drugs table to ensure consistent styling and proper display of action links and medication information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->