### PR TITLE
fix: fax encounter note shows wrong time due to hardcoded UTC timezone

### DIFF
--- a/src/main/webapp/oscarRx/printRx/PrintPreview.js
+++ b/src/main/webapp/oscarRx/printRx/PrintPreview.js
@@ -399,8 +399,7 @@ function printPaste2Parent(ctx, print, fax, pasteRx, rxPasteAsterisk, prefPharma
             year: 'numeric',
             hour: '2-digit',
             minute: '2-digit',
-            hour12: true,
-            timeZone: 'UTC'
+            hour12: true
         });
         if (rxPasteAsterisk) {
             text += "**********************************************************************************\n";


### PR DESCRIPTION
## Summary
- Fax & Add to encounter note was stamping the wrong time in the encounter note
- Root cause: `toLocaleString` in `PrintPreview.js` had `timeZone: 'UTC'` hardcoded, so the timestamp always reflected UTC regardless of the user's local timezone
- Fix: removed the hardcoded `timeZone: 'UTC'` option so the browser uses the client's local timezone

Before:
<img width="724" height="221" alt="image" src="https://github.com/user-attachments/assets/6c1f7940-ee77-4da1-84b1-9127f24f49dd" />


After:
<img width="454" height="163" alt="image" src="https://github.com/user-attachments/assets/efa37fc2-3289-4dad-ad10-ce19b8c49e5d" />

## Summary by Sourcery

Bug Fixes:
- Correct encounter note timestamps by removing the hardcoded UTC timezone from the print preview formatting.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed encounter note timestamps for fax and “Add to encounter note” to use the user’s local timezone instead of UTC.

- **Bug Fixes**
  - Removed hardcoded `timeZone: 'UTC'` from `toLocaleString` in `PrintPreview.js` so the browser uses the client’s timezone.

<sup>Written for commit 2a055732d91373688cbe145585402bb821f03bde. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openo-beta/Open-O/pull/2474?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated timestamp formatting in prescription preview printing to display using the local timezone instead of UTC.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->