### PR TITLE
Fix: Rx module meds list should display all meds

### DIFF
--- a/src/main/webapp/oscarRx/ListDrugs.jsp
+++ b/src/main/webapp/oscarRx/ListDrugs.jsp
@@ -418,16 +418,18 @@
 <script type="text/javascript">
 
     window.drugListTableConfig = window.drugListTableConfig || {
-      bStateSave: true,
-      fnStateSave: function (oSettings, oData) {
-        localStorage.setItem('drugListTable', JSON.stringify(oData));
-      },
-      fnStateLoad: function () {
-        return JSON.parse(localStorage.getItem('drugListTable'));
+      // Default page length: the user's saved choice, or "All" (-1) when they've never changed it.
+      // A getter (not a static value) because this config object is created once but reused every
+      // time the table is rebuilt, so the length must be re-read from storage on each init.
+      get pageLength() { return parseInt(localStorage.getItem('drugListPageLength')) || -1; },
+      // Persist the choice whenever the user changes the dropdown (tickler uses the same approach).
+      initComplete: function (settings) {
+        jQuery(settings.nTable).on('length.dt', function (e, s, len) {
+          localStorage.setItem('drugListPageLength', len);
+        });
       },
       searching: true,
-      // "aLengthMenu": [[25, 50, 75, -1], [25, 50, 75, "All"]],
-      // "iDisplayLength": 50,
+      lengthMenu: [[25, 50, 75, 100, -1], [25, 50, 75, 100, "All"]],
       columns: [
         {}, //entered date
         {}, //start date


### PR DESCRIPTION
## Problem

After the DataTables upgrade (`edac1715d5`, "upgrade medication list to use DataTables and eliminate the server-side sorting"), the Rx medication list stopped showing the full medication list. With no page-length configured, DataTables fell back to its built-in default of **10 rows**, so the list silently truncated. Before the upgrade the module displayed the full (filtered) list.

The reporter's workaround was to set the dropdown to "100" — but that still isn't "all", and the choice didn't survive a reload.

Fixes #2475

## Root cause

Two separate problems in the `window.drugListTableConfig` DataTables config in `ListDrugs.jsp`:

1. **No default page length.** The `aLengthMenu` / `iDisplayLength` lines were commented out, so DataTables used its default of 10 rows.

2. **Page-length persistence was effectively broken.** The config used `bStateSave` with `fnStateSave` / `fnStateLoad` callbacks. Those callback names are from the DataTables 1.9 API and were **renamed** in 1.13.x (`stateSaveCallback` / `stateLoadCallback`), so they were never invoked — the intended `drugListTable` localStorage key was never written. DataTables' built-in default state-save ran instead and wrote the full state blob to `DataTables_Drug_table_<path>`, but the drug list is **destroyed and rebuilt on every load** (`rebuildDrugProfile` in `SearchDrug3.jsp`), and that rebuild re-draws the table at the config defaults — overwriting the saved state back to defaults before the user ever sees their value. The net effect: neither page length nor sort order survived a reload.

## Fix

Replaced the broken full-state-save with a small, targeted page-length preference, mirroring the approach already used by the tickler table (the one table in the app that persists its length reliably):

- **Default to "All"** (`pageLength: -1`) when the user has no saved preference, restoring the pre-upgrade full-list behaviour.
- **Persist only the page length** to `localStorage['drugListPageLength']`, written on an explicit `length.dt` change (i.e. only when the user actually changes the dropdown).
- **A `pageLength` getter** (rather than a static value) so the saved length is re-read from storage on every table init — important because the config object is created once but reused across the destroy/rebuild churn.
- **`lengthMenu`** offers `25, 50, 75, 100, All`, with "All" in the last position to match the tickler and consultation tables.

Resulting behaviour (exactly the requested spec):

- Never changed the dropdown → no saved value → **All**.
- Changed the dropdown → that value is restored on the next visit (and survives legend-filter rebuilds within a session).

Old `DataTables_Drug_table_*` / `drugListTable` localStorage entries are simply never read anymore, so existing users land on "All" with no manual cache clear.

<img width="1655" height="303" alt="image" src="https://github.com/user-attachments/assets/4670d75a-0149-4a2a-8d70-4699c4791959" />


## Testing

Verified in-browser (DataTables 1.13.4, demographic with 133 meds):

| Scenario | Result |
| --- | --- |
| Fresh state (empty localStorage) | Defaults to **All** (133 rows)  |
| Change to 50 → reload | Restores **50** (writes `drugListPageLength=50`) |
| Change to 25 → legend-filter rebuild | Both rebuilt sections stay at **25** (getter re-reads per init) |
| "All" selection → reload | Persists as "All" (`-1`) |

For comparison, the **original** version was also rebuilt and tested: a changed length (50) and sort (`[0,'asc']`) were both clobbered back to defaults (`length:10`, `order:[[1,'desc']]`) on the next reload — confirming the prior persistence was non-functional, and that the custom `drugListTable` key was never written.

## Scope / safety

- Change is isolated to `src/main/webapp/oscarRx/ListDrugs.jsp` (10 additions, 8 deletions).
- No other DataTables instances are affected: the `pageLength` default lives only in `drugListTableConfig`, and the tickler (`ticklerPageLength`, default 50) and consultation (default 10) tables use their own separate keys/pages.
- No server-side, schema, or security-surface changes.

## Summary by Sourcery

Persist and honor the user’s chosen page size for the Rx medications list, and expose an option to view all medications at once.

Bug Fixes:
- Ensure the Rx medications list correctly loads using the user’s last selected page size or defaults to showing all medications when no preference exists.

Enhancements:
- Update the Rx medications list pagination controls to offer 25, 50, 75, 100, and All page-size options and remember the selection between sessions.

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the Rx meds list so it can display all medications and correctly remembers the user's page size.

- **Bug Fixes**
  - Added length menu options: 25, 50, 75, 100, and "All" (-1), with "All" as the default when no preference is saved.
  - Persist page length to localStorage on change and restore it on table init.

<sup>Written for commit 16c6db9d63bb2bf3eb2ace6a00706a1839a39fb3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openo-beta/Open-O/pull/2477?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Drug list now persists your selected page length preference across sessions.
  * Added "All" option to display all items in the drug list view simultaneously.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->