### PR TITLE
Fix: Rx - long favourites list causes the pt's medication list to render halfway down the page

### DIFF
--- a/src/main/webapp/oscarRx/SearchDrug3.jsp
+++ b/src/main/webapp/oscarRx/SearchDrug3.jsp
@@ -1062,6 +1062,9 @@
 
     .rightColumnAdjust {
       padding-left: 10px;
+      /* Table cells default to vertical-align: middle, so a long favourites column (left cell)
+         makes the row tall and drifts this content to the page middle (#2464). Pin it to top. */
+      vertical-align: top;
     }
   </style>
 


### PR DESCRIPTION
## Summary

In the Rx module (`SearchDrug3.jsp`), a provider with a very long favourites list (60+) saw the
search bar and the patient's medication list render vertically centered ("halfway down the page")
instead of at the top. The cause is a missing vertical-alignment on the right-hand content cell of
the two-column layout. The fix is a one-line CSS change: pin that cell to `vertical-align: top`.
Applies to `develop` and `release/2026-03-17` (identical layout);

Fixes: #2464 

## Problem

`SearchDrug3.jsp` lays the screen out as a single two-column table row:

- **Left cell** — the favourites/allergies/dx sidebar (`SideLinksEditFavorites2.jsp`). One `<dd>`
  per favourite, so a 60+ favourites list makes this cell very tall.
- **Right cell** (`<td class="rightColumnAdjust">`) — everything the user works with: the drug
  search bar, the staging area, and the patient medication list.

Both cells share the same `<tr>`, so the tall favourites column dictates the row height.

HTML table cells default to `vertical-align: middle`. The left favourites cell explicitly sets
`vertical-align: top`, but the right content cell had no vertical-align, so it fell back to
`middle`. When the favourites column was very tall, the right cell vertically centered its entire
contents — the reported "renders halfway down the page" symptom.

The asymmetry traces to commit `de82590af5` ("move inline styles to head"), which added
`vertical-align: top` to the left cell but not the right.

## Solution

Give the right content cell the same top alignment the left cell already has, in the
`.rightColumnAdjust` rule in `src/main/webapp/oscarRx/SearchDrug3.jsp`:

```css
.rightColumnAdjust {
  padding-left: 10px;
  /* Table cells default to vertical-align: middle, so a long favourites column (left cell)
     makes the row tall and drifts this content to the page middle (#2464). Pin it to top. */
  vertical-align: top;
}
```

<img width="1920" height="967" alt="image" src="https://github.com/user-attachments/assets/c5b74fba-4f59-4575-be9b-3d6793cdd662" />


Now neither column drifts to the middle when the other is tall — the search bar and medication
list stay anchored at the top regardless of favourites-list length. Verified in the running app
with 80 seeded favourites.

## Summary by Sourcery

Bug Fixes:
- Prevent the Rx drug search and patient medication list from rendering midway down the page by top-aligning the right content cell when the favourites column is tall.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes an Rx UI bug where a long favourites list pushed the search bar and the patient medication list to the middle of the page. Sets `vertical-align: top` on the right content cell in `SearchDrug3.jsp` so the content stays anchored to the top regardless of favourites length.

<sup>Written for commit 64a9cfa8305afeb8806fc24ef6b2c982fcf58add. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openo-beta/Open-O/pull/2468?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

