### PR TITLE
Fix: typo in Invoice Reports status filter label ("Submmitted" → "Submitted")

### DIFF
--- a/src/main/webapp/billing/CA/ON/billingONStatus.jsp
+++ b/src/main/webapp/billing/CA/ON/billingONStatus.jsp
@@ -684,7 +684,7 @@
                             <!--li><label class="radio inline"><input type="radio" name="statusType" value="N" <%=statusType.equals("N")?"checked":""%>>Do Not Bill</label>
                                     <label class="radio inline"><input type="radio" name="statusType" value="W" <%=statusType.equals("W")?"checked":""%>>WCB</label>-->
                             <label class="radio inline"><input type="radio" name="statusType"
-                                                               value="B" <%=statusType.equals("B")?"checked":""%>>Submmitted
+                                                               value="B" <%=statusType.equals("B")?"checked":""%>>Submitted
                                 OHIP</label>
                             <label class="radio inline"><input type="radio" name="statusType"
                                                                value="S" <%=statusType.equals("S")?"checked":""%>>Settled/Paid</label>


### PR DESCRIPTION
## Summary

Corrects a spelling mistake in the Ontario billing **Invoice Reports** screen, where the
"Submitted OHIP" status-filter radio button was mislabelled **"Submmitted OHIP"** (double "m").
This is a one-line, display-only text change with no functional impact.

Closes: [Typos in OSCAR GUI](https://trello.com/c/OqQdeJEw/898-typos-in-oscar-gui)

## Problem

In **Admin Panel → Billing → Invoice Reports**, the radio button used to filter invoices by
status rendered its label as **"Submmitted OHIP"** instead of **"Submitted OHIP"**. The misspelling
was visible to every user of the Ontario billing reporting screen.

- **File:** `src/main/webapp/billing/CA/ON/billingONStatus.jsp`
- **Element:** `statusType` radio button, `value="B"`

## Solution

Corrected the label text from `Submmitted` to `Submitted`.

```diff
                             <label class="radio inline"><input type="radio" name="statusType"
-                                                               value="B" <%=statusType.equals("B")?"checked":""%>>Submmitted
+                                                               value="B" <%=statusType.equals("B")?"checked":""%>>Submitted
                                 OHIP</label>
```

### **UI Before:**
<img width="900" height="41" alt="image" src="https://github.com/user-attachments/assets/58c21936-583e-42ef-bbbe-8056513101a7" />

### **UI After:**
<img width="862" height="42" alt="Screenshot_20260624_164329" src="https://github.com/user-attachments/assets/81de7e98-775b-41c6-a572-af5d2d7221da" />

Only the user-visible label text was changed. The radio button's `value="B"` — the value submitted
to the server and used for filtering — is untouched, so there is no behavioural or data change.

## Testing

- Visual verification: the radio button on the Invoice Reports screen now reads "Submitted OHIP".
- No logic, request parameters, or stored values were modified.

## Summary by Sourcery

Bug Fixes:
- Fix a typo in the "Submitted OHIP" status filter label in the Ontario billing Invoice Reports screen.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed a misspelling in the Ontario billing Invoice Reports status filter: "Submmitted OHIP" is now "Submitted OHIP".
Display-only change; no logic, values, or behavior affected.

<sup>Written for commit 80b044243b6f07d5378c669eb2361a25bc961898. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openo-beta/Open-O/pull/2484?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a typo in the billing status label from “Submmitted” to “Submitted” for clearer, more polished text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->