### PR TITLE
Fix Error 500 on Manage Billing Form and clarify the service-code grid

### DIFF
--- a/src/main/webapp/billing/CA/ON/dbManageBillingform_service.jsp
+++ b/src/main/webapp/billing/CA/ON/dbManageBillingform_service.jsp
@@ -47,12 +47,15 @@
             serviceCode = (serviceCode == null) ? "" : serviceCode.trim();
 
             if (!serviceCode.isEmpty()) {
-                // Any invalid order (blank, non-numeric, or out of int range) falls back to the row position so it can't crash the page.
+                // Any invalid order (blank, non-numeric, negative, or out of int range) falls back to the row position so it can't crash the page.
                 String orderParam = request.getParameter(field + "_order");
                 orderParam = (orderParam == null) ? "" : orderParam.trim();
                 int serviceOrder;
                 try {
                     serviceOrder = Integer.parseInt(orderParam);
+                    if (serviceOrder < 0) {
+                        serviceOrder = i;
+                    }
                 } catch (NumberFormatException e) {
                     serviceOrder = i;
                 }

--- a/src/main/webapp/billing/CA/ON/dbManageBillingform_service.jsp
+++ b/src/main/webapp/billing/CA/ON/dbManageBillingform_service.jsp
@@ -42,15 +42,24 @@
         group[j] = request.getParameter("group" + j);
 
         for (int i = 0; i < 20; i++) {
-            if (request.getParameter("group" + j + "_service" + i).length() != 0) {
+            String field = "group" + j + "_service" + i;
+            String serviceCode = request.getParameter(field);
+            serviceCode = (serviceCode == null) ? "" : serviceCode.trim();
+
+            if (!serviceCode.isEmpty()) {
+                // Blank or non-numeric order falls back to the row position so it can't crash the page.
+                String orderParam = request.getParameter(field + "_order");
+                orderParam = (orderParam == null) ? "" : orderParam.trim();
+                int serviceOrder = orderParam.matches("\\d+") ? Integer.parseInt(orderParam) : i;
+
                 CtlBillingService cbs = new CtlBillingService();
                 cbs.setServiceTypeName(type);
                 cbs.setServiceType(typeid);
-                cbs.setServiceCode(request.getParameter("group" + j + "_service" + i));
+                cbs.setServiceCode(serviceCode);
                 cbs.setServiceGroupName(group[j]);
                 cbs.setServiceGroup("Group" + j);
                 cbs.setStatus("A");
-                cbs.setServiceOrder(Integer.parseInt(request.getParameter("group" + j + "_service" + i + "_order")));
+                cbs.setServiceOrder(serviceOrder);
                 ctlBillingServiceDao.persist(cbs);
             }
         }

--- a/src/main/webapp/billing/CA/ON/dbManageBillingform_service.jsp
+++ b/src/main/webapp/billing/CA/ON/dbManageBillingform_service.jsp
@@ -47,10 +47,15 @@
             serviceCode = (serviceCode == null) ? "" : serviceCode.trim();
 
             if (!serviceCode.isEmpty()) {
-                // Blank or non-numeric order falls back to the row position so it can't crash the page.
+                // Any invalid order (blank, non-numeric, or out of int range) falls back to the row position so it can't crash the page.
                 String orderParam = request.getParameter(field + "_order");
                 orderParam = (orderParam == null) ? "" : orderParam.trim();
-                int serviceOrder = orderParam.matches("\\d+") ? Integer.parseInt(orderParam) : i;
+                int serviceOrder;
+                try {
+                    serviceOrder = Integer.parseInt(orderParam);
+                } catch (NumberFormatException e) {
+                    serviceOrder = i;
+                }
 
                 CtlBillingService cbs = new CtlBillingService();
                 cbs.setServiceTypeName(type);

--- a/src/main/webapp/billing/CA/ON/manageBillingform_service.jspf
+++ b/src/main/webapp/billing/CA/ON/manageBillingform_service.jspf
@@ -88,7 +88,7 @@ int rCount = 0;
 			</tr>
 			<tr>
 				<td colspan="2"><input type="text" name="group<%=i%>"
-					value="<%=Encode.forHtmlAttribute(String.valueOf(servicetype_name))%>"
+					value="<%= servicetype_name == null ? "" : Encode.forHtmlAttribute(servicetype_name) %>"
 					placeholder="Group name"
 					style="width: 213px;"></td>
 			</tr>

--- a/src/main/webapp/billing/CA/ON/manageBillingform_service.jspf
+++ b/src/main/webapp/billing/CA/ON/manageBillingform_service.jspf
@@ -99,14 +99,14 @@ int rCount = 0;
 			<% for(int k=0; k<20;k++){ %>
 			<tr>
 				<td><input type="text" name="group<%=i%>_service<%=k%>"
-					value="<%=Encode.forHtmlAttribute(String.valueOf(service_code[k]))%>"
+					value="<%= service_code[k] == null ? "" : Encode.forHtmlAttribute(service_code[k]) %>"
 					placeholder="Billing code"
 					oninput="toggleOrderRequired(this);"
 					style="width: 120px;"></td>
 				<td style="padding-left: 4px;"><input type="number" min="0" name="group<%=i%>_service<%=k%>_order"
 					value="<%=Encode.forHtmlAttribute(String.valueOf(service_order[k]))%>"
 					placeholder="Order"
-					<%= service_code[k].isEmpty() ? "" : "required" %>
+					<%= (service_code[k] == null || service_code[k].isEmpty()) ? "" : "required" %>
 					style="width: 75px;"></td>
 			</tr>
 			<% } %>

--- a/src/main/webapp/billing/CA/ON/manageBillingform_service.jspf
+++ b/src/main/webapp/billing/CA/ON/manageBillingform_service.jspf
@@ -30,9 +30,20 @@
 <%@ page import="org.owasp.encoder.Encode" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 
+<script type="text/javascript">
+	// A billing code makes its order box required; clearing it removes the requirement.
+	function toggleOrderRequired(codeInput) {
+		const row = codeInput.closest('tr');
+		const orderInput = row ? row.querySelector('input[type="number"]') : null;
+		if (orderInput) {
+			orderInput.required = codeInput.value.trim().length > 0;
+		}
+	}
+</script>
+
 <form method="post" name="form1"
 	action="dbManageBillingform_service.jsp">
-<table width="75%" border="0" cellpadding="3" bgcolor="#9999CC">
+<table border="0" cellpadding="3" cellspacing="0" bgcolor="#9999CC">
 	<tr>
 
 
@@ -70,21 +81,33 @@ int rCount = 0;
    }
   }          
   %>
-		<td>
-		<table width="100%" border="0">
+		<td style="vertical-align: top; padding: 0 10px;">
+		<table border="0" cellpadding="0" cellspacing="0">
 			<tr>
-				<td><input type="text" name="group<%=i%>"
-					value="<%=Encode.forHtmlAttribute(String.valueOf(servicetype_name))%>" size="20"
-					style="font-size: 8pt; text-align: right; vertical-align: bottom"></td>
+				<td colspan="2" style="font-weight: bold;">Group name</td>
+			</tr>
+			<tr>
+				<td colspan="2"><input type="text" name="group<%=i%>"
+					value="<%=Encode.forHtmlAttribute(String.valueOf(servicetype_name))%>"
+					placeholder="Group name"
+					style="width: 213px;"></td>
+			</tr>
+			<tr>
+				<td style="font-weight: bold;">Billing code</td>
+				<td style="font-weight: bold; padding-left: 4px;">Order</td>
 			</tr>
 			<% for(int k=0; k<20;k++){ %>
 			<tr>
 				<td><input type="text" name="group<%=i%>_service<%=k%>"
-					value="<%=Encode.forHtmlAttribute(String.valueOf(service_code[k]))%>" size="10"
-					style="font-size: 8pt; text-align: right; vertical-align: bottom"><input
-					type="text" name="group<%=i%>_service<%=k%>_order"
-					value="<%=Encode.forHtmlAttribute(String.valueOf(service_order[k]))%>" size="5"
-					style="font-size: 8pt; text-align: right; vertical-align: bottom"></td>
+					value="<%=Encode.forHtmlAttribute(String.valueOf(service_code[k]))%>"
+					placeholder="Billing code"
+					oninput="toggleOrderRequired(this);"
+					style="width: 120px;"></td>
+				<td style="padding-left: 4px;"><input type="number" min="0" name="group<%=i%>_service<%=k%>_order"
+					value="<%=Encode.forHtmlAttribute(String.valueOf(service_order[k]))%>"
+					placeholder="Order"
+					<%= service_code[k].isEmpty() ? "" : "required" %>
+					style="width: 75px;"></td>
 			</tr>
 			<% } %>
 		</table>


### PR DESCRIPTION
## Problem
In **Administration → Billing → Manage Billing Form** (Service Code), entering a billing code but leaving the **Order** box empty and clicking **Update** returned an **Error 500**. The page also gave no hint the second box was required - just a wall of unlabeled boxes, so this was easy to hit.

Root cause: the save code ran `Integer.parseInt("")` on the empty Order value, which throws `NumberFormatException`.

<img width="1174" height="875" alt="before" src="https://github.com/user-attachments/assets/8548609d-b6ba-44b3-a2bd-765e9db64d6a" />

<img width="1978" height="487" alt="image" src="https://github.com/user-attachments/assets/256a0067-dba9-4134-a071-8adf2c3f972f" />


## Solution
- **Clearer form:** Billing code and Order are now labeled, side-by-side columns, and each group has a **Group name** label.

<img width="788" height="779" alt="after" src="https://github.com/user-attachments/assets/e81a94ee-e45f-4f48-9cf6-c57a2710b6ac" />


- **No more crash:** a blank or non-numeric Order now falls back to the row position instead of throwing; parameter reads are null-safe.

<img width="770" height="263" alt="after with require" src="https://github.com/user-attachments/assets/adfbbceb-bb6a-4ce8-8c1d-5fdf6dfd0a38" />

- **Guided input:** the Order box is `type="number"` and becomes **required** the moment a code is typed, so the browser blocks the bad submit up front instead of failing on the server.

Closes https://trello.com/c/8hPqu3LY

## Summary by Sourcery

Prevent crashes when saving billing service codes with missing or invalid order values and improve the usability of the Manage Billing Form service-code grid.

Bug Fixes:
- Handle blank or non-numeric service order values without throwing errors when persisting billing services.

Enhancements:
- Normalize and validate service code and order request parameters before persistence to make the Manage Billing Form more robust.
- Clarify the Manage Billing Form service-code grid layout and input behavior so required fields are more obvious to users.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the 500 error on Administration → Billing → Manage Billing Form when Order is blank, negative, or out of range. Clarified the service-code grid and made inputs safer to block bad submits.

- **Bug Fixes**
  - Null-safe, trimmed reads; guard Order parse against blank, non-numeric, negative, and overflow; fallback to row index instead of throwing.
  - Labeled “Group name”, “Billing code”, and “Order”; two-column layout; number-only Order (min 0) becomes required when a code is entered; render empty Group name/Billing code when null with a null-safe required check.

<sup>Written for commit 5e1856e130d63458f5c624dfc4370ea60f6bef8e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openo-beta/Open-O/pull/2488?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved billing form behavior so the “Order” field is only required when a billing code is entered.
  * Prevented errors when saving billing services by handling blank or invalid order values more safely.
  * Updated the billing section layout for a clearer two-column display of billing code and order fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->