### PR TITLE
Consultation table filters

### DIFF
--- a/src/main/java/ca/openosp/openo/commn/dao/ConsultationRequestDao.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/ConsultationRequestDao.java
@@ -96,13 +96,16 @@ public interface ConsultationRequestDao extends AbstractDao<ConsultationRequest>
     List<ConsultationListDTO> getConsultationDTOs(String team, boolean showCompleted, Date startDate, Date endDate, String orderby, String desc, String searchDate, Integer offset, Integer limit, Integer consultantId, String filterProviderNo);
 
     /**
-     * Searches distinct consultants (specialists) that appear on any consultation request whose
-     * first or last name matches the given keyword, ordered by last then first name and capped
-     * to maxResults.
+     * Searches distinct consultants (specialists) that appear on any consultation request and whose
+     * name matches the given keyword, ordered by last then first name and capped to maxResults.
+     * The keyword is split into terms on whitespace and commas and every term must appear in the
+     * specialist's "lastName, firstName" name, so terms match in any order and spacing around the
+     * comma is irrelevant: "Smith,B", "Smith, B" and "B Smith" all match "Smith, Brian".
      *
-     * @param keyword String the case-insensitive search term to match against specialist name
+     * @param keyword String the case-insensitive search term(s) to match against specialist name
      * @param maxResults int the maximum number of results to return
-     * @return List of matching ProfessionalSpecialist referenced by consultation requests
+     * @return List of matching ProfessionalSpecialist referenced by consultation requests, empty
+     *         if the keyword is null or contains no searchable terms
      */
     List<ProfessionalSpecialist> searchDistinctConsultants(String keyword, int maxResults);
 

--- a/src/main/java/ca/openosp/openo/commn/dao/ConsultationRequestDao.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/ConsultationRequestDao.java
@@ -7,6 +7,8 @@ import java.util.Date;
 import java.util.List;
 
 import ca.openosp.openo.commn.model.ConsultationRequest;
+import ca.openosp.openo.commn.model.ProfessionalSpecialist;
+import ca.openosp.openo.commn.model.Provider;
 import ca.openosp.openo.consultation.dto.ConsultationListDTO;
 
 public interface ConsultationRequestDao extends AbstractDao<ConsultationRequest> {
@@ -71,4 +73,41 @@ public interface ConsultationRequestDao extends AbstractDao<ConsultationRequest>
      * @since 2026-02-03
      */
     List<ConsultationListDTO> getConsultationDTOsByDemographic(Integer demoNo);
+
+    /**
+     * Retrieves consultation requests as lightweight DTOs with optional consultant and provider
+     * filters, in addition to the existing team, date, and completed filters. Both filters are
+     * optional and combine with each other and the other filters. Uses the same DTO projection
+     * and batch extension loading as {@link #getConsultationDTOs(String, boolean, Date, Date, String, String, String, Integer, Integer)}.
+     *
+     * @param team String the team/sendTo filter value (empty string for all teams)
+     * @param showCompleted boolean whether to include completed (status 4) consultations
+     * @param startDate Date the start date filter (null for no lower bound)
+     * @param endDate Date the end date filter (null for no upper bound)
+     * @param orderby String the sort column identifier (1-9), null for default referral date desc
+     * @param desc String "1" for descending sort, null/other for ascending
+     * @param searchDate String "1" to filter on appointment date instead of referral date
+     * @param offset Integer the pagination offset (null defaults to 0)
+     * @param limit Integer the page size (null defaults to {@link #DEFAULT_CONSULT_REQUEST_RESULTS_LIMIT})
+     * @param consultantId Integer the ProfessionalSpecialist id to filter by (null for no consultant filter)
+     * @param filterProviderNo String the patient MRP provider number to filter by (null/empty for no provider filter)
+     * @return List of ConsultationListDTO with all display fields populated
+     */
+    List<ConsultationListDTO> getConsultationDTOs(String team, boolean showCompleted, Date startDate, Date endDate, String orderby, String desc, String searchDate, Integer offset, Integer limit, Integer consultantId, String filterProviderNo);
+
+    /**
+     * Returns the distinct consultants (specialists) that appear on any consultation request,
+     * ordered by last then first name, for populating the consultant filter options.
+     *
+     * @return List of distinct ProfessionalSpecialist referenced by consultation requests
+     */
+    List<ProfessionalSpecialist> getDistinctConsultants();
+
+    /**
+     * Returns the distinct patient providers (MRPs) that appear on any consultation request,
+     * ordered by last then first name, for populating the provider filter options.
+     *
+     * @return List of distinct Provider acting as MRP for patients with consultation requests
+     */
+    List<Provider> getDistinctConsultProviders();
 }

--- a/src/main/java/ca/openosp/openo/commn/dao/ConsultationRequestDao.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/ConsultationRequestDao.java
@@ -96,12 +96,15 @@ public interface ConsultationRequestDao extends AbstractDao<ConsultationRequest>
     List<ConsultationListDTO> getConsultationDTOs(String team, boolean showCompleted, Date startDate, Date endDate, String orderby, String desc, String searchDate, Integer offset, Integer limit, Integer consultantId, String filterProviderNo);
 
     /**
-     * Returns the distinct consultants (specialists) that appear on any consultation request,
-     * ordered by last then first name, for populating the consultant filter options.
+     * Searches distinct consultants (specialists) that appear on any consultation request whose
+     * first or last name matches the given keyword, ordered by last then first name and capped
+     * to maxResults.
      *
-     * @return List of distinct ProfessionalSpecialist referenced by consultation requests
+     * @param keyword String the case-insensitive search term to match against specialist name
+     * @param maxResults int the maximum number of results to return
+     * @return List of matching ProfessionalSpecialist referenced by consultation requests
      */
