### PR TITLE
fix: prevent ArrayIndexOutOfBoundsException in provider autocomplete search

### DIFF
--- a/src/main/java/ca/openosp/openo/providers/data/ProviderData.java
+++ b/src/main/java/ca/openosp/openo/providers/data/ProviderData.java
@@ -646,8 +646,10 @@ public class ProviderData {
         String firstname = null;
         String lastname = null;
         if (searchStr.indexOf(",") != -1) {
-            String[] array = new String[2];
-            array = searchStr.split(",");
+            // Use -1 limit so split preserves a trailing empty string: "lastname,".split(",")
+            // returns ["lastname", ""] instead of ["lastname"], avoiding an ArrayIndexOutOfBoundsException
+            // when only the lastname is entered before the comma.
+            String[] array = searchStr.split(",", -1);
             lastname = array[0].trim();
             firstname = array[1].trim();
         } else {


### PR DESCRIPTION
## Problem
Typing a lastname followed by a comma (e.g. `la,`) in the provider autocomplete input throws `ArrayIndexOutOfBoundsException: Index 1 out of bounds for length 1` at `ProviderData.searchProvider()`.

`searchStr.split(",")` drops trailing empty strings, so `"la,"` returns `["la"]`. Accessing `array[1]` for the firstname then fails.

<img width="518" height="271" alt="image" src="https://github.com/user-attachments/assets/4cf8a238-b3ed-4481-9d01-f1c655bab023" />


## Fix
Use `split(",", -1)` so the trailing empty field is preserved (`["la", ""]`). The firstname becomes an empty string and the search runs normally. Also removed a redundant `new String[2]` allocation that was immediately overwritten.

## Summary by Sourcery

Bug Fixes:
- Handle trailing commas in provider search input without causing ArrayIndexOutOfBoundsException.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent ArrayIndexOutOfBoundsException in provider autocomplete when a user types a lastname followed by a comma (e.g., "la,") by preserving the empty firstname during split. Also removes a redundant array allocation.

<sup>Written for commit 337d3ed6fd98dd23959baf2dfadbe6c6d08be9ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openo-beta/Open-O/pull/2485?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved provider search input handling when a comma-separated name includes a trailing empty value.
  * Prevented errors during search and made first-name/last-name trimming work correctly when only a last name is entered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->