### PR TITLE
fix: eForm Print now always saves to the eChart

### DIFF
--- a/src/main/webapp/eform/eformFloatingToolbar/eform_floating_toolbar.js
+++ b/src/main/webapp/eform/eformFloatingToolbar/eform_floating_toolbar.js
@@ -436,12 +436,12 @@ function remotePrint() {
 		}
 
 		/*
-		 * for situations when the eForm does not contain dirty form
-		 * detection; save it everytime.
+		 * either the eForm has no dirty form detection, or dirty form
+		 * detection did not flag a change; confirm before saving.
 		 */
-		else if(typeof needToConfirm === 'undefined') {
+		else if(confirm("You haven't manually edited this document, would you like to save a copy to the patient's chart regardless?")) {
 			remoteSave();
-	}
+		}
 }
 
 function hailMary() {


### PR DESCRIPTION
## Issue
  The floating eForm toolbar's Print button prints but does not always save to the eChart. When a form is filled using the mouse only (e.g. clicking checkboxes on the HPV Test requisition), Print produces the printout but the eForm is missing from the patient's eForms list. Typing a single character before printing makes it save. 

<img width="248" height="137" alt="image" src="https://github.com/user-attachments/assets/6110cfed-9853-4ce4-9e16-9b3be0f9ae2e" />

  ## Cause
  `remotePrint()` in `eform_floating_toolbar.js` guarded its save behind `needToConfirm`. Each eForm sets `needToConfirm` to `true` only on a keyboard `keyup` event, so mouse-only input left it `false` - and with the flag defined but false, neither save branch ran.
  
From `eform_floating_toolbar.js`:
<img width="452" height="497" alt="image" src="https://github.com/user-attachments/assets/6f6a7da6-b111-409d-b69c-18980efc0032" />

From `HPV Test` eform:
<img width="451" height="158" alt="image" src="https://github.com/user-attachments/assets/f801b963-c8f4-4d95-8826-65d8c57db5b0" />


## Fix
  `remotePrint()` no longer saves unconditionally. It branches on `needToConfirm`:

  - **`true`** (form was manually edited): save and print, no prompt - unchanged behaviour.
  - **`undefined`** \ **`false`** (dirty-form detection present but no edit registered, e.g. mouse-only input): prompt before saving a copy to the chart:
    > You haven't manually edited this document, would you like to save a copy to the patient's chart regardless?
    - **OK** -> save and print
    - **Cancel** -> just print

## Summary by Sourcery

Bug Fixes:
- Always save the eForm to the eChart when printing, regardless of input method or dirty-form detection state.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Printing an eForm now auto-saves to the patient’s eChart and prompts to save when no manual edits are detected. This fixes missed saves for mouse-only input while preventing silent data loss.

- **Bug Fixes**
  - `remotePrint()` saves when `needToConfirm` is `undefined`; otherwise shows a confirm dialog and saves on OK.
  - Covers mouse-only forms (e.g., HPV Test) that previously failed to save.

<sup>Written for commit ca884f2a0ba16e159ca63cf06d24bfb7da6467d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openo-beta/Open-O/pull/2489?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * After printing an eForm, the app now saves changes consistently based on an updated confirmation flow.
  * If confirmation is not explicitly required, users are prompted and saving happens only after they accept.
  * Removed the previous behavior that could auto-save when confirmation state was unset, helping prevent missed or unintended saves after print actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->