### PR TITLE
Fix: Using double quotes " breaks prescriptions

### DIFF
--- a/src/main/webapp/oscarRx/printRx/PreviewContent.jsp
+++ b/src/main/webapp/oscarRx/printRx/PreviewContent.jsp
@@ -316,8 +316,8 @@
                             <td colspan="2" id="additNotes">${requestScope.comment}</td>
                         </tr>
 
-                        <input type="hidden" name="rx" value="${requestScope.strRx}"/>
-                        <input type="hidden" name="rx_no_newlines" id="rx_no_newlines" value="${requestScope.strRxNoNewLines}"/>
+                        <input type="hidden" name="rx" value="<%= Encode.forHtmlAttribute(request.getAttribute("strRx") != null ? request.getAttribute("strRx").toString() : "") %>"/>
+                        <input type="hidden" name="rx_no_newlines" id="rx_no_newlines" value="<%= Encode.forHtmlAttribute(request.getAttribute("strRxNoNewLines") != null ? request.getAttribute("strRxNoNewLines").toString() : "") %>"/>
                         <input type="hidden" name="additNotes" value="${requestScope.comment}"/>
                         </tbody>
                     </table>


### PR DESCRIPTION
## Summary

A double quote (`"`) in a drug name, instructions, or special instructions silently
truncated the **faxed/printed prescription** and the **"Add to encounter note"** text from the
first `"` onward. The Rx body was interpolated **raw** into two double-quoted HTML hidden-input
attributes, so the `"` closed the attribute early and everything after it was lost. The fix
applies context-appropriate OWASP encoding at those two output points. This is the same class
of bug — and the same fix pattern — as #2451 / PR #2459, which handled the pharmacy name; this
change covers the prescription text itself.

Files changed:
- `src/main/webapp/oscarRx/printRx/PreviewContent.jsp`

Fixes #2482

## Problem

When a drug name or its (special) instructions contained a `"`, e.g. `Tylenol "extra"`:

- The **faxed Rx** PDF was cut off at the first `"`.
- The **encounter/chart note** created by "Print & Add to encounter note" (and the fax + paste
  button) was cut off at the first `"`.

The on-screen preview looked correct, which masked the problem.

Root cause: in `PreviewContent.jsp`, the prescription text was rendered **raw** into two
double-quoted HTML hidden inputs:

```jsp
<input type="hidden" name="rx"             value="${requestScope.strRx}"/>
<input type="hidden" name="rx_no_newlines" id="rx_no_newlines" value="${requestScope.strRxNoNewLines}"/>
```

Both values come from `RxPrescriptionData.getFullOutLine()` (drug name + instructions + special
instructions, concatenated). A `"` in that text closed the `value="..."` attribute early, so:

- **`name="rx"`** — submitted via `preview2Form` to `FrmCustomedPDFServlet`
  (`/form/createcustomedpdf`) for the print/fax PDF. The form posted a **truncated** value, so
  the PDF was cut off. (The servlet splits the text on newlines/`<br>`, never on `"`, so the
  truncation is purely the browser closing the attribute at submit time.)
- **`name="rx_no_newlines"`** — read in JS by `printPaste2Parent()` as
  `document.getElementById("rx_no_newlines").value`. The DOM only contained text up to the first
  `"`, so the encounter note was truncated.

The on-screen preview was unaffected because it renders the Rx in an **HTML body** context
(`<td>${fullOutLine}</td>`), where a literal `"` is harmless — the bug only manifests in the
**attribute** context of the hidden inputs.

This also explains the reporter's observation that the **fax** issue was recent while the
**encounter note** issue was long-standing: the fax-via-PDF-servlet path and the
`rx_no_newlines` input were introduced in the recent Rx print-preview refactor, whereas the
encounter-note paste has emitted Rx text into an unescaped attribute/JS context for far longer.
In the current code both symptoms share the one root cause above, so a single change resolves
both.

## Solution

Encode the two hidden inputs at the **output point**, per context, instead of leaving them raw —
matching the already-correct sibling inputs in this same file (`pharmaName`, `pharmaFax`,
`pharmacyInfo`) that were fixed in PR #2459:

```jsp
<input type="hidden" name="rx"
       value="<%= Encode.forHtmlAttribute(request.getAttribute("strRx") != null ? request.getAttribute("strRx").toString() : "") %>"/>
<input type="hidden" name="rx_no_newlines" id="rx_no_newlines"
       value="<%= Encode.forHtmlAttribute(request.getAttribute("strRxNoNewLines") != null ? request.getAttribute("strRxNoNewLines").toString() : "") %>"/>
```

`Encode.forHtmlAttribute` turns `"` into `&#34;`, so it can no longer break out of the
`value="..."` attribute. The encoding is **transparent to both consumers** — the browser decodes
it back to a literal `"`:

- On **form submit**, `FrmCustomedPDFServlet.getParameter("rx")` receives the real value, so the
  printed/faxed PDF shows the full line.
- On **DOM read**, `getElementById("rx_no_newlines").value` returns the real value, so the
  encounter note contains the full line.

<img width="1920" height="1024" alt="image" src="https://github.com/user-attachments/assets/697d15c1-f0ca-4131-b730-92c1605ea8a2" />

<img width="1103" height="125" alt="image" src="https://github.com/user-attachments/assets/733a1c91-13f8-49a6-8c95-f332e1ce9be7" />

<img width="768" height="606" alt="image" src="https://github.com/user-attachments/assets/903610bb-cbd5-47f1-a338-5c789fac750a" />

## Summary by Sourcery

Escape prescription text when rendering into hidden HTML inputs to prevent truncation when it contains double quotes.

Bug Fixes:
- Ensure faxed/printed prescriptions are no longer cut off when drug names or instructions contain double quotes.
- Ensure encounter notes created from prescriptions include the full text even when it contains double quotes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal data handling for prescription preview rendering with enhanced security measures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->