### PR TITLE
fix: additional Rx notes not included when printing to encounter note

### DIFF
--- a/src/main/webapp/oscarRx/printRx/PrintPreview.js
+++ b/src/main/webapp/oscarRx/printRx/PrintPreview.js
@@ -423,8 +423,8 @@ function printPaste2Parent(ctx, print, fax, pasteRx, rxPasteAsterisk, prefPharma
                 text += rxNoNewLines.value + "\n";
             }
             const additionalNotes = document.getElementById("additionalNotes");
-            if (additionalNotes && additionalNotes.value.length > 0) {
-                text += "\n" + additionalNotes.value + "\n";
+            if (additionalNotes && additionalNotes.value.trim().length > 0) {
+                text += "\n" + additionalNotes.value.trim() + "\n";
             }
         }
         if (rxPasteAsterisk) {

--- a/src/main/webapp/oscarRx/printRx/PrintPreview.js
+++ b/src/main/webapp/oscarRx/printRx/PrintPreview.js
@@ -422,6 +422,10 @@ function printPaste2Parent(ctx, print, fax, pasteRx, rxPasteAsterisk, prefPharma
             if (rxNoNewLines && rxNoNewLines.value.length > 0) {
                 text += rxNoNewLines.value + "\n";
             }
+            const additionalNotes = document.getElementById("additionalNotes");
+            if (additionalNotes && additionalNotes.value.length > 0) {
+                text += "\n" + additionalNotes.value + "\n";
+            }
         }
         if (rxPasteAsterisk) {
             if (prefPharmacy != null && prefPharmacy.trim() !== "") {


### PR DESCRIPTION
## Problem
When a provider adds notes via the "Additional Rx Notes" button on the Rx print preview and then clicks "Print & Add to Encounter Note", the notes were silently dropped - only the medication list was pasted into the encounter note.

## Root Cause
`printPaste2Parent` in `PrintPreview.js` reads `rx_no_newlines` to build the encounter note text but never reads the `additionalNotes` textarea value. The original `ViewScript2.jsp` flow had this logic but it was missed when the print preview was refactored into a standalone JS file.

## Fix
After appending the medication list, also append the `additionalNotes` textarea value - matching the behaviour in `ViewScript2.jsp`.

<img width="1353" height="458" alt="image" src="https://github.com/user-attachments/assets/7e3918fc-343b-4dbd-86e0-0cb883716042" />

## Summary by Sourcery

Bug Fixes:
- Include the Additional Rx Notes textarea content when composing text pasted into the encounter note from the Rx print preview.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prescription previews now properly capture and display additional notes in the generated output when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->