### PR TITLE
Feat: add specialist name to the eChart Consultations box

### DIFF
--- a/src/main/java/ca/openosp/openo/consultation/dto/ConsultationListDTO.java
+++ b/src/main/java/ca/openosp/openo/consultation/dto/ConsultationListDTO.java
@@ -24,7 +24,7 @@ public class ConsultationListDTO implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    private static final String NOT_APPLICABLE = "N/A";
+    public static final String NOT_APPLICABLE = "N/A";
 
     private Integer id;
     private String status;

--- a/src/main/java/ca/openosp/openo/encounter/pageUtil/EctDisplayConsult2Action.java
+++ b/src/main/java/ca/openosp/openo/encounter/pageUtil/EctDisplayConsult2Action.java
@@ -139,8 +139,9 @@ public class EctDisplayConsult2Action extends EctDisplayAction {
                 
                 //label as "Service - Specialist", omitting any missing part or the "N/A" placeholder
                 boolean hasService = service != null && !service.trim().isEmpty();
-                boolean hasSpecialist = specialist != null && !specialist.trim().isEmpty()
-                        && !ConsultationListDTO.NOT_APPLICABLE.equals(specialist);
+                String trimmedSpecialist = specialist == null ? "" : specialist.trim();
+                boolean hasSpecialist = !trimmedSpecialist.isEmpty()
+                        && !ConsultationListDTO.NOT_APPLICABLE.equals(trimmedSpecialist);
                 String referralLabel = "";
                 if (hasService && hasSpecialist) {
                     referralLabel = service + " - " + specialist;
@@ -152,7 +153,8 @@ public class EctDisplayConsult2Action extends EctDisplayAction {
 
                 //date alone when no label, to avoid a leading space in the tooltip
                 String linkTitle = referralLabel.isEmpty() ? serviceDateStr : referralLabel + " " + serviceDateStr;
-                //encode both sinks (JSP writes them unescaped); truncate before encoding
+                //encode both sinks (the JSP writes them unescaped). the tooltip stays full length;
+                //only the visible title is capped, before encoding so the cap can't split an entity
                 item.setLinkTitle(Encode.forHtmlAttribute(linkTitle));
                 item.setTitle(Encode.forHtml(StringUtils.maxLenString(referralLabel, MAX_LEN_TITLE, CROP_LEN_TITLE, ELLIPSES)));
                 item.setURL(url);

--- a/src/main/java/ca/openosp/openo/encounter/pageUtil/EctDisplayConsult2Action.java
+++ b/src/main/java/ca/openosp/openo/encounter/pageUtil/EctDisplayConsult2Action.java
@@ -34,6 +34,7 @@ import java.util.Date;
 import javax.servlet.http.HttpServletRequest;
 
 import ca.openosp.openo.encounter.oscarConsultationRequest.pageUtil.EctViewConsultationRequestsUtil;
+import ca.openosp.openo.consultation.dto.ConsultationListDTO;
 import ca.openosp.openo.commn.dao.UserPropertyDAO;
 import ca.openosp.openo.commn.model.UserProperty;
 import ca.openosp.openo.utility.LoggedInInfo;
@@ -135,9 +136,25 @@ public class EctDisplayConsult2Action extends EctDisplayAction {
                 }
                 url = "popupPage(700,960,'" + winName + "','" + request.getContextPath() + "/oscarEncounter/ViewRequest.do?de=" + bean.demographicNo + "&requestId=" + theRequests.ids.get(idx) + "'); return false;";
                 
-                item.setLinkTitle(service + "(" + specialist + ") " + serviceDateStr);
-                service = StringUtils.maxLenString(service, MAX_LEN_TITLE, CROP_LEN_TITLE, ELLIPSES);
-                item.setTitle(service);
+                //build the referral label as "Service - Specialist" so referrals can be identified
+                //without hovering; omit whichever part is missing so we never render a stray
+                //separator or the "N/A" placeholder when no specialist is set
+                boolean hasService = service != null && !service.trim().isEmpty();
+                boolean hasSpecialist = specialist != null && !specialist.trim().isEmpty()
+                        && !ConsultationListDTO.NOT_APPLICABLE.equals(specialist);
+                String referralLabel;
+                if (hasService && hasSpecialist) {
+                    referralLabel = service + " - " + specialist;
+                } else if (hasSpecialist) {
+                    referralLabel = specialist;
+                } else {
+                    referralLabel = hasService ? service : "";
+                }
+
+                //tooltip shows the full untruncated label plus the referral date; the visible row
+                //text uses the same format but is length-capped to fit the navbar (matching siblings)
+                item.setLinkTitle(referralLabel + " " + serviceDateStr);
+                item.setTitle(StringUtils.maxLenString(referralLabel, MAX_LEN_TITLE, CROP_LEN_TITLE, ELLIPSES));
                 item.setURL(url);
                 item.setDate(date);
                 Dao.addItem(item);

--- a/src/main/java/ca/openosp/openo/encounter/pageUtil/EctDisplayConsult2Action.java
+++ b/src/main/java/ca/openosp/openo/encounter/pageUtil/EctDisplayConsult2Action.java
@@ -43,6 +43,7 @@ import org.springframework.web.context.support.WebApplicationContextUtils;
 
 import ca.openosp.openo.util.DateUtils;
 import ca.openosp.openo.util.StringUtils;
+import org.owasp.encoder.Encode;
 
 
 /**
@@ -136,25 +137,24 @@ public class EctDisplayConsult2Action extends EctDisplayAction {
                 }
                 url = "popupPage(700,960,'" + winName + "','" + request.getContextPath() + "/oscarEncounter/ViewRequest.do?de=" + bean.demographicNo + "&requestId=" + theRequests.ids.get(idx) + "'); return false;";
                 
-                //build the referral label as "Service - Specialist" so referrals can be identified
-                //without hovering; omit whichever part is missing so we never render a stray
-                //separator or the "N/A" placeholder when no specialist is set
+                //label as "Service - Specialist", omitting any missing part or the "N/A" placeholder
                 boolean hasService = service != null && !service.trim().isEmpty();
                 boolean hasSpecialist = specialist != null && !specialist.trim().isEmpty()
                         && !ConsultationListDTO.NOT_APPLICABLE.equals(specialist);
-                String referralLabel;
+                String referralLabel = "";
                 if (hasService && hasSpecialist) {
                     referralLabel = service + " - " + specialist;
                 } else if (hasSpecialist) {
                     referralLabel = specialist;
-                } else {
-                    referralLabel = hasService ? service : "";
+                } else if (hasService) {
+                    referralLabel = service;
                 }
 
-                //tooltip shows the full untruncated label plus the referral date; the visible row
-                //text uses the same format but is length-capped to fit the navbar (matching siblings)
-                item.setLinkTitle(referralLabel + " " + serviceDateStr);
-                item.setTitle(StringUtils.maxLenString(referralLabel, MAX_LEN_TITLE, CROP_LEN_TITLE, ELLIPSES));
+                //date alone when no label, to avoid a leading space in the tooltip
+                String linkTitle = referralLabel.isEmpty() ? serviceDateStr : referralLabel + " " + serviceDateStr;
+                //encode both sinks (JSP writes them unescaped); truncate before encoding
+                item.setLinkTitle(Encode.forHtmlAttribute(linkTitle));
+                item.setTitle(Encode.forHtml(StringUtils.maxLenString(referralLabel, MAX_LEN_TITLE, CROP_LEN_TITLE, ELLIPSES)));
                 item.setURL(url);
                 item.setDate(date);
                 Dao.addItem(item);

--- a/src/main/java/ca/openosp/openo/encounter/pageUtil/EctDisplayConsult2Action.java
+++ b/src/main/java/ca/openosp/openo/encounter/pageUtil/EctDisplayConsult2Action.java
@@ -144,9 +144,9 @@ public class EctDisplayConsult2Action extends EctDisplayAction {
                         && !ConsultationListDTO.NOT_APPLICABLE.equals(trimmedSpecialist);
                 String referralLabel = "";
                 if (hasService && hasSpecialist) {
-                    referralLabel = service + " - " + specialist;
+                    referralLabel = service + " - " + trimmedSpecialist;
                 } else if (hasSpecialist) {
-                    referralLabel = specialist;
+                    referralLabel = trimmedSpecialist;
                 } else if (hasService) {
                     referralLabel = service;
                 }


### PR DESCRIPTION
## Summary

Adds the referred-to specialist's name into each row of the **Consultations** box in the eChart
left navbar, so referrals can be identified at a glance without opening them. Rows now read
`Service - Specialist` before the date (e.g. `OBGYN - Smith, John  ...  2023-09-15`), and the hover
tooltip is aligned to the same format.

Closes: [Add the specialist name into the consultation box in the chart](https://trello.com/c/XcANINbs/902-add-the-specialist-name-into-the-consdultation-box-in-the-chart)

## Problem

In the eChart Consultations box, each referral row showed only the service type and the referral
date — with no indication of *who* the referral was to:

```
OBGYN  ......  2023-09-15
```

This made it slow to identify the right referral when processing appointment notifications or
locating a referral referenced in a tickler, and contributed to duplicate-referral errors (a new
referral created when one already existed).

## Solution

Surface the specialist inline as `Service - Specialist`, immediately before the existing date. The
specialist name was already loaded by the same query that builds the list (and already shown in the
row's hover tooltip), so this surfaces existing data rather than adding any new query.

Changes:
- **`EctDisplayConsult2Action.java`** — builds the row label as `Service - Specialist`, omitting
  whichever part is missing so there is never a stray separator or an `"N/A"` placeholder
  (both → `Service - Specialist`; specialist only → `Specialist`; service only → `Service`). The
  visible title and the hover tooltip now use the same format; the tooltip also appends the date,
  replacing the legacy `Service(Specialist) Date` parenthesis format (which removes the old
  `Service(N/A) Date` artifact on no-specialist rows).
- **`ConsultationListDTO.java`** — `NOT_APPLICABLE` (`"N/A"`) promoted to `public` so the
  no-specialist sentinel has a single source of truth that the action references.
- Output encoding — both HTML sinks are encoded in the action: Encode.forHtml(...) for the visible title (anchor body) and Encode.forHtmlAttribute(...) for the tooltip (title= attribute), since specialist names are user-entered. Encoding is done at the source, not in the shared LeftNavBarDisplay.jsp, because that JSP renders the title as raw HTML for boxes that intentionally embed markup (e.g. EctDisplayPregnancy2Action's red <span>), so a blanket sink-level encode would break them. The visible title is length-capped before encoding so the cap can't split an HTML entity; the tooltip is left full-length by design.

Behavior (visible row / hover tooltip):

| Case | Visible | Hover |
|------|---------|-------|
| Normal referral | `OBGYN - Smith, John` | `OBGYN - Smith, John 2023-09-15` |
| No specialist | `OBGYN` | `OBGYN 2023-09-15` |
| eReferral | `Cardiology - Dr. Jones` | `Cardiology - Dr. Jones 2023-09-15` |
| Empty service + specialist | `Smith, John` | `Smith, John 2023-09-15` |

### **UI Before:**
<img width="376" height="113" alt="image" src="https://github.com/user-attachments/assets/a3eb5460-56dd-4fec-bd94-61fa15ea9dc2" />

<img width="381" height="115" alt="image" src="https://github.com/user-attachments/assets/e5b7e59b-801c-4fd8-b5ba-2816e7fe3c09" />

### **UI After**
<img width="380" height="117" alt="image" src="https://github.com/user-attachments/assets/c7ea6eb6-5c88-41ac-bb3e-18ce48c09348" />

<img width="379" height="116" alt="image" src="https://github.com/user-attachments/assets/75660bde-7206-4b42-8347-662fc8a11f18" />

## Summary by Sourcery

Show referral service and specialist inline in eChart Consultations rows and tooltips to make referrals identifiable at a glance.

New Features:
- Display combined "Service - Specialist" referral labels in the eChart Consultations box, falling back cleanly when either value is missing.

Bug Fixes:
- Remove "N/A" specialist placeholders from consultation labels and tooltips to avoid confusing artifacts.
- Ensure consultation tooltip formatting does not include stray spaces when no label is available.

Enhancements:
- HTML-encode consultation titles and tooltips and centralize the "N/A" sentinel for specialists via a shared constant to improve safety and consistency.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the specialist’s name in each row of the eChart Consultations box so referrals are identifiable at a glance. Rows now read “Service - Specialist” before the date, and the hover tooltip matches this format.

- **New Features**
  - Display “Service - Specialist” per row; omit missing parts to avoid stray separators or “N/A”.
  - Tooltip shows the full label plus the date; visible label is truncated to fit the navbar.
  - Reuse existing data (no new queries). Exposed `NOT_APPLICABLE` as public for consistent checks.

- **Bug Fixes**
  - Use only the date in the tooltip when the label is empty to avoid stray spaces.
  - HTML-encode the visible title and tooltip to prevent injection; truncate before encoding.
  - Trim specialist text and use the trimmed value consistently for comparisons and display (including against `NOT_APPLICABLE`) to avoid edge-case formatting issues.

<sup>Written for commit e5c915b939937103e3528348a208ba270c66f786. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openo-beta/Open-O/pull/2487?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved referral label formatting so when specialist details are missing or marked “N/A”, they no longer appear as awkward placeholders.
  * Updated displayed referral titles and hover/tooltip text to reflect the complete, correctly composed label for clearer consistency.
  * Standardized “N/A” handling across consultation display logic to ensure consistent presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->