-    List<ProfessionalSpecialist> getDistinctConsultants();
+    List<ProfessionalSpecialist> searchDistinctConsultants(String keyword, int maxResults);
 
     /**
      * Returns the distinct patient providers (MRPs) that appear on any consultation request,

--- a/src/main/java/ca/openosp/openo/commn/dao/ConsultationRequestDaoImpl.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/ConsultationRequestDaoImpl.java
@@ -9,6 +9,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -341,7 +342,7 @@ public class ConsultationRequestDaoImpl extends AbstractDaoImpl<ConsultationRequ
         if (keyword == null) {
             return terms;
         }
-        for (String term : keyword.toLowerCase().split("[\\s,]+")) {
+        for (String term : keyword.toLowerCase(Locale.ROOT).split("[\\s,]+")) {
             if (!term.isEmpty()) {
                 terms.add(escapeLikeWildcards(term));
                 if (terms.size() == MAX_NAME_SEARCH_TERMS) {

--- a/src/main/java/ca/openosp/openo/commn/dao/ConsultationRequestDaoImpl.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/ConsultationRequestDaoImpl.java
@@ -14,10 +14,11 @@ import java.util.stream.Collectors;
 
 import javax.persistence.Query;
 
-import org.apache.commons.lang3.time.DateFormatUtils;
 import ca.openosp.openo.commn.NativeSql;
 import ca.openosp.openo.commn.model.ConsultationRequest;
 import ca.openosp.openo.commn.model.ConsultationRequestExt;
+import ca.openosp.openo.commn.model.ProfessionalSpecialist;
+import ca.openosp.openo.commn.model.Provider;
 import ca.openosp.openo.consultation.dto.ConsultationListDTO;
 
 @SuppressWarnings("unchecked")
@@ -67,22 +68,22 @@ public class ConsultationRequestDaoImpl extends AbstractDaoImpl<ConsultationRequ
         }
 
         if (!team.isEmpty()) {
-            sql.append("and cr.sendTo = '" + team + "' ");
+            sql.append("and cr.sendTo = :team ");
         }
 
         if (startDate != null) {
             if (searchDate != null && searchDate.equals("1")) {
-                sql.append("and cr.appointmentDate >= '" + DateFormatUtils.ISO_DATETIME_FORMAT.format(startDate) + "' ");
+                sql.append("and cr.appointmentDate >= :startDate ");
             } else {
-                sql.append("and cr.referralDate >= '" + DateFormatUtils.ISO_DATETIME_FORMAT.format(startDate) + "' ");
+                sql.append("and cr.referralDate >= :startDate ");
             }
         }
 
         if (endDate != null) {
             if (searchDate != null && searchDate.equals("1")) {
-                sql.append("and cr.appointmentDate <= '" + DateFormatUtils.ISO_DATETIME_FORMAT.format(endDate) + "' ");
+                sql.append("and cr.appointmentDate <= :endDate ");
             } else {
-                sql.append("and cr.referralDate <= '" + DateFormatUtils.ISO_DATETIME_FORMAT.format(endDate) + "' ");
+                sql.append("and cr.referralDate <= :endDate ");
             }
         }
 
@@ -107,6 +108,15 @@ public class ConsultationRequestDaoImpl extends AbstractDaoImpl<ConsultationRequ
 
 
         Query query = entityManager.createQuery(sql.toString());
+        if (!team.isEmpty()) {
+            query.setParameter("team", team);
+        }
+        if (startDate != null) {
+            query.setParameter("startDate", startDate);
+        }
+        if (endDate != null) {
+            query.setParameter("endDate", endDate);
+        }
         query.setFirstResult(offset != null ? offset : 0);
 
         //need to never send more than MAX_LIST_RETURN_SIZE
@@ -229,8 +239,16 @@ public class ConsultationRequestDaoImpl extends AbstractDaoImpl<ConsultationRequ
      */
     @Override
     public List<ConsultationListDTO> getConsultationDTOs(String team, boolean showCompleted, Date startDate, Date endDate, String orderby, String desc, String searchDate, Integer offset, Integer limit) {
+        return getConsultationDTOs(team, showCompleted, startDate, endDate, orderby, desc, searchDate, offset, limit, null, null);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<ConsultationListDTO> getConsultationDTOs(String team, boolean showCompleted, Date startDate, Date endDate, String orderby, String desc, String searchDate, Integer offset, Integer limit, Integer consultantId, String filterProviderNo) {
         List<Object> paramList = new ArrayList<>();
-        String sql = buildConsultationDTOQuery(paramList, team, showCompleted, startDate, endDate, orderby, desc, searchDate);
+        String sql = buildConsultationDTOQuery(paramList, team, showCompleted, startDate, endDate, orderby, desc, searchDate, consultantId, filterProviderNo);
 
         Query query = entityManager.createQuery(sql, ConsultationListDTO.class);
         for (int i = 0; i < paramList.size(); i++) {
@@ -265,6 +283,22 @@ public class ConsultationRequestDaoImpl extends AbstractDaoImpl<ConsultationRequ
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<ProfessionalSpecialist> getDistinctConsultants() {
+        return entityManager.createQuery("SELECT DISTINCT specialist FROM ConsultationRequest cr JOIN cr.professionalSpecialist specialist ORDER BY specialist.lastName, specialist.firstName", ProfessionalSpecialist.class).getResultList();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<Provider> getDistinctConsultProviders() {
+        return entityManager.createQuery("SELECT DISTINCT mrp FROM ConsultationRequest cr JOIN Demographic d ON d.DemographicNo = cr.demographicId JOIN Provider mrp ON mrp.ProviderNo = d.ProviderNo ORDER BY mrp.LastName, mrp.FirstName", Provider.class).getResultList();
+    }
+
+    /**
      * Builds the complete JPQL query string for DTO projection with parameterized filters and sorting.
      * Uses positional parameters to prevent SQL injection (replacing the previous string concatenation pattern).
      *
@@ -276,9 +310,11 @@ public class ConsultationRequestDaoImpl extends AbstractDaoImpl<ConsultationRequ
      * @param orderby String the sort column identifier (1-9)
      * @param desc String "1" for descending, otherwise ascending
      * @param searchDate String "1" to filter on appointment date instead of referral date
+     * @param consultantId Integer the ProfessionalSpecialist id to filter by (null to skip)
+     * @param filterProviderNo String the patient MRP provider number to filter by (null/empty to skip)
      * @return String the complete JPQL query
      */
-    private String buildConsultationDTOQuery(List<Object> paramList, String team, boolean showCompleted, Date startDate, Date endDate, String orderby, String desc, String searchDate) {
+    private String buildConsultationDTOQuery(List<Object> paramList, String team, boolean showCompleted, Date startDate, Date endDate, String orderby, String desc, String searchDate, Integer consultantId, String filterProviderNo) {
         int paramIndex = 1;
         StringBuilder sql = new StringBuilder(DTO_SELECT);
         sql.append(DTO_FROM);
@@ -291,6 +327,16 @@ public class ConsultationRequestDaoImpl extends AbstractDaoImpl<ConsultationRequ
         if (team != null && !team.isEmpty()) {
             sql.append("AND cr.sendTo = ?").append(paramIndex++).append(" ");
             paramList.add(team);
+        }
+
+        if (consultantId != null) {
+            sql.append("AND specialist.id = ?").append(paramIndex++).append(" ");
+            paramList.add(consultantId);
+        }
+
+        if (filterProviderNo != null && !filterProviderNo.isEmpty()) {
+            sql.append("AND mrp.ProviderNo = ?").append(paramIndex++).append(" ");
+            paramList.add(filterProviderNo);
         }
 
         if (startDate != null) {

--- a/src/main/java/ca/openosp/openo/commn/dao/ConsultationRequestDaoImpl.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/ConsultationRequestDaoImpl.java
@@ -287,7 +287,7 @@ public class ConsultationRequestDaoImpl extends AbstractDaoImpl<ConsultationRequ
      */
     @Override
     public List<ProfessionalSpecialist> searchDistinctConsultants(String keyword, int maxResults) {
-        Query query = entityManager.createQuery("SELECT DISTINCT specialist FROM ConsultationRequest cr JOIN cr.professionalSpecialist specialist WHERE LOWER(specialist.lastName) LIKE :keyword OR LOWER(specialist.firstName) LIKE :keyword ORDER BY specialist.lastName, specialist.firstName", ProfessionalSpecialist.class);
+        Query query = entityManager.createQuery("SELECT DISTINCT specialist FROM ConsultationRequest cr JOIN cr.professionalSpecialist specialist WHERE LOWER(CONCAT(CONCAT(specialist.lastName, ', '), specialist.firstName)) LIKE :keyword ORDER BY specialist.lastName, specialist.firstName", ProfessionalSpecialist.class);
         String likePattern = "%" + keyword.toLowerCase() + "%";
         query.setParameter("keyword", likePattern);
         query.setMaxResults(maxResults);

--- a/src/main/java/ca/openosp/openo/commn/dao/ConsultationRequestDaoImpl.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/ConsultationRequestDaoImpl.java
@@ -232,6 +232,31 @@ public class ConsultationRequestDaoImpl extends AbstractDaoImpl<ConsultationRequ
             "LEFT JOIN ConsultationServices svc ON svc.serviceId = cr.serviceId " +
             "LEFT JOIN cr.professionalSpecialist specialist ";
 
+    /** Escape character used by LIKE patterns; see {@link #escapeLikeWildcards(String)}. */
+    private static final String LIKE_ESCAPE_CHAR = "!";
+
+    /** Named parameter prefix for the consultant search terms ("term0", "term1", ...). */
+    private static final String NAME_TERM_PARAM = "term";
+
+    /** Number of name terms {@link #CONSULTANT_SEARCH_QUERY} matches; extra terms are ignored. */
+    private static final int MAX_NAME_SEARCH_TERMS = 4;
+
+    /**
+     * JPQL for the consultant autocomplete search. Each term is matched against the specialist name
+     * as the autocomplete displays it ("lastName, firstName"), lowercased for case-insensitive
+     * matching, with nested two-argument CONCAT to stay within the JPA spec. Requiring every term
+     * to appear somewhere in that string lets terms match in any order and keeps the ", " separator
+     * from blocking a match. Term slots are fixed and fully parameterized; unused slots bind "%".
+     */
+    private static final String CONSULTANT_SEARCH_QUERY = """
+            SELECT DISTINCT specialist FROM ConsultationRequest cr
+            JOIN cr.professionalSpecialist specialist
+            WHERE LOWER(CONCAT(CONCAT(specialist.lastName, ', '), specialist.firstName)) LIKE :term0 ESCAPE '!'
+            AND LOWER(CONCAT(CONCAT(specialist.lastName, ', '), specialist.firstName)) LIKE :term1 ESCAPE '!'
+            AND LOWER(CONCAT(CONCAT(specialist.lastName, ', '), specialist.firstName)) LIKE :term2 ESCAPE '!'
+            AND LOWER(CONCAT(CONCAT(specialist.lastName, ', '), specialist.firstName)) LIKE :term3 ESCAPE '!'
+            ORDER BY specialist.lastName, specialist.firstName""";
+
     /**
      * {@inheritDoc}
      *
@@ -287,11 +312,57 @@ public class ConsultationRequestDaoImpl extends AbstractDaoImpl<ConsultationRequ
      */
     @Override
     public List<ProfessionalSpecialist> searchDistinctConsultants(String keyword, int maxResults) {
-        Query query = entityManager.createQuery("SELECT DISTINCT specialist FROM ConsultationRequest cr JOIN cr.professionalSpecialist specialist WHERE LOWER(CONCAT(CONCAT(specialist.lastName, ', '), specialist.firstName)) LIKE :keyword ORDER BY specialist.lastName, specialist.firstName", ProfessionalSpecialist.class);
-        String likePattern = "%" + keyword.toLowerCase() + "%";
-        query.setParameter("keyword", likePattern);
+        List<String> terms = tokenizeNameKeyword(keyword);
+        if (terms.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        Query query = entityManager.createQuery(CONSULTANT_SEARCH_QUERY, ProfessionalSpecialist.class);
+        for (int i = 0; i < MAX_NAME_SEARCH_TERMS; i++) {
+            // unused term slots match anything, so a keyword with fewer terms is not narrowed
+            query.setParameter(NAME_TERM_PARAM + i, i < terms.size() ? "%" + terms.get(i) + "%" : "%");
+        }
         query.setMaxResults(maxResults);
         return query.getResultList();
+    }
+
+    /**
+     * Splits a name search keyword into lowercase terms on whitespace and commas, so the keyword is
+     * matched term by term rather than as one literal string. This makes spacing and punctuation
+     * around the "lastName, firstName" separator irrelevant: "Smith,B", "Smith,   B", "Smith B" and
+     * "B Smith" all match "Smith, Brian". Terms past {@link #MAX_NAME_SEARCH_TERMS} are ignored,
+     * which only ever broadens the result set.
+     *
+     * @param keyword String the raw user-typed keyword (null or punctuation-only yields no terms)
+     * @return List of lowercase terms, LIKE wildcards escaped, in the order typed
+     */
+    private static List<String> tokenizeNameKeyword(String keyword) {
+        List<String> terms = new ArrayList<>();
+        if (keyword == null) {
+            return terms;
+        }
+        for (String term : keyword.toLowerCase().split("[\\s,]+")) {
+            if (!term.isEmpty()) {
+                terms.add(escapeLikeWildcards(term));
+                if (terms.size() == MAX_NAME_SEARCH_TERMS) {
+                    break;
+                }
+            }
+        }
+        return terms;
+    }
+
+    /**
+     * Escapes LIKE wildcards so a user-typed "%" or "_" matches literally instead of acting as a
+     * wildcard. Only valid against a LIKE carrying {@code ESCAPE '<LIKE_ESCAPE_CHAR>'}.
+     *
+     * @param term String the search term to escape
+     * @return String the term with the escape character, "%" and "_" escaped
+     */
+    private static String escapeLikeWildcards(String term) {
+        return term.replace(LIKE_ESCAPE_CHAR, LIKE_ESCAPE_CHAR + LIKE_ESCAPE_CHAR)
+                .replace("%", LIKE_ESCAPE_CHAR + "%")
+                .replace("_", LIKE_ESCAPE_CHAR + "_");
     }
 
     /**

--- a/src/main/java/ca/openosp/openo/commn/dao/ConsultationRequestDaoImpl.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/ConsultationRequestDaoImpl.java
@@ -286,8 +286,12 @@ public class ConsultationRequestDaoImpl extends AbstractDaoImpl<ConsultationRequ
      * {@inheritDoc}
      */
     @Override
-    public List<ProfessionalSpecialist> getDistinctConsultants() {
-        return entityManager.createQuery("SELECT DISTINCT specialist FROM ConsultationRequest cr JOIN cr.professionalSpecialist specialist ORDER BY specialist.lastName, specialist.firstName", ProfessionalSpecialist.class).getResultList();
+    public List<ProfessionalSpecialist> searchDistinctConsultants(String keyword, int maxResults) {
+        Query query = entityManager.createQuery("SELECT DISTINCT specialist FROM ConsultationRequest cr JOIN cr.professionalSpecialist specialist WHERE LOWER(specialist.lastName) LIKE :keyword OR LOWER(specialist.firstName) LIKE :keyword ORDER BY specialist.lastName, specialist.firstName", ProfessionalSpecialist.class);
+        String likePattern = "%" + keyword.toLowerCase() + "%";
+        query.setParameter("keyword", likePattern);
+        query.setMaxResults(maxResults);
+        return query.getResultList();
     }
 
     /**

--- a/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/pageUtil/EctViewConsultationRequests2Action.java
+++ b/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/pageUtil/EctViewConsultationRequests2Action.java
@@ -122,6 +122,7 @@ public class EctViewConsultationRequests2Action extends ActionSupport {
      * response stays small regardless of how many consultants are registered.
      *
      * @throws IOException if writing the JSON response fails
+     * @since 2026-07-10
      */
     public void searchConsultants() throws IOException {
         if (!securityInfoManager.hasPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), "_con", "r", null)) {
@@ -292,18 +293,34 @@ public class EctViewConsultationRequests2Action extends ActionSupport {
         this.limit = limit;
     }
 
+    /**
+     * @return Integer the consultant the list is filtered to, null for all consultants
+     * @since 2026-06-19
+     */
     public Integer getConsultantId() {
         return consultantId;
     }
 
+    /**
+     * @param consultantId Integer the consultant to filter by, null for all consultants
+     * @since 2026-06-19
+     */
     public void setConsultantId(Integer consultantId) {
         this.consultantId = consultantId;
     }
 
+    /**
+     * @return String the provider number the list is filtered to, null or empty for all providers
+     * @since 2026-06-19
+     */
     public String getFilterProviderNo() {
         return filterProviderNo;
     }
 
+    /**
+     * @param filterProviderNo String the provider number to filter by, null or empty for all
+     * @since 2026-06-19
+     */
     public void setFilterProviderNo(String filterProviderNo) {
         this.filterProviderNo = filterProviderNo;
     }

--- a/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/pageUtil/EctViewConsultationRequests2Action.java
+++ b/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/pageUtil/EctViewConsultationRequests2Action.java
@@ -28,17 +28,24 @@ package ca.openosp.openo.encounter.oscarConsultationRequest.pageUtil;
 
 import java.io.IOException;
 import java.text.SimpleDateFormat;
+import java.util.List;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.logging.log4j.Logger;
+import ca.openosp.openo.commn.dao.ConsultationRequestDao;
 import ca.openosp.openo.commn.dao.ConsultationRequestDaoImpl;
+import ca.openosp.openo.commn.model.ProfessionalSpecialist;
 import ca.openosp.openo.managers.SecurityInfoManager;
 import ca.openosp.openo.utility.LoggedInInfo;
 import ca.openosp.openo.utility.MiscUtils;
 import ca.openosp.openo.utility.SpringUtils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import org.apache.struts2.ActionSupport;
 import org.apache.struts2.ServletActionContext;
@@ -49,6 +56,9 @@ public class EctViewConsultationRequests2Action extends ActionSupport {
 
     private static SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
     private static final Logger logger = MiscUtils.getLogger();
+    private static final int CONSULTANT_SEARCH_MAX_RESULTS = 20;
+
+    private ConsultationRequestDao consultationRequestDao = SpringUtils.getBean(ConsultationRequestDao.class);
 
     private String sendTo;
     private String currentTeam;
@@ -103,6 +113,38 @@ public class EctViewConsultationRequests2Action extends ActionSupport {
         request.setAttribute("consultantId", consultantId);
         request.setAttribute("filterProviderNo", filterProviderNo);
         return SUCCESS;
+    }
+
+    /**
+     * Returns consultants (professional specialists) whose name matches the given keyword, as a
+     * JSON array of {@code {label, value}} pairs for the Consultants autocomplete filter on the
+     * Consultations page. Results are capped at {@link #CONSULTANT_SEARCH_MAX_RESULTS} so the
+     * response stays small regardless of how many consultants are registered.
+     *
+     * @throws IOException if writing the JSON response fails
+     */
+    public void searchConsultants() throws IOException {
+        if (!securityInfoManager.hasPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), "_con", "r", null)) {
+            throw new SecurityException("missing required sec object (_con)");
+        }
+
+        String keyword = request.getParameter("keyword");
+        ObjectMapper mapper = new ObjectMapper();
+        ArrayNode results = mapper.createArrayNode();
+
+        if (keyword != null && !keyword.trim().isEmpty()) {
+            List<ProfessionalSpecialist> matches = consultationRequestDao.searchDistinctConsultants(keyword.trim(), CONSULTANT_SEARCH_MAX_RESULTS);
+            for (ProfessionalSpecialist specialist : matches) {
+                ObjectNode node = mapper.createObjectNode();
+                node.put("label", specialist.getFormattedName());
+                node.put("value", specialist.getId() != null ? specialist.getId().toString() : "");
+                results.add(node);
+            }
+        }
+
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(results.toString());
     }
 
     public String getSendTo() {

--- a/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/pageUtil/EctViewConsultationRequests2Action.java
+++ b/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/pageUtil/EctViewConsultationRequests2Action.java
@@ -61,6 +61,8 @@ public class EctViewConsultationRequests2Action extends ActionSupport {
     private String searchDate = null;
     private Integer offset;
     private Integer limit = ConsultationRequestDaoImpl.DEFAULT_CONSULT_REQUEST_RESULTS_LIMIT;
+    private Integer consultantId;
+    private String filterProviderNo;
 
     public String execute() throws ServletException, IOException {
         if (!securityInfoManager.hasPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), "_con", "r", null)) {
@@ -98,6 +100,8 @@ public class EctViewConsultationRequests2Action extends ActionSupport {
         request.setAttribute("orderby", orderby);
         request.setAttribute("desc", desc);
         request.setAttribute("searchDate", searchDate);
+        request.setAttribute("consultantId", consultantId);
+        request.setAttribute("filterProviderNo", filterProviderNo);
         return SUCCESS;
     }
 
@@ -244,5 +248,21 @@ public class EctViewConsultationRequests2Action extends ActionSupport {
 
     public void setLimit(Integer limit) {
         this.limit = limit;
+    }
+
+    public Integer getConsultantId() {
+        return consultantId;
+    }
+
+    public void setConsultantId(Integer consultantId) {
+        this.consultantId = consultantId;
+    }
+
+    public String getFilterProviderNo() {
+        return filterProviderNo;
+    }
+
+    public void setFilterProviderNo(String filterProviderNo) {
+        this.filterProviderNo = filterProviderNo;
     }
 }

--- a/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/pageUtil/EctViewConsultationRequestsUtil.java
+++ b/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/pageUtil/EctViewConsultationRequestsUtil.java
@@ -155,7 +155,8 @@ public class EctViewConsultationRequestsUtil {
           }
 
       } catch(Exception e) {
-         MiscUtils.getLogger().error("Error loading consultation list for team: " + (team != null ? team : "all"), e);
+         String requestingProviderNo = (loggedInInfo != null && loggedInInfo.getLoggedInProviderNo() != null) ? loggedInInfo.getLoggedInProviderNo() : "unknown";
+         MiscUtils.getLogger().error("Error loading consultation list for team: " + (team != null ? team : "all") + " (requesting provider: " + requestingProviderNo + ")", e);
          verdict = false;
       }
       return verdict;

--- a/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/pageUtil/EctViewConsultationRequestsUtil.java
+++ b/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/pageUtil/EctViewConsultationRequestsUtil.java
@@ -113,12 +113,25 @@ public class EctViewConsultationRequestsUtil {
     * @return boolean true if data was loaded successfully, false on error
     */
    public boolean estConsultationVecByTeam(LoggedInInfo loggedInInfo, String team,boolean showCompleted,Date startDate, Date endDate,String orderby,String desc,String searchDate, Integer offset, Integer limit) {
+      return estConsultationVecByTeam(loggedInInfo, team, showCompleted, startDate, endDate, orderby, desc, searchDate, offset, limit, null, null);
+   }
+
+   /**
+    * Same as {@link #estConsultationVecByTeam(LoggedInInfo, String, boolean, Date, Date, String, String, String, Integer, Integer)}
+    * but additionally filters by an optional consultant (specialist) and/or patient provider (MRP).
+    * Both filters are optional and combine with each other and the other filters.
+    *
+    * @param consultantId Integer the ProfessionalSpecialist id to filter by (null for no consultant filter)
+    * @param filterProviderNo String the patient MRP provider number to filter by (null/empty for no provider filter)
+    * @return boolean true if data was loaded successfully, false on error
+    */
+   public boolean estConsultationVecByTeam(LoggedInInfo loggedInInfo, String team,boolean showCompleted,Date startDate, Date endDate,String orderby,String desc,String searchDate, Integer offset, Integer limit, Integer consultantId, String filterProviderNo) {
       initLists();
 
       boolean verdict = true;
       try {
           ConsultationRequestDao consultReqDao = SpringUtils.getBean(ConsultationRequestDao.class);
-          List<ConsultationListDTO> dtos = consultReqDao.getConsultationDTOs(team, showCompleted, startDate, endDate, orderby, desc, searchDate, offset, limit);
+          List<ConsultationListDTO> dtos = consultReqDao.getConsultationDTOs(team, showCompleted, startDate, endDate, orderby, desc, searchDate, offset, limit, consultantId, filterProviderNo);
 
           for (ConsultationListDTO dto : dtos) {
               ids.add(dto.getId() != null ? dto.getId().toString() : "");

--- a/src/main/webapp/WEB-INF/classes/struts.xml
+++ b/src/main/webapp/WEB-INF/classes/struts.xml
@@ -1015,6 +1015,7 @@
         <action name="oscarEncounter/ViewConsultation" class="ca.openosp.openo.encounter.oscarConsultationRequest.pageUtil.EctViewConsultationRequests2Action">
             <result name="success">/oscarEncounter/oscarConsultationRequest/ViewConsultationRequests.jsp</result>
         </action>
+        <action name="oscarEncounter/searchConsultationConsultants" class="ca.openosp.openo.encounter.oscarConsultationRequest.pageUtil.EctViewConsultationRequests2Action" method="searchConsultants"/>
         <action name="oscarEncounter/ViewRequest" class="ca.openosp.openo.encounter.oscarConsultationRequest.pageUtil.EctViewRequest2Action">
             <result name="failESend">/oscarEncounter/ViewRequest.do</result>
             <result name="success">/oscarEncounter/oscarConsultationRequest/ConsultationFormRequest.jsp</result>

--- a/src/main/webapp/oscarEncounter/oscarConsultationRequest/ViewConsultationRequests.jsp
+++ b/src/main/webapp/oscarEncounter/oscarConsultationRequest/ViewConsultationRequests.jsp
@@ -201,6 +201,12 @@
                 }
             }
             distinctConsultProviders = filteredProviders;
+            // Defense-in-depth: ignore a provider filter outside the user's site/team scope so a
+            // crafted request can't push an out-of-scope providerNo into the query. (Out-of-scope
+            // rows are also dropped per-row at render time.)
+            if (!filterProviderNo.isEmpty() && !providerMap.containsKey(filterProviderNo)) {
+                filterProviderNo = "";
+            }
         }
 
         // Pre-compute labels for the current selections so the search boxes repopulate on reload.
@@ -324,6 +330,7 @@ background-color:rgb(212, 212, 254);
                 document.forms[0].orderby.value = val;
                 document.forms[0].desc.value = '0';
             }
+            if (typeof sanitizeConsultationFilters === "function") sanitizeConsultationFilters();
             document.forms[0].submit();
         }
 
@@ -334,6 +341,7 @@ background-color:rgb(212, 212, 254);
             if (next) frm.offset.value = "<%=Encode.forJavaScript(String.valueOf(offset+limit))%>";
             else frm.offset.value = "<%=Encode.forJavaScript(String.valueOf(offset-limit))%>";
 
+            if (typeof sanitizeConsultationFilters === "function") sanitizeConsultationFilters();
             frm.submit();
         }
     </script>
@@ -467,6 +475,30 @@ background-color:rgb(212, 212, 254);
                                     <% } %>
                                 ];
 
+                                // Drop a stale hidden id if the visible text no longer matches a known option.
+                                function reconcileConsultationFilter(searchId, hiddenId, options) {
+                                    var text = jQuery(searchId).val().trim();
+                                    var idVal = jQuery(hiddenId).val();
+                                    if (text === "") {
+                                        jQuery(hiddenId).val("");
+                                        return;
+                                    }
+                                    var matched = options.some(function (o) {
+                                        return o.label === text && o.value === idVal;
+                                    });
+                                    if (!matched) {
+                                        jQuery(searchId).val("");
+                                        jQuery(hiddenId).val("");
+                                    }
+                                }
+
+                                // Sanitize both filter fields. Invoked from every submit path (filter button,
+                                // sort headers, paging) because native form.submit() bypasses jQuery submit handlers.
+                                function sanitizeConsultationFilters() {
+                                    reconcileConsultationFilter("#consultantSearch", "#consultantId", consultantOptions);
+                                    reconcileConsultationFilter("#providerSearch", "#filterProviderNo", providerOptions);
+                                }
+
                                 jQuery(function () {
                                     function setupFilterAutocomplete(searchId, hiddenId, options) {
                                         jQuery(searchId).autocomplete({
@@ -495,31 +527,13 @@ background-color:rgb(212, 212, 254);
                                         });
                                     }
 
-                                    // Drop a stale hidden id if the visible text no longer matches a known option.
-                                    function reconcileFilter(searchId, hiddenId, options) {
-                                        var text = jQuery(searchId).val().trim();
-                                        var idVal = jQuery(hiddenId).val();
-                                        if (text === "") {
-                                            jQuery(hiddenId).val("");
-                                            return;
-                                        }
-                                        var matched = options.some(function (o) {
-                                            return o.label === text && o.value === idVal;
-                                        });
-                                        if (!matched) {
-                                            jQuery(searchId).val("");
-                                            jQuery(hiddenId).val("");
-                                        }
-                                    }
-
                                     setupFilterAutocomplete("#consultantSearch", "#consultantId", consultantOptions);
                                     setupFilterAutocomplete("#providerSearch", "#filterProviderNo", providerOptions);
 
-                                    // When filters change, reset paging to the first page and sanitize the hidden ids.
+                                    // Filter button submit: reset paging to the first page, then sanitize hidden ids.
                                     jQuery("#consultSearchForm").on("submit", function () {
                                         jQuery("#offset").val(0);
-                                        reconcileFilter("#consultantSearch", "#consultantId", consultantOptions);
-                                        reconcileFilter("#providerSearch", "#filterProviderNo", providerOptions);
+                                        sanitizeConsultationFilters();
                                     });
                                 });
                             </script>

--- a/src/main/webapp/oscarEncounter/oscarConsultationRequest/ViewConsultationRequests.jsp
+++ b/src/main/webapp/oscarEncounter/oscarConsultationRequest/ViewConsultationRequests.jsp
@@ -57,6 +57,8 @@
 <%@ page import="java.text.SimpleDateFormat" %>
 <%@ page import="ca.openosp.openo.encounter.oscarConsultationRequest.pageUtil.EctConsultationFormRequestUtil" %>
 <%@ page import="ca.openosp.openo.encounter.oscarConsultationRequest.pageUtil.EctViewConsultationRequestsUtil" %>
+<%@ page import="ca.openosp.openo.commn.model.ProfessionalSpecialist" %>
+<%@ page import="ca.openosp.openo.commn.model.Provider" %>
 <%@ page import="ca.openosp.openo.commn.IsPropertiesOn" %>
 <%@ page import="org.owasp.encoder.Encode" %>
 
@@ -178,6 +180,45 @@
             searchDate = "0";
         }
 
+        // Consultant and provider filter selections (issue #2455). Both optional and combinable.
+        Integer consultantId = (Integer) request.getAttribute("consultantId");
+        String filterProviderNo = (String) request.getAttribute("filterProviderNo");
+        if (filterProviderNo == null) {
+            filterProviderNo = "";
+        }
+
+        // Compute the distinct consultant and provider lists directly here so the filter dropdowns
+        // are always populated regardless of how this page is reached. Apply the same site/team
+        // privacy filter used elsewhere on this page to the provider list.
+        ConsultationRequestDao consultReqDaoForFilters = SpringUtils.getBean(ConsultationRequestDao.class);
+        List<ProfessionalSpecialist> distinctConsultants = consultReqDaoForFilters.getDistinctConsultants();
+        List<Provider> distinctConsultProviders = consultReqDaoForFilters.getDistinctConsultProviders();
+        if (isSiteAccessPrivacy || isTeamAccessPrivacy) {
+            List<Provider> filteredProviders = new ArrayList<Provider>();
+            for (Provider pv : distinctConsultProviders) {
+                if (providerMap.containsKey(pv.getProviderNo())) {
+                    filteredProviders.add(pv);
+                }
+            }
+            distinctConsultProviders = filteredProviders;
+        }
+
+        // Pre-compute labels for the current selections so the search boxes repopulate on reload.
+        String selectedConsultantLabel = "";
+        for (ProfessionalSpecialist sp : distinctConsultants) {
+            if (consultantId != null && consultantId.equals(sp.getId())) {
+                selectedConsultantLabel = sp.getFormattedName();
+                break;
+            }
+        }
+        String selectedProviderLabel = "";
+        for (Provider pv : distinctConsultProviders) {
+            if (!filterProviderNo.isEmpty() && filterProviderNo.equals(pv.getProviderNo())) {
+                selectedProviderLabel = pv.getFormattedName();
+                break;
+            }
+        }
+
         EctConsultationFormRequestUtil consultUtil;
         consultUtil = new EctConsultationFormRequestUtil();
 
@@ -237,6 +278,9 @@ background-color:rgb(212, 212, 254);
 
         </style>
 
+        <link rel="stylesheet" type="text/css" href="<%= request.getContextPath() %>/library/jquery/jquery-ui-1.12.1.min.css">
+        <script type="text/javascript" src="<%= request.getContextPath() %>/library/jquery/jquery-3.6.4.min.js"></script>
+        <script type="text/javascript" src="<%= request.getContextPath() %>/library/jquery/jquery-ui-1.12.1.min.js"></script>
 
     </head>
     <script language="javascript">
@@ -342,7 +386,7 @@ background-color:rgb(212, 212, 254);
                 <table width="100%">
                     <tr>
                         <td style="margin: 0; padding: 0;">
-                            <form action="${pageContext.request.contextPath}/oscarEncounter/ViewConsultation.do" method="get">
+                            <form id="consultSearchForm" action="${pageContext.request.contextPath}/oscarEncounter/ViewConsultation.do" method="get">
                                 <fmt:setBundle basename="oscarResources"/><fmt:message key="oscarEncounter.oscarConsultationRequest.ViewConsultationRequests.formSelectTeam"/>:
                                 <select name="sendTo">
                                     <option value=""><fmt:setBundle basename="oscarResources"/><fmt:message key="oscarEncounter.oscarConsultationRequest.ViewConsultationRequests.formViewAll"/></option>
@@ -367,6 +411,16 @@ background-color:rgb(212, 212, 254);
                                         }
                                     %>
                                 </select>
+                                <input type="text" id="consultantSearch" autocomplete="off" size="22"
+                                       placeholder="All Consultants"
+                                       value="<%=Encode.forHtmlAttribute(selectedConsultantLabel)%>"/>
+                                <input type="hidden" name="consultantId" id="consultantId"
+                                       value="<%=Encode.forHtmlAttribute(consultantId != null ? consultantId.toString() : "")%>"/>
+                                <input type="text" id="providerSearch" autocomplete="off" size="22"
+                                       placeholder="All Providers"
+                                       value="<%=Encode.forHtmlAttribute(selectedProviderLabel)%>"/>
+                                <input type="hidden" name="filterProviderNo" id="filterProviderNo"
+                                       value="<%=Encode.forHtmlAttribute(filterProviderNo)%>"/>
                                 <input type="submit"
                                        value="<fmt:setBundle basename="oscarResources"/><fmt:message key="oscarEncounter.oscarConsultationRequest.ViewConsultationRequests.btnConsReq"/>"/>
                                 <div style="margin: 0; padding: 0; ">
@@ -391,6 +445,84 @@ background-color:rgb(212, 212, 254);
                                     <input type="hidden" name="limit" id="limit" value="<%= Encode.forHtmlAttribute(String.valueOf(limit)) %>"/>
                                 </div>
                             </form>
+                            <script type="text/javascript">
+                                var consultantOptions = [
+                                    <%
+                                        for (int ci = 0; ci < distinctConsultants.size(); ci++) {
+                                            ProfessionalSpecialist sp = distinctConsultants.get(ci);
+                                            String consLabel = sp.getFormattedName();
+                                            String consIdVal = sp.getId() != null ? sp.getId().toString() : "";
+                                    %>
+                                    {label: "<%=Encode.forJavaScript(consLabel)%>", value: "<%=Encode.forJavaScript(consIdVal)%>"}<%= ci < distinctConsultants.size() - 1 ? "," : "" %>
+                                    <% } %>
+                                ];
+                                var providerOptions = [
+                                    <%
+                                        for (int pi = 0; pi < distinctConsultProviders.size(); pi++) {
+                                            Provider pv = distinctConsultProviders.get(pi);
+                                            String pvLabel = pv.getFormattedName();
+                                            String pvNoVal = pv.getProviderNo() != null ? pv.getProviderNo() : "";
+                                    %>
+                                    {label: "<%=Encode.forJavaScript(pvLabel)%>", value: "<%=Encode.forJavaScript(pvNoVal)%>"}<%= pi < distinctConsultProviders.size() - 1 ? "," : "" %>
+                                    <% } %>
+                                ];
+
+                                jQuery(function () {
+                                    function setupFilterAutocomplete(searchId, hiddenId, options) {
+                                        jQuery(searchId).autocomplete({
+                                            source: options,
+                                            minLength: 0,
+                                            delay: 0,
+                                            focus: function (event, ui) {
+                                                event.preventDefault();
+                                                jQuery(searchId).val(ui.item.label);
+                                            },
+                                            select: function (event, ui) {
+                                                event.preventDefault();
+                                                jQuery(searchId).val(ui.item.label);
+                                                jQuery(hiddenId).val(ui.item.value);
+                                            },
+                                            change: function (event, ui) {
+                                                if (!ui.item) {
+                                                    jQuery(searchId).val("");
+                                                    jQuery(hiddenId).val("");
+                                                }
+                                            }
+                                        });
+                                        // Show the full list on focus so the input behaves like a searchable dropdown.
+                                        jQuery(searchId).on("focus", function () {
+                                            jQuery(this).autocomplete("search", jQuery(this).val());
+                                        });
+                                    }
+
+                                    // Drop a stale hidden id if the visible text no longer matches a known option.
+                                    function reconcileFilter(searchId, hiddenId, options) {
+                                        var text = jQuery(searchId).val().trim();
+                                        var idVal = jQuery(hiddenId).val();
+                                        if (text === "") {
+                                            jQuery(hiddenId).val("");
+                                            return;
+                                        }
+                                        var matched = options.some(function (o) {
+                                            return o.label === text && o.value === idVal;
+                                        });
+                                        if (!matched) {
+                                            jQuery(searchId).val("");
+                                            jQuery(hiddenId).val("");
+                                        }
+                                    }
+
+                                    setupFilterAutocomplete("#consultantSearch", "#consultantId", consultantOptions);
+                                    setupFilterAutocomplete("#providerSearch", "#filterProviderNo", providerOptions);
+
+                                    // When filters change, reset paging to the first page and sanitize the hidden ids.
+                                    jQuery("#consultSearchForm").on("submit", function () {
+                                        jQuery("#offset").val(0);
+                                        reconcileFilter("#consultantSearch", "#consultantId", consultantOptions);
+                                        reconcileFilter("#providerSearch", "#filterProviderNo", providerOptions);
+                                    });
+                                });
+                            </script>
                         </td>
                     </tr>
                     <tr>
@@ -456,7 +588,7 @@ background-color:rgb(212, 212, 254);
                                 <%
                                     EctViewConsultationRequestsUtil theRequests;
                                     theRequests = new EctViewConsultationRequestsUtil();
-                                    theRequests.estConsultationVecByTeam(LoggedInInfo.getLoggedInInfoFromSession(request), team, includeCompleted, startDate, endDate, orderby, desc, searchDate, offset, limit);
+                                    theRequests.estConsultationVecByTeam(LoggedInInfo.getLoggedInInfoFromSession(request), team, includeCompleted, startDate, endDate, orderby, desc, searchDate, offset, limit, consultantId, filterProviderNo);
                                     boolean overdue;
                                     UserPropertyDAO pref = (UserPropertyDAO) WebApplicationContextUtils.getWebApplicationContext(pageContext.getServletContext()).getBean(UserPropertyDAO.class);
                                     String user = (String) session.getAttribute("user");

--- a/src/main/webapp/oscarEncounter/oscarConsultationRequest/ViewConsultationRequests.jsp
+++ b/src/main/webapp/oscarEncounter/oscarConsultationRequest/ViewConsultationRequests.jsp
@@ -58,6 +58,7 @@
 <%@ page import="ca.openosp.openo.encounter.oscarConsultationRequest.pageUtil.EctConsultationFormRequestUtil" %>
 <%@ page import="ca.openosp.openo.encounter.oscarConsultationRequest.pageUtil.EctViewConsultationRequestsUtil" %>
 <%@ page import="ca.openosp.openo.commn.model.ProfessionalSpecialist" %>
+<%@ page import="ca.openosp.openo.commn.dao.ProfessionalSpecialistDao" %>
 <%@ page import="ca.openosp.openo.commn.model.Provider" %>
 <%@ page import="ca.openosp.openo.commn.IsPropertiesOn" %>
 <%@ page import="org.owasp.encoder.Encode" %>
@@ -187,11 +188,9 @@
             filterProviderNo = "";
         }
 
-        // Compute the distinct consultant and provider lists directly here so the filter dropdowns
-        // are always populated regardless of how this page is reached. Apply the same site/team
-        // privacy filter used elsewhere on this page to the provider list.
+        // Providers are a bounded, per-clinic list, so the filter is a plain dropdown populated
+        // up front. Apply the same site/team privacy filter used elsewhere on this page.
         ConsultationRequestDao consultReqDaoForFilters = SpringUtils.getBean(ConsultationRequestDao.class);
-        List<ProfessionalSpecialist> distinctConsultants = consultReqDaoForFilters.getDistinctConsultants();
         List<Provider> distinctConsultProviders = consultReqDaoForFilters.getDistinctConsultProviders();
         if (isSiteAccessPrivacy || isTeamAccessPrivacy) {
             List<Provider> filteredProviders = new ArrayList<Provider>();
@@ -209,19 +208,14 @@
             }
         }
 
-        // Pre-compute labels for the current selections so the search boxes repopulate on reload.
+        // Consultant options are loaded via AJAX.
+        // Selected consultant label is tracked in the event of a reload.
         String selectedConsultantLabel = "";
-        for (ProfessionalSpecialist sp : distinctConsultants) {
-            if (consultantId != null && consultantId.equals(sp.getId())) {
-                selectedConsultantLabel = sp.getFormattedName();
-                break;
-            }
-        }
-        String selectedProviderLabel = "";
-        for (Provider pv : distinctConsultProviders) {
-            if (!filterProviderNo.isEmpty() && filterProviderNo.equals(pv.getProviderNo())) {
-                selectedProviderLabel = pv.getFormattedName();
-                break;
+        if (consultantId != null) {
+            ProfessionalSpecialistDao professionalSpecialistDao = SpringUtils.getBean(ProfessionalSpecialistDao.class);
+            ProfessionalSpecialist selectedConsultant = professionalSpecialistDao.find(consultantId);
+            if (selectedConsultant != null) {
+                selectedConsultantLabel = selectedConsultant.getFormattedName();
             }
         }
 
@@ -424,11 +418,16 @@ background-color:rgb(212, 212, 254);
                                        value="<%=Encode.forHtmlAttribute(selectedConsultantLabel)%>"/>
                                 <input type="hidden" name="consultantId" id="consultantId"
                                        value="<%=Encode.forHtmlAttribute(consultantId != null ? consultantId.toString() : "")%>"/>
-                                <input type="text" id="providerSearch" autocomplete="off" size="22"
-                                       placeholder="All Providers"
-                                       value="<%=Encode.forHtmlAttribute(selectedProviderLabel)%>"/>
-                                <input type="hidden" name="filterProviderNo" id="filterProviderNo"
-                                       value="<%=Encode.forHtmlAttribute(filterProviderNo)%>"/>
+                                <select name="filterProviderNo" id="filterProviderNo">
+                                    <option value="">All Providers</option>
+                                    <%
+                                        for (Provider pv : distinctConsultProviders) {
+                                            String pvNo = pv.getProviderNo() != null ? pv.getProviderNo() : "";
+                                            boolean pvSelected = !filterProviderNo.isEmpty() && filterProviderNo.equals(pvNo);
+                                    %>
+                                    <option value="<%=Encode.forHtmlAttribute(pvNo)%>" <%=pvSelected ? "selected" : ""%>><%=Encode.forHtml(pv.getFormattedName())%></option>
+                                    <% } %>
+                                </select>
                                 <input type="submit"
                                        value="<fmt:setBundle basename="oscarResources"/><fmt:message key="oscarEncounter.oscarConsultationRequest.ViewConsultationRequests.btnConsReq"/>"/>
                                 <div style="margin: 0; padding: 0; ">
@@ -454,83 +453,49 @@ background-color:rgb(212, 212, 254);
                                 </div>
                             </form>
                             <script type="text/javascript">
-                                var consultantOptions = [
-                                    <%
-                                        for (int ci = 0; ci < distinctConsultants.size(); ci++) {
-                                            ProfessionalSpecialist sp = distinctConsultants.get(ci);
-                                            String consLabel = sp.getFormattedName();
-                                            String consIdVal = sp.getId() != null ? sp.getId().toString() : "";
-                                    %>
-                                    {label: "<%=Encode.forJavaScript(consLabel)%>", value: "<%=Encode.forJavaScript(consIdVal)%>"}<%= ci < distinctConsultants.size() - 1 ? "," : "" %>
-                                    <% } %>
-                                ];
-                                var providerOptions = [
-                                    <%
-                                        for (int pi = 0; pi < distinctConsultProviders.size(); pi++) {
-                                            Provider pv = distinctConsultProviders.get(pi);
-                                            String pvLabel = pv.getFormattedName();
-                                            String pvNoVal = pv.getProviderNo() != null ? pv.getProviderNo() : "";
-                                    %>
-                                    {label: "<%=Encode.forJavaScript(pvLabel)%>", value: "<%=Encode.forJavaScript(pvNoVal)%>"}<%= pi < distinctConsultProviders.size() - 1 ? "," : "" %>
-                                    <% } %>
-                                ];
+                                // Typing clears any prior selection; a fresh id is only set via the
+                                // autocomplete "select" handler below, so half-typed/unselected text
+                                // never silently implies a filter.
+                                jQuery("#consultantSearch").on("input", function () {
+                                    jQuery("#consultantId").val("");
+                                });
 
-                                // Drop a stale hidden id if the visible text no longer matches a known option.
-                                function reconcileConsultationFilter(searchId, hiddenId, options) {
-                                    var text = jQuery(searchId).val().trim();
-                                    var idVal = jQuery(hiddenId).val();
-                                    if (text === "") {
-                                        jQuery(hiddenId).val("");
-                                        return;
-                                    }
-                                    var matched = options.some(function (o) {
-                                        return o.label === text && o.value === idVal;
-                                    });
-                                    if (!matched) {
-                                        jQuery(searchId).val("");
-                                        jQuery(hiddenId).val("");
-                                    }
-                                }
-
-                                // Sanitize both filter fields. Invoked from every submit path (filter button,
-                                // sort headers, paging) because native form.submit() bypasses jQuery submit handlers.
+                                // If the box was left with typed text but no confirmed selection,
+                                // clear the text too. Invoked from every submit path (filter button,
+                                // sort headers, paging) because native form.submit() bypasses jQuery
+                                // submit handlers.
                                 function sanitizeConsultationFilters() {
-                                    reconcileConsultationFilter("#consultantSearch", "#consultantId", consultantOptions);
-                                    reconcileConsultationFilter("#providerSearch", "#filterProviderNo", providerOptions);
+                                    if (!jQuery("#consultantId").val()) {
+                                        jQuery("#consultantSearch").val("");
+                                    }
                                 }
 
                                 jQuery(function () {
-                                    function setupFilterAutocomplete(searchId, hiddenId, options) {
-                                        jQuery(searchId).autocomplete({
-                                            source: options,
-                                            minLength: 0,
-                                            delay: 0,
-                                            focus: function (event, ui) {
-                                                event.preventDefault();
-                                                jQuery(searchId).val(ui.item.label);
-                                            },
-                                            select: function (event, ui) {
-                                                event.preventDefault();
-                                                jQuery(searchId).val(ui.item.label);
-                                                jQuery(hiddenId).val(ui.item.value);
-                                            },
-                                            change: function (event, ui) {
-                                                if (!ui.item) {
-                                                    jQuery(searchId).val("");
-                                                    jQuery(hiddenId).val("");
-                                                }
-                                            }
-                                        });
-                                        // Show the full list on focus so the input behaves like a searchable dropdown.
-                                        jQuery(searchId).on("focus", function () {
-                                            jQuery(this).autocomplete("search", jQuery(this).val());
-                                        });
-                                    }
+                                    var contextPath = "<%= request.getContextPath() %>";
+                                    jQuery("#consultantSearch").autocomplete({
+                                        minLength: 2,
+                                        delay: 300,
+                                        source: function (request, response) {
+                                            jQuery.getJSON(contextPath + "/oscarEncounter/searchConsultationConsultants.do", {keyword: request.term})
+                                                .done(function (data) {
+                                                    response(data || []);
+                                                })
+                                                .fail(function () {
+                                                    response([]);
+                                                });
+                                        },
+                                        focus: function (event, ui) {
+                                            event.preventDefault();
+                                            jQuery("#consultantSearch").val(ui.item.label);
+                                        },
+                                        select: function (event, ui) {
+                                            event.preventDefault();
+                                            jQuery("#consultantSearch").val(ui.item.label);
+                                            jQuery("#consultantId").val(ui.item.value);
+                                        }
+                                    });
 
-                                    setupFilterAutocomplete("#consultantSearch", "#consultantId", consultantOptions);
-                                    setupFilterAutocomplete("#providerSearch", "#filterProviderNo", providerOptions);
-
-                                    // Filter button submit: reset paging to the first page, then sanitize hidden ids.
+                                    // Filter button submit: reset paging to the first page, then sanitize.
                                     jQuery("#consultSearchForm").on("submit", function () {
                                         jQuery("#offset").val(0);
                                         sanitizeConsultationFilters();

--- a/src/test/java/ca/openosp/openo/commn/dao/ConsultationRequestDaoTest.java
+++ b/src/test/java/ca/openosp/openo/commn/dao/ConsultationRequestDaoTest.java
@@ -33,6 +33,7 @@ import org.junit.Before;
 import org.junit.Test;
 import ca.openosp.openo.commn.dao.utils.SchemaUtils;
 import ca.openosp.openo.commn.model.ConsultationRequest;
+import ca.openosp.openo.commn.model.ProfessionalSpecialist;
 import ca.openosp.openo.commn.dao.ConsultationRequestDao;
 import ca.openosp.openo.utility.SpringUtils;
 
@@ -82,6 +83,31 @@ public class ConsultationRequestDaoTest extends DaoTestFixtures {
     @Test
     public void testFindRequestsByDemoNo() {
         assertNotNull(dao.findRequestsByDemoNo(100, new Date()));
+    }
+
+    @Test
+    public void testSearchDistinctConsultantsMatchesKeywordSpanningNameSeparator() {
+        ProfessionalSpecialist specialist = new ProfessionalSpecialist();
+        specialist.setLastName("Smith");
+        specialist.setFirstName("Brian");
+        dao.persist(specialist);
+
+        ConsultationRequest cr = new ConsultationRequest();
+        cr.setProviderNo("0");
+        cr.setReferralDate(new Date());
+        cr.setProfessionalSpecialist(specialist);
+        dao.persist(cr);
+
+        // keyword spans the "lastName, firstName" separator, as displayed by the autocomplete
+        List<ProfessionalSpecialist> matches = dao.searchDistinctConsultants("smith, b", 10);
+        assertNotNull(matches);
+        assertTrue(matches.size() == 1);
+        assertTrue(matches.get(0).getLastName().equals("Smith"));
+
+        // single-token keyword should still match
+        matches = dao.searchDistinctConsultants("Smith", 10);
+        assertNotNull(matches);
+        assertTrue(matches.size() == 1);
     }
 
 }

--- a/src/test/java/ca/openosp/openo/commn/dao/ConsultationRequestDaoTest.java
+++ b/src/test/java/ca/openosp/openo/commn/dao/ConsultationRequestDaoTest.java
@@ -87,6 +87,44 @@ public class ConsultationRequestDaoTest extends DaoTestFixtures {
 
     @Test
     public void testSearchDistinctConsultantsMatchesKeywordSpanningNameSeparator() {
+        persistConsultantNamedSmithBrian();
+
+        // keyword spans the "lastName, firstName" separator, as displayed by the autocomplete
+        assertMatchesSmith("smith, b");
+
+        // single-token keyword should still match
+        assertMatchesSmith("Smith");
+    }
+
+    @Test
+    public void testSearchDistinctConsultantsIgnoresSpacingAndTermOrder() {
+        persistConsultantNamedSmithBrian();
+
+        assertMatchesSmith("smith,b");          // no space after the comma
+        assertMatchesSmith("smith,   b");       // extra spaces after the comma
+        assertMatchesSmith("  Smith,B  ");      // surrounding whitespace
+        assertMatchesSmith("smith b");          // no comma at all
+        assertMatchesSmith("brian smith");      // first name typed first
+        assertMatchesSmith("smith, brian");     // the full formatted name
+    }
+
+    @Test
+    public void testSearchDistinctConsultantsExcludesNonMatchingAndWildcardKeywords() {
+        persistConsultantNamedSmithBrian();
+
+        // every term must match, so an unrelated second term rules the consultant out
+        assertTrue(dao.searchDistinctConsultants("smith, z", 10).isEmpty());
+
+        // "%" and "_" are matched literally rather than as LIKE wildcards
+        assertTrue(dao.searchDistinctConsultants("%", 10).isEmpty());
+        assertTrue(dao.searchDistinctConsultants("smit_", 10).isEmpty());
+
+        // a keyword with no searchable terms matches nothing
+        assertTrue(dao.searchDistinctConsultants(" , ", 10).isEmpty());
+        assertTrue(dao.searchDistinctConsultants(null, 10).isEmpty());
+    }
+
+    private void persistConsultantNamedSmithBrian() {
         ProfessionalSpecialist specialist = new ProfessionalSpecialist();
         specialist.setLastName("Smith");
         specialist.setFirstName("Brian");
@@ -97,17 +135,13 @@ public class ConsultationRequestDaoTest extends DaoTestFixtures {
         cr.setReferralDate(new Date());
         cr.setProfessionalSpecialist(specialist);
         dao.persist(cr);
+    }
 
-        // keyword spans the "lastName, firstName" separator, as displayed by the autocomplete
-        List<ProfessionalSpecialist> matches = dao.searchDistinctConsultants("smith, b", 10);
+    private void assertMatchesSmith(String keyword) {
+        List<ProfessionalSpecialist> matches = dao.searchDistinctConsultants(keyword, 10);
         assertNotNull(matches);
-        assertTrue(matches.size() == 1);
+        assertTrue("expected a match for keyword [" + keyword + "]", matches.size() == 1);
         assertTrue(matches.get(0).getLastName().equals("Smith"));
-
-        // single-token keyword should still match
-        matches = dao.searchDistinctConsultants("Smith", 10);
-        assertNotNull(matches);
-        assertTrue(matches.size() == 1);
     }
 
 }


### PR DESCRIPTION
# Changes Made
  - Add `Consultant` and `Provider` filter inputs on the consultations page.
  - Extend `ConsultationRequestDao` with an overloaded `getConsultationDTOs()`, for the consultant and provider filters.
  - Add `getDistinctConsultants()` and `getDistinctConsultProviders()` queries to populate filter options.
  - Pass `Consultant` and `Provider` filters to the DAO via `EctViewConsultationRequestsUtil` and `EctViewConsultationRequests2Action`.
  - Reset pagination and clear stale filter ids on submit.
  - Parameterize legacy `getConsults()` to fix a SQL injection.

## Summary by Sourcery

Add consultant and provider filtering to the consultations view and improve safety of consultation queries.

New Features:
- Introduce consultant and provider filters with autocomplete inputs on the consultations page that combine with existing team/date/completed filters and sorting.

Bug Fixes:
- Parameterize legacy consultation query filters to prevent SQL injection vulnerabilities.

Enhancements:
- Extend consultation DAO and utilities to support optional consultant and provider filters and expose distinct consultants/providers for populating filter options.
- Reset pagination and clear inconsistent filter selections when submitting the consultation search form.
- Apply site/team privacy constraints to provider filter options in the consultations view.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds consultant autocomplete and patient MRP provider filters to the Consultations page, combining with existing filters and sorting. Improves query safety and makes consultant search consistent across name formatting and locales.

- UI: Consultant autocomplete with debounced search and Provider dropdown; both compose with team/date/completed filters and sorting; pagination resets to the first page; unconfirmed consultant text is cleared on submit/sort/page.
- DAO: Overloaded `ConsultationRequestDao#getConsultationDTOs(..., consultantId, filterProviderNo)`; `searchDistinctConsultants` matches terms against "lastName, firstName", escapes `%`/`_`, and uses locale‑independent lowercasing; `getDistinctConsultProviders` populates provider options.
- Endpoint: New `oscarEncounter/searchConsultationConsultants` returns `{label, value}` pairs for autocomplete.
- Validation and safety: Provider options respect site/team privacy; ignore out‑of‑scope `filterProviderNo`; legacy `getConsults(...)` now parameterized to prevent SQL injection.
- Tests: Coverage for consultant search across separator, spacing, term order, and wildcard input.

<sup>Written for commit 8b0d6750f7c23923e20abbd40226f5055b241cdf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openo-beta/Open-O/pull/2480?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added server-driven consultation request filtering by consultant and patient MRP provider.
  * Added dynamically populated provider options and consultant autocomplete search.
* **Bug Fixes / UX Improvements**
  * Prevented unconfirmed consultant text from being applied as a filter.
  * Reset pagination when filters are submitted while preserving sorting.
  * Restricted provider selections to available results.
* **Tests**
  * Added coverage for consultant searches across name formatting, spacing, term order, and wildcard input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->