### PR TITLE
Fix: show descending sort arrow on Document Manager "Observed" column

### DIFF
--- a/src/main/webapp/documentManager/documentReport.jsp
+++ b/src/main/webapp/documentManager/documentReport.jsp
@@ -316,7 +316,7 @@
                         [-1, 10, 20, 50, 100, 200],
                         ['All', 10, 20, 50, 100, 200]
                     ],
-                    order: [[6, 'dsc']],
+                    order: [[6, 'desc']],
                     "language": {
                         "url": "<%=request.getContextPath() %>/library/DataTables/i18n/<fmt:setBundle basename="oscarResources"/><fmt:message key="global.i18nLanguagecode"/>.json"
                     }


### PR DESCRIPTION
## Summary

The Document Manager table (patient **Document Manager** and the provider **eDoc** tab) is configured to default-sort by the **Observed** (observation date) column, newest-first. The rows *do* render in the correct descending order, but the column header never shows the descending (down) arrow — it displays the neutral "unsorted" up/down glyph instead. This makes it look like the table isn't sorted by Observed date at all.

The cause is a one-character typo in the DataTables initialization: the sort direction was written as `'dsc'` instead of `'desc'`. This change corrects it.

Found due to: [Documents manager defaults to sorted by first column instead of observed date](https://trello.com/c/ICP9McOo/899-documents-manager-defaults-to-sorted-by-first-column-instead-of-observed-date)

> As mentioned, this underlying issue was fixed, but this residual bug was found during the process of investigating this issue, so it was fixed.

## Problem

`src/main/webapp/documentManager/documentReport.jsp` initializes the documents table with:

```js
order: [[6, 'dsc']],   // column 6 = "Observed" (observation date)
```

`'dsc'` is not a valid DataTables direction (the valid values are `'asc'` / `'desc'`). Because of how DataTables 1.13.4 handles the value, the three pieces of "sorted" state diverge:

| Aspect | Result with `'dsc'` | Why |
| --- | --- | --- |
| Row data order | Descending (correct) | The sort comparator only checks `dir === 'asc'`; anything else is treated as descending. |
| `aria-sort` attribute | `"descending"` | `_fnSortAria` uses `dir == 'asc' ? 'ascending' : 'descending'`. |
| Header arrow (CSS class) | Neutral `sorting` (no arrow) | The header renderer matches the direction **exactly**: `dir == 'asc' ? sSortAsc : dir == 'desc' ? sSortDesc : <neutral>`. `'dsc'` matches neither branch, so the column falls back to the neutral glyph instead of `sorting_desc`. |

So users see correctly-ordered rows but no visual indicator that the Observed column is the active (descending) sort.

The typo originates from commit [`d87797cb45`](https://github.com/openo-beta/Open-O/commit/d87797cb455c64e23d9797d7f4a3f9ed7a68de77) ("fix order grouping in document manager ordered by obs date desc"), which introduced the `order` option to fix an earlier "defaults to first column" bug. That commit fixed the data ordering but shipped the `'dsc'` typo, leaving this residual cosmetic bug. It is present on both `develop` and `release/2026-03-17`, and affects both the patient Document Manager (`function=demographic`) and the provider eDoc tab (`function=providers`).

## Solution

Change the DataTables sort direction from the invalid `'dsc'` to the correct `'desc'` in `documentReport.jsp`:

```diff
-                    order: [[6, 'desc']],
+                    order: [[6, 'desc']],
```

(Actual change: `'dsc'` → `'desc'` on the `order:` line.)

This is a one-character, behavior-preserving fix: the data was already sorting descending, and now the header correctly renders the `sorting_desc` (down-arrow) class so the Observed column visibly shows it is the active descending sort.

### **UI Before:**
<img width="1209" height="567" alt="image (3)" src="https://github.com/user-attachments/assets/37e1a41e-e830-4dbb-8443-c05ab1282e9a" />

### **UI After:**
<img width="1209" height="567" alt="image (4)" src="https://github.com/user-attachments/assets/9581fcc2-7d73-4bd7-87ce-feb2bd6087d1" />

## Verification

Verified live in the running app (logged in, demographic 1 + provider eDoc tab):

- **Before** (`'dsc'`): Observed header class = `sorting` (neutral, no arrow); rows ordered descending.
- **After** (`'desc'`): Observed header class = `sorting sorting_desc` (down arrow shown); rows ordered descending — **identical data order**, only the indicator changes.

Confirmed on both tables of the provider eDoc view (private `tblDocs0` and published `tblDocs1`).

## Summary by Sourcery

Bug Fixes:
- Fix the DataTables order configuration typo so the Observed column shows the correct descending sort indicator without changing row order.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the missing descending arrow on the Observed column in the Document Manager and provider eDoc tables by correcting the DataTables sort direction from 'dsc' to 'desc'. Rows were already sorted newest-first; now the header correctly shows the active descending arrow.

<sup>Written for commit 7c4cb064f7a52c458dbdeeee12276959559f870a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openo-beta/Open-O/pull/2486?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the initial sorting of the document report table so it now opens in descending order correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->