### PR TITLE
Fix: dhirSubmission.jsp compilation error after AbstractFhirMessageBuilder relocation

### DIFF
--- a/src/main/webapp/oscarPrevention/dhirSubmission.jsp
+++ b/src/main/webapp/oscarPrevention/dhirSubmission.jsp
@@ -40,7 +40,7 @@
 <%@page import="org.hl7.fhir.dstu3.model.Patient" %>
 <%@page import="org.hl7.fhir.dstu3.model.Bundle.BundleEntryComponent" %>
 <%@page import="ca.openosp.openo.utility.LoggedInInfo" %>
-<%@page import="ca.openosp.openo.integration.fhir.builder.AbstractFhirMessageBuilder" %>
+<%@page import="ca.openosp.openo.integration.fhir.dstu3.builder.AbstractFhirMessageBuilder" %>
 <%@page import="org.hl7.fhir.dstu3.model.Bundle" %>
 <%@page import="java.util.Map" %>
 <%@page import="java.io.InputStream" %>


### PR DESCRIPTION
## Summary

`oscarPrevention/dhirSubmission.jsp` fails to compile because it imports
`AbstractFhirMessageBuilder` from a package that no longer exists. The FHIR
libraries refactor (OpenOSP PR `#224`, reached `develop` via the upstream sync PR #2479)
split that single class into version-specific `dstu3` and `r4` variants and
removed the old path. This one-line fix repoints the import at the **dstu3**
variant — the version this JSP's import previously resolved to — restoring the
page to its prior state and unblocking compilation.

## Problem

The JSP imports the builder from its old, now-deleted location:

```jsp
<%@page import="ca.openosp.openo.integration.fhir.builder.AbstractFhirMessageBuilder" %>
```

The package `ca.openosp.openo.integration.fhir.builder` no longer exists. As part
of the FHIR-libraries refactor, `AbstractFhirMessageBuilder` was forked into two
version-pinned variants:

- `ca.openosp.openo.integration.fhir.dstu3.builder.AbstractFhirMessageBuilder`
  (`FhirContext.forDstu3()`)
- `ca.openosp.openo.integration.fhir.r4.builder.AbstractFhirMessageBuilder`
  (`FhirContext.forR4()`)

Because the import target is gone, the JSP no longer compiles. The class is used
on the page (line ~333), where it serializes the FHIR bundle:

```jsp
String theString = AbstractFhirMessageBuilder.getFhirContext()
        .newJsonParser().setPrettyPrint(true).encodeResourceToString(bundle);
```

## Solution

Repoint the import at the **dstu3** sub-package — the variant this JSP's import
resolved to before the file moved (the original pre-split builder was bound to
`FhirContext.forDstu3()`):

```diff
-<%@page import="ca.openosp.openo.integration.fhir.builder.AbstractFhirMessageBuilder" %>
+<%@page import="ca.openosp.openo.integration.fhir.dstu3.builder.AbstractFhirMessageBuilder" %>
```

This is the minimal, behavior-preserving change: it restores the page to the
state it was in before the file was relocated, without altering FHIR-version
semantics. The page (and the wider DHIR feature) ships disabled by default
(`dhir.enabled=false`), so this is a low-risk fix to unblock JSP compilation.

### Verification

- Confirmed the old package `ca.openosp.openo.integration.fhir.builder` no longer
  exists on disk.
- Confirmed the original pre-split builder was bound to `FhirContext.forDstu3()`,
  so the dstu3 variant is the faithful continuation of this import.
- Confirmed `getFhirContext()` is a `public static` method on the dstu3 builder,
  so the usage resolves and compiles.
- Confirmed no other file under `src/` still references the old package path.
- Final gate: `make jspc` to confirm the JSP compiles cleanly.

## Note for future DHIR work

While tracing this, I noticed that other parts of the DHIR path appear to be on
r4 — e.g. the producer that fills the `bundles` session attribute
(`prevention/pageUtil/AddPrevention2Action`) and the `integration/dhir/*` backend
now reference `org.hl7.fhir.r4.model.*`, whereas this JSP is dstu3. We have not
fully traced why this page was left on dstu3, and there may be an intentional
reason we're missing, so this PR deliberately does not change it — it only
restores the page to its previous (dstu3) state to fix the build.

Flagging it so it can be looked at properly whenever DHIR is next worked on: it
would be worth confirming whether this consumer should be aligned to r4 to match
the producer, and validating an actual DHIR submission end-to-end.

For reference, the upstream OscarPro version of this page resolves these imports
to the **r4** variants, which may be a useful comparison point for that future
investigation:
https://bitbucket.org/oscaremr/oscarpro/src/master/src/main/webapp/oscarPrevention/dhirSubmission.jsp

## Files changed

- `src/main/webapp/oscarPrevention/dhirSubmission.jsp` — 1 line (import path).

## Summary by Sourcery

Bug Fixes:
- Fix dhirSubmission.jsp failing to compile due to an outdated AbstractFhirMessageBuilder import path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal data processing library used for handling submissions to improve compatibility and consistency with current standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->