### PR TITLE
Update tickler with new attachment component

### DIFF
--- a/database/mysql/updates/update-2026-06-12-tickler-docs.sql
+++ b/database/mysql/updates/update-2026-06-12-tickler-docs.sql
@@ -1,0 +1,40 @@
+-- Issue #2476: Migrate Tickler to the Consult/EForm document attachment component.
+--
+-- Introduces the `ticklerdocs` table (mirrors `consultdocs`/`EFormDocs`) which replaces
+-- the legacy `tickler_link` table as the Tickler attachment store. Existing `tickler_link`
+-- rows are copied into `ticklerdocs` so historical attachments remain visible.
+--
+-- Legacy `tickler_link.table_name` (char(3)) -> new `ticklerdocs.doctype` (char(1)) mapping:
+--   DOC                 -> D (document)
+--   HRM                 -> H (hospital report)
+--   HL7, MDS, CML, BCP  -> L (lab)  (and any other lab source code)
+--
+-- The `tickler_link` table itself is intentionally left in place (REST/Integrator code
+-- still references it); it is simply no longer used by the Tickler UI.
+
+CREATE TABLE IF NOT EXISTS `ticklerdocs` (
+  `id` int(10) NOT NULL auto_increment PRIMARY KEY,
+  `tickler_id` int(10) NOT NULL,
+  `document_no` int(10) NOT NULL,
+  `doctype` char(1) NOT NULL,
+  `deleted` char(1) DEFAULT NULL,
+  `attach_date` date,
+  `provider_no` varchar(6) NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS `idx_ticklerdocs_tickler_id` ON `ticklerdocs` (`tickler_id`);
+
+-- Backfill existing attachments from tickler_link.
+INSERT INTO `ticklerdocs` (`tickler_id`, `document_no`, `doctype`, `deleted`, `attach_date`, `provider_no`)
+SELECT
+  tl.`tickler_no`,
+  tl.`table_id`,
+  CASE
+    WHEN tl.`table_name` = 'DOC' THEN 'D'
+    WHEN tl.`table_name` = 'HRM' THEN 'H'
+    ELSE 'L'
+  END,
+  NULL,
+  CURDATE(),
+  ''
+FROM `tickler_link` tl;

--- a/src/main/java/ca/openosp/openo/commn/dao/TicklerDocsDao.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/TicklerDocsDao.java
@@ -1,0 +1,23 @@
+//CHECKSTYLE:OFF
+
+package ca.openosp.openo.commn.dao;
+
+import java.util.List;
+
+import ca.openosp.openo.commn.model.TicklerDocs;
+
+/**
+ * Data access for {@link TicklerDocs} (Tickler document attachments).
+ *
+ * <p>Tickler counterpart of {@code ConsultDocsDao}/{@code EFormDocsDao}. All finders exclude
+ * soft-deleted rows ({@code deleted is NULL}).</p>
+ *
+ * @since 2026-06-12
+ */
+public interface TicklerDocsDao extends AbstractDao<TicklerDocs> {
+    List<TicklerDocs> findByTicklerIdDocNoDocType(Integer ticklerId, Integer documentNo, String docType);
+
+    List<TicklerDocs> findByTicklerIdDocType(Integer ticklerId, String docType);
+
+    List<TicklerDocs> findByTicklerId(Integer ticklerId);
+}

--- a/src/main/java/ca/openosp/openo/commn/dao/TicklerDocsDaoImpl.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/TicklerDocsDaoImpl.java
@@ -1,0 +1,59 @@
+//CHECKSTYLE:OFF
+
+package ca.openosp.openo.commn.dao;
+
+import java.util.Collections;
+import java.util.List;
+
+import javax.persistence.Query;
+
+import ca.openosp.openo.commn.model.TicklerDocs;
+import org.springframework.stereotype.Repository;
+
+/**
+ * Default {@link TicklerDocsDao} implementation. Mirrors {@code ConsultDocsDaoImpl}; every query
+ * filters out soft-deleted rows with {@code x.deleted is NULL}.
+ *
+ * @since 2026-06-12
+ */
+@Repository
+@SuppressWarnings("unchecked")
+public class TicklerDocsDaoImpl extends AbstractDaoImpl<TicklerDocs> implements TicklerDocsDao {
+
+    public TicklerDocsDaoImpl() {
+        super(TicklerDocs.class);
+    }
+
+    public List<TicklerDocs> findByTicklerIdDocNoDocType(Integer ticklerId, Integer documentNo, String docType) {
+        String sql = "select x from TicklerDocs x where x.ticklerId=?1 and x.documentNo=?2 and x.docType=?3 and x.deleted is NULL";
+        Query query = entityManager.createQuery(sql);
+        query.setParameter(1, ticklerId);
+        query.setParameter(2, documentNo);
+        query.setParameter(3, docType);
+
+        List<TicklerDocs> results = query.getResultList();
+        return results;
+    }
+
+    public List<TicklerDocs> findByTicklerIdDocType(Integer ticklerId, String docType) {
+        String sql = "select x from TicklerDocs x where x.ticklerId=?1 and x.docType=?2 and x.deleted is NULL";
+        Query query = entityManager.createQuery(sql);
+        query.setParameter(1, ticklerId);
+        query.setParameter(2, docType);
+
+        List<TicklerDocs> results = query.getResultList();
+        if (results == null) {
+            return Collections.emptyList();
+        }
+        return results;
+    }
+
+    public List<TicklerDocs> findByTicklerId(Integer ticklerId) {
+        String sql = "select x from TicklerDocs x where x.ticklerId=?1 and x.deleted is NULL";
+        Query query = entityManager.createQuery(sql);
+        query.setParameter(1, ticklerId);
+
+        List<TicklerDocs> results = query.getResultList();
+        return results;
+    }
+}

--- a/src/main/java/ca/openosp/openo/commn/model/TicklerDocs.java
+++ b/src/main/java/ca/openosp/openo/commn/model/TicklerDocs.java
@@ -1,0 +1,149 @@
+//CHECKSTYLE:OFF
+/**
+ * Copyright (c) 2001-2002. Department of Family Medicine, McMaster University. All Rights Reserved.
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ * <p>
+ * This software was written for the
+ * Department of Family Medicine
+ * McMaster University
+ * Hamilton
+ * Ontario, Canada
+ */
+
+
+package ca.openosp.openo.commn.model;
+
+import java.util.Date;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+
+/**
+ * Links a document (document, lab, eForm, HRM report or encounter form) to a Tickler.
+ *
+ * <p>This is the Tickler counterpart of {@link ConsultDocs} and {@code EFormDocs}; it backs the
+ * shared document attachment component (see {@code documentManager/attachDocument.jsp}). Detached
+ * attachments are soft-deleted by setting {@link #deleted} to {@link #DELETED} rather than being
+ * physically removed.</p>
+ *
+ * @since 2026-06-12
+ */
+@Entity
+@Table(name = "ticklerdocs")
+public class TicklerDocs extends AbstractModel<Integer> {
+    public static final String DOCTYPE_DOC = "D";
+    public static final String DOCTYPE_EFORM = "E";
+    public static final String DOCTYPE_LAB = "L";
+
+    public static final String DOCTYPE_FORM = "F";
+    public static final String DOCTYPE_HRM = "H";
+    public static final String DELETED = "Y";
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @Column(name = "tickler_id")
+    private int ticklerId;
+
+    @Column(name = "document_no")
+    private int documentNo;
+
+    @Column(name = "doctype")
+    private String docType;
+
+    private String deleted;
+
+    @Column(name = "attach_date")
+    @Temporal(TemporalType.DATE)
+    private Date attachDate;
+
+    @Column(name = "provider_no")
+    private String providerNo;
+
+    public TicklerDocs() {
+    }
+
+    public TicklerDocs(int ticklerId, int documentNo, String docType, String providerNo) {
+        setTicklerId(ticklerId);
+        setDocumentNo(documentNo);
+        setDocType(docType);
+        setProviderNo(providerNo);
+        setAttachDate(new Date());
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public int getTicklerId() {
+        return ticklerId;
+    }
+
+    public void setTicklerId(int ticklerId) {
+        this.ticklerId = ticklerId;
+    }
+
+    public int getDocumentNo() {
+        return documentNo;
+    }
+
+    public void setDocumentNo(int documentNo) {
+        this.documentNo = documentNo;
+    }
+
+    public String getDocType() {
+        return docType;
+    }
+
+    public void setDocType(String docType) {
+        this.docType = docType;
+    }
+
+    public String getDeleted() {
+        return deleted;
+    }
+
+    public void setDeleted(String deleted) {
+        this.deleted = deleted;
+    }
+
+    public Date getAttachDate() {
+        return attachDate;
+    }
+
+    public void setAttachDate(Date attachDate) {
+        this.attachDate = attachDate;
+    }
+
+    public String getProviderNo() {
+        return providerNo;
+    }
+
+    public void setProviderNo(String providerNo) {
+        this.providerNo = providerNo;
+    }
+}

--- a/src/main/java/ca/openosp/openo/documentManager/DocumentAttach.java
+++ b/src/main/java/ca/openosp/openo/documentManager/DocumentAttach.java
@@ -3,8 +3,10 @@ package ca.openosp.openo.documentManager;
 
 import ca.openosp.openo.commn.dao.ConsultDocsDao;
 import ca.openosp.openo.commn.dao.EFormDocsDao;
+import ca.openosp.openo.commn.dao.TicklerDocsDao;
 import ca.openosp.openo.commn.model.ConsultDocs;
 import ca.openosp.openo.commn.model.EFormDocs;
+import ca.openosp.openo.commn.model.TicklerDocs;
 import ca.openosp.openo.commn.model.enumerator.DocumentType;
 import ca.openosp.openo.utility.SpringUtils;
 
@@ -17,6 +19,7 @@ import java.util.List;
 public class DocumentAttach {
     private final ConsultDocsDao consultDocsDao = SpringUtils.getBean(ConsultDocsDao.class);
     private final EFormDocsDao eFormDocsDao = SpringUtils.getBean(EFormDocsDao.class);
+    private final TicklerDocsDao ticklerDocsDao = SpringUtils.getBean(TicklerDocsDao.class);
 
     /*
      * When editOnOcean is set to false, it signifies a normal consult request, performing just attach or detach operations on the consult request form.
@@ -110,6 +113,40 @@ public class DocumentAttach {
             for (EFormDocs eFormDoc : detachList) {
                 eFormDoc.setDeleted("Y");
                 eFormDocsDao.merge(eFormDoc);
+            }
+        }
+    }
+
+    public void attachToTickler(String[] attachments, DocumentType documentType, String providerNo, Integer ticklerId) {
+        List<String> currentList = new ArrayList<>(Arrays.asList(attachments));
+        List<TicklerDocs> ticklerDocsList = ticklerDocsDao.findByTicklerIdDocType(ticklerId, documentType.getType());
+        List<String> oldList = new ArrayList<>();
+        for (TicklerDocs ticklerDoc : ticklerDocsList) {
+            oldList.add(Integer.toString(ticklerDoc.getDocumentNo()));
+        }
+        detachFromTickler(currentList, oldList, documentType, ticklerId);
+        attachToTickler(currentList, oldList, documentType, providerNo, ticklerId);
+    }
+
+    private void attachToTickler(List<String> currentList, List<String> oldList, DocumentType documentType, String providerNo, Integer ticklerId) {
+        for (String docId : currentList) {
+            if (oldList.contains(docId)) {
+                continue;
+            }
+            TicklerDocs ticklerDocs = new TicklerDocs(ticklerId, Integer.parseInt(docId), documentType.getType(), providerNo);
+            ticklerDocsDao.persist(ticklerDocs);
+        }
+    }
+
+    private void detachFromTickler(List<String> currentList, List<String> oldList, DocumentType documentType, Integer ticklerId) {
+        for (String docId : oldList) {
+            if (currentList.contains(docId)) {
+                continue;
+            }
+            List<TicklerDocs> detachList = ticklerDocsDao.findByTicklerIdDocNoDocType(ticklerId, Integer.valueOf(docId), documentType.getType());
+            for (TicklerDocs ticklerDoc : detachList) {
+                ticklerDoc.setDeleted("Y");
+                ticklerDocsDao.merge(ticklerDoc);
             }
         }
     }

--- a/src/main/java/ca/openosp/openo/documentManager/DocumentAttachmentManager.java
+++ b/src/main/java/ca/openosp/openo/documentManager/DocumentAttachmentManager.java
@@ -164,6 +164,37 @@ public interface DocumentAttachmentManager {
     public void attachToEForm(LoggedInInfo loggedInInfo, DocumentType documentType, String[] attachments, String providerNo, Integer fdid, Integer demographicNo);
 
     /**
+     * Retrieves all attachments of a given type associated with a specific tickler.
+     *
+     * <p>Tickler counterpart of {@link #getConsultAttachments} and {@link #getEFormAttachments}.
+     * Returns the document identifiers currently attached to the tickler for the requested
+     * document type (document, lab, eForm, HRM report or encounter form).</p>
+     *
+     * @param loggedInInfo LoggedInInfo the current user's session information for security and audit purposes
+     * @param ticklerId Integer the unique identifier of the tickler
+     * @param documentType DocumentType the type of documents to retrieve
+     * @param demographicNo Integer the patient's unique demographic identifier
+     * @return List&lt;String&gt; list of document identifiers attached to the tickler
+     */
+    public List<String> getTicklerAttachments(LoggedInInfo loggedInInfo, Integer ticklerId, DocumentType documentType, Integer demographicNo);
+
+    /**
+     * Attaches documents to a tickler.
+     *
+     * <p>Tickler counterpart of {@link #attachToConsult} and {@link #attachToEForm}. Synchronises the
+     * supplied set of document identifiers with the tickler's existing attachments of the given type:
+     * new identifiers are persisted and identifiers no longer present are soft-deleted.</p>
+     *
+     * @param loggedInInfo LoggedInInfo the current user's session information for security and audit purposes
+     * @param documentType DocumentType the type of documents being attached
+     * @param attachments String[] array of document identifiers that should be attached to the tickler
+     * @param providerNo String the provider number performing the attachment operation
+     * @param ticklerId Integer the unique identifier of the tickler
+     * @param demographicNo Integer the patient's unique demographic identifier
+     */
+    public void attachToTickler(LoggedInInfo loggedInInfo, DocumentType documentType, String[] attachments, String providerNo, Integer ticklerId, Integer demographicNo);
+
+    /**
      * Concatenates multiple PDF documents into a single PDF file.
      *
      * <p>This method combines a list of PDF document objects into a single consolidated PDF file.

--- a/src/main/java/ca/openosp/openo/documentManager/DocumentAttachmentManagerImpl.java
+++ b/src/main/java/ca/openosp/openo/documentManager/DocumentAttachmentManagerImpl.java
@@ -6,6 +6,8 @@ import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.interactive.form.PDAcroForm;
 import ca.openosp.openo.commn.dao.ConsultDocsDao;
 import ca.openosp.openo.commn.dao.EFormDocsDao;
+import ca.openosp.openo.commn.dao.TicklerDocsDao;
+import ca.openosp.openo.commn.model.TicklerDocs;
 import ca.openosp.openo.commn.model.ConsultDocs;
 import ca.openosp.openo.commn.model.EFormData;
 import ca.openosp.openo.commn.model.EFormDocs;
@@ -69,6 +71,8 @@ public class DocumentAttachmentManagerImpl implements DocumentAttachmentManager 
     private ConsultDocsDao consultDocsDao;
     @Autowired
     private EFormDocsDao eFormDocsDao;
+    @Autowired
+    private TicklerDocsDao ticklerDocsDao;
 
     @Autowired
     private ConsultationManager consultationManager;
@@ -363,6 +367,56 @@ public class DocumentAttachmentManagerImpl implements DocumentAttachmentManager 
 
         DocumentAttach documentAttach = new DocumentAttach();
         documentAttach.attachToEForm(attachments, documentType, providerNo, fdid);
+    }
+
+    /**
+     * Retrieves a list of document IDs attached to a specific tickler.
+     *
+     * Tickler counterpart of {@link #getConsultAttachments} and {@link #getEFormAttachments}. Security
+     * checks ensure the user has read access to tickler data for the specified patient.
+     *
+     * @param loggedInInfo LoggedInInfo the current user's session information
+     * @param ticklerId Integer the unique identifier of the tickler
+     * @param documentType DocumentType the type of documents to retrieve (e.g., DOC, LAB, EFORM, HRM, FORM)
+     * @param demographicNo Integer the patient's demographic number for security validation
+     * @return List&lt;String&gt; a list of document IDs as strings attached to the tickler
+     * @throws RuntimeException if the user lacks the required "_tickler" read privilege
+     */
+    public List<String> getTicklerAttachments(LoggedInInfo loggedInInfo, Integer ticklerId, DocumentType documentType, Integer demographicNo) {
+        if (!securityInfoManager.hasPrivilege(loggedInInfo, "_tickler", SecurityInfoManager.READ, demographicNo)) {
+            throw new RuntimeException("missing required sec object (_tickler)");
+        }
+
+        List<String> ticklerAttachments = new ArrayList<>();
+        List<TicklerDocs> ticklerDocs = ticklerDocsDao.findByTicklerIdDocType(ticklerId, documentType.getType());
+        for (TicklerDocs ticklerDocs1 : ticklerDocs) {
+            ticklerAttachments.add(String.valueOf(ticklerDocs1.getDocumentNo()));
+        }
+        return ticklerAttachments;
+    }
+
+    /**
+     * Attaches documents to a tickler.
+     *
+     * Tickler counterpart of {@link #attachToConsult} and {@link #attachToEForm}. Synchronises the supplied
+     * set of document IDs with the tickler's existing attachments of the given type, persisting new
+     * attachments and soft-deleting those no longer present.
+     *
+     * @param loggedInInfo LoggedInInfo the current user's session information
+     * @param documentType DocumentType the type of documents being attached
+     * @param attachments String[] an array of document IDs to attach to the tickler
+     * @param providerNo String the provider number performing the attachment operation
+     * @param ticklerId Integer the unique identifier of the tickler
+     * @param demographicNo Integer the patient's demographic number for security validation
+     * @throws RuntimeException if the user lacks the required "_tickler" write privilege
+     */
+    public void attachToTickler(LoggedInInfo loggedInInfo, DocumentType documentType, String[] attachments, String providerNo, Integer ticklerId, Integer demographicNo) {
+        if (!securityInfoManager.hasPrivilege(loggedInInfo, "_tickler", SecurityInfoManager.WRITE, demographicNo)) {
+            throw new RuntimeException("missing required sec object (_tickler)");
+        }
+
+        DocumentAttach documentAttach = new DocumentAttach();
+        documentAttach.attachToTickler(attachments, documentType, providerNo, ticklerId);
     }
 
     /**

--- a/src/main/java/ca/openosp/openo/documentManager/actions/DocumentPreview2Action.java
+++ b/src/main/java/ca/openosp/openo/documentManager/actions/DocumentPreview2Action.java
@@ -116,6 +116,8 @@ public class DocumentPreview2Action extends ActionSupport {
             }
             else if (method.equalsIgnoreCase("fetchConsultDocuments"))
                 return fetchConsultDocuments();
+            else if (method.equalsIgnoreCase("fetchTicklerDocuments"))
+                return fetchTicklerDocuments();
         }
 
         return fetchConsultDocuments();
@@ -370,6 +372,31 @@ public class DocumentPreview2Action extends ActionSupport {
 
         populateCommonDocs(loggedInInfo, demographicNo);
 		List<EFormData> allEForms = EFormUtil.listPatientEformsCurrent(Integer.valueOf(demographicNo), true);
+        request.setAttribute("allEForms", allEForms);
+
+        return "fetchDocuments";
+    }
+
+    /**
+     * Fetches the documents available for attaching to a tickler.
+     *
+     * <p>Tickler counterpart of {@link #fetchConsultDocuments()}. Populates the patient's documents,
+     * HRM reports, labs and encounter forms (via {@link #populateCommonDocs}) plus the full list of
+     * current eForms, then forwards to the shared attachment picker ({@code attachDocument.jsp}). Unlike
+     * {@link #fetchEFormDocuments()} there is no self-exclusion, since a tickler is not itself an eForm.</p>
+     *
+     * Request parameters:
+     * - demographicNo: String the patient's demographic number (defaults to "0" if not provided)
+     *
+     * @return String "fetchDocuments" result name for Struts2 result mapping
+     */
+    public String fetchTicklerDocuments() {
+        LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
+
+        String demographicNo = StringUtils.isNullOrEmpty(request.getParameter("demographicNo")) ? "0" : request.getParameter("demographicNo");
+
+        populateCommonDocs(loggedInInfo, demographicNo);
+        List<EFormData> allEForms = EFormUtil.listPatientEformsCurrent(Integer.valueOf(demographicNo), true);
         request.setAttribute("allEForms", allEForms);
 
         return "fetchDocuments";

--- a/src/main/java/ca/openosp/openo/mds/pageUtil/ReportMacro2Action.java
+++ b/src/main/java/ca/openosp/openo/mds/pageUtil/ReportMacro2Action.java
@@ -33,10 +33,10 @@ import javax.servlet.http.HttpServletResponse;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 import ca.openosp.openo.commn.dao.TicklerDao;
-import ca.openosp.openo.commn.dao.TicklerLinkDao;
+import ca.openosp.openo.commn.dao.TicklerDocsDao;
 import ca.openosp.openo.commn.dao.UserPropertyDAO;
 import ca.openosp.openo.commn.model.Tickler;
-import ca.openosp.openo.commn.model.TicklerLink;
+import ca.openosp.openo.commn.model.TicklerDocs;
 import ca.openosp.openo.commn.model.UserProperty;
 import ca.openosp.openo.managers.SecurityInfoManager;
 import ca.openosp.openo.utility.LoggedInInfo;
@@ -61,7 +61,7 @@ public class ReportMacro2Action extends ActionSupport {
 
     private SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
     private TicklerDao ticklerDao = SpringUtils.getBean(TicklerDao.class);
-    private TicklerLinkDao ticklerLinkDao = SpringUtils.getBean(TicklerLinkDao.class);
+    private TicklerDocsDao ticklerDocsDao = SpringUtils.getBean(TicklerDocsDao.class);
 
     
     private static final ObjectMapper objectMapper = new ObjectMapper();
@@ -138,11 +138,9 @@ public class ReportMacro2Action extends ActionSupport {
                 t.setCreator(LoggedInInfo.getLoggedInInfoFromSession(request).getLoggedInProviderNo());
                 ticklerDao.persist(t);
 
-                TicklerLink tl = new TicklerLink();
-                tl.setTableId(Long.valueOf(segmentID));
-                tl.setTableName(LabResultData.HL7TEXT);
-                tl.setTicklerNo(t.getId());
-                ticklerLinkDao.persist(tl);
+                // Attach the lab to the tickler using the modern attachment store (ticklerdocs).
+                TicklerDocs ticklerDocs = new TicklerDocs(t.getId(), Integer.parseInt(segmentID), TicklerDocs.DOCTYPE_LAB, providerNo);
+                ticklerDocsDao.persist(ticklerDocs);
             } else {
                 logger.info("Cannot sent tickler. Not enough information in macro definition. providers taskAssignedTo and message");
             }

--- a/src/main/java/ca/openosp/openo/tickler/pageUtil/EditTickler2Action.java
+++ b/src/main/java/ca/openosp/openo/tickler/pageUtil/EditTickler2Action.java
@@ -33,6 +33,8 @@ import ca.openosp.openo.commn.model.Tickler;
 import ca.openosp.openo.commn.model.TicklerComment;
 import ca.openosp.openo.commn.model.TicklerTextSuggest;
 import ca.openosp.openo.commn.model.TicklerUpdate;
+import ca.openosp.openo.commn.model.enumerator.DocumentType;
+import ca.openosp.openo.documentManager.DocumentAttachmentManager;
 import ca.openosp.openo.managers.SecurityInfoManager;
 import ca.openosp.openo.managers.TicklerManager;
 import ca.openosp.openo.utility.LoggedInInfo;
@@ -51,6 +53,7 @@ public class EditTickler2Action extends ActionSupport {
     private static final Logger logger = MiscUtils.getLogger();
     private TicklerManager ticklerManager = SpringUtils.getBean(TicklerManager.class);
     private SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
+    private DocumentAttachmentManager documentAttachmentManager = SpringUtils.getBean(DocumentAttachmentManager.class);
 
     public String execute() {
         if ("editTickler".equals(request.getParameter("method"))) {
@@ -180,6 +183,10 @@ public class EditTickler2Action extends ActionSupport {
             ticklerManager.updateTickler(loggedInInfo, t);
         }
 
+        // Process document attachments unconditionally: a user may change only the attachments
+        // without touching any other tickler field, so this must not be gated on isUpdate/isComment.
+        processAttachments(loggedInInfo, t, providerNo);
+
         if (emailFailed) {
             addActionError(getText("tickler.ticklerEdit.emailFailed.error"));
             return "failure";
@@ -191,6 +198,32 @@ public class EditTickler2Action extends ActionSupport {
 
         return "close";
 
+    }
+
+    /**
+     * Synchronises the tickler's document attachments with the values submitted by the
+     * attachment picker. Each document type is processed independently; a {@code null} array
+     * (the type was not present in the submission) is treated as an empty selection so that
+     * de-selecting all attachments of a type correctly soft-deletes them.
+     *
+     * @param loggedInInfo LoggedInInfo the current user's session information
+     * @param t Tickler the tickler being edited
+     * @param providerNo String the provider performing the attachment operation
+     */
+    private void processAttachments(LoggedInInfo loggedInInfo, Tickler t, String providerNo) {
+        Integer ticklerId = t.getId();
+        Integer demographicNo = t.getDemographicNo();
+
+        documentAttachmentManager.attachToTickler(loggedInInfo, DocumentType.DOC, attachmentValues("docNo"), providerNo, ticklerId, demographicNo);
+        documentAttachmentManager.attachToTickler(loggedInInfo, DocumentType.LAB, attachmentValues("labNo"), providerNo, ticklerId, demographicNo);
+        documentAttachmentManager.attachToTickler(loggedInInfo, DocumentType.EFORM, attachmentValues("eFormNo"), providerNo, ticklerId, demographicNo);
+        documentAttachmentManager.attachToTickler(loggedInInfo, DocumentType.HRM, attachmentValues("hrmNo"), providerNo, ticklerId, demographicNo);
+        documentAttachmentManager.attachToTickler(loggedInInfo, DocumentType.FORM, attachmentValues("formNo"), providerNo, ticklerId, demographicNo);
+    }
+
+    private String[] attachmentValues(String parameterName) {
+        String[] values = request.getParameterValues(parameterName);
+        return values == null ? new String[0] : values;
     }
 
     public String updateTextSuggest() {

--- a/src/main/webapp/tickler/dbTicklerAdd.jsp
+++ b/src/main/webapp/tickler/dbTicklerAdd.jsp
@@ -30,8 +30,8 @@
 <%@ page import="org.springframework.web.context.WebApplicationContext" %>
 <%@ page import="ca.openosp.openo.utility.SpringUtils" %>
 <%@ page import="ca.openosp.openo.commn.model.Tickler" %>
-<%@ page import="ca.openosp.openo.commn.model.TicklerLink" %>
-<%@ page import="ca.openosp.openo.commn.dao.TicklerLinkDao" %>
+<%@ page import="ca.openosp.openo.commn.model.enumerator.DocumentType" %>
+<%@ page import="ca.openosp.openo.documentManager.DocumentAttachmentManager" %>
 <%@ page import="ca.openosp.openo.util.UtilDateUtilities" %>
 <%@page import="ca.openosp.openo.utility.MiscUtils" %>
 <%@ page import="ca.openosp.openo.utility.LoggedInInfo" %>
@@ -99,12 +99,19 @@
     if (docType != null && docId != null && !docType.trim().equals("") && !docId.trim().equals("") && !docId.equalsIgnoreCase("null")) {
         if (ticklerNo > 0) {
             try {
-                TicklerLink tLink = new TicklerLink();
-                tLink.setTableId(Long.parseLong(docId));
-                tLink.setTableName(docType);
-                tLink.setTicklerNo(new Long(ticklerNo).intValue());
-                TicklerLinkDao ticklerLinkDao = (TicklerLinkDao) SpringUtils.getBean(TicklerLinkDao.class);
-                ticklerLinkDao.save(tLink);
+                // Attach the source document to the tickler using the modern attachment store (ticklerdocs).
+                // The legacy docType is a table_name code (DOC / HRM / HL7 / MDS / CML / ...); anything that
+                // is not a document or HRM report is treated as a lab.
+                DocumentType attachmentType;
+                if ("DOC".equalsIgnoreCase(docType)) {
+                    attachmentType = DocumentType.DOC;
+                } else if ("HRM".equalsIgnoreCase(docType)) {
+                    attachmentType = DocumentType.HRM;
+                } else {
+                    attachmentType = DocumentType.LAB;
+                }
+                DocumentAttachmentManager documentAttachmentManager = SpringUtils.getBean(DocumentAttachmentManager.class);
+                documentAttachmentManager.attachToTickler(loggedInInfo, attachmentType, new String[]{docId}, doccreator, ticklerNo, tickler.getDemographicNo());
             } catch (Exception e) {
                 MiscUtils.getLogger().error("No link with this tickler", e);
             }

--- a/src/main/webapp/tickler/dbTicklerAdd.jsp
+++ b/src/main/webapp/tickler/dbTicklerAdd.jsp
@@ -96,25 +96,57 @@
     ticklerManager.addTickler(loggedInInfo, tickler);
 
     int ticklerNo = tickler.getId();
-    if (docType != null && docId != null && !docType.trim().equals("") && !docId.trim().equals("") && !docId.equalsIgnoreCase("null")) {
-        if (ticklerNo > 0) {
-            try {
-                // Attach the source document to the tickler using the modern attachment store (ticklerdocs).
-                // The legacy docType is a table_name code (DOC / HRM / HL7 / MDS / CML / ...); anything that
-                // is not a document or HRM report is treated as a lab.
-                DocumentType attachmentType;
+    if (ticklerNo > 0) {
+        try {
+            DocumentAttachmentManager documentAttachmentManager = SpringUtils.getBean(DocumentAttachmentManager.class);
+
+            // Map the legacy forward-from-document docType (a table_name code: DOC / HRM / HL7 / MDS /
+            // CML / ...) to a DocumentType so it can be merged into the matching picker selection.
+            // Anything that is not a document or HRM report is treated as a lab.
+            DocumentType forwardedType = null;
+            if (docType != null && docId != null && !docType.trim().isEmpty()
+                    && !docId.trim().isEmpty() && !docId.equalsIgnoreCase("null")) {
                 if ("DOC".equalsIgnoreCase(docType)) {
-                    attachmentType = DocumentType.DOC;
+                    forwardedType = DocumentType.DOC;
                 } else if ("HRM".equalsIgnoreCase(docType)) {
-                    attachmentType = DocumentType.HRM;
+                    forwardedType = DocumentType.HRM;
                 } else {
-                    attachmentType = DocumentType.LAB;
+                    forwardedType = DocumentType.LAB;
                 }
-                DocumentAttachmentManager documentAttachmentManager = SpringUtils.getBean(DocumentAttachmentManager.class);
-                documentAttachmentManager.attachToTickler(loggedInInfo, attachmentType, new String[]{docId}, doccreator, ticklerNo, tickler.getDemographicNo());
-            } catch (Exception e) {
-                MiscUtils.getLogger().error("No link with this tickler", e);
             }
+
+            // The interactive attachment picker (ticklerAdd.jsp) submits one parameter per document
+            // type. attachToTickler performs a full per-type sync (it soft-deletes any stored doc of
+            // that type not in the submitted array), so each type is synced exactly once and the
+            // forwarded document is unioned into its type's list rather than attached separately.
+            java.util.LinkedHashMap<DocumentType, String> attachParams = new java.util.LinkedHashMap<DocumentType, String>();
+            attachParams.put(DocumentType.DOC, "docNo");
+            attachParams.put(DocumentType.LAB, "labNo");
+            attachParams.put(DocumentType.EFORM, "eFormNo");
+            attachParams.put(DocumentType.HRM, "hrmNo");
+            attachParams.put(DocumentType.FORM, "formNo");
+
+            for (java.util.Map.Entry<DocumentType, String> entry : attachParams.entrySet()) {
+                DocumentType attachmentType = entry.getKey();
+                String[] picked = request.getParameterValues(entry.getValue());
+
+                java.util.LinkedHashSet<String> ids = new java.util.LinkedHashSet<String>();
+                if (picked != null) {
+                    for (String id : picked) {
+                        if (id != null && !id.trim().isEmpty()) {
+                            ids.add(id.trim());
+                        }
+                    }
+                }
+                if (forwardedType == attachmentType) {
+                    ids.add(docId.trim());
+                }
+
+                documentAttachmentManager.attachToTickler(loggedInInfo, attachmentType,
+                        ids.toArray(new String[0]), doccreator, ticklerNo, tickler.getDemographicNo());
+            }
+        } catch (Exception e) {
+            MiscUtils.getLogger().error("Unable to attach documents to tickler " + ticklerNo, e);
         }
     }
 

--- a/src/main/webapp/tickler/ticklerAdd.jsp
+++ b/src/main/webapp/tickler/ticklerAdd.jsp
@@ -185,10 +185,28 @@
         table tr td {
           border:none !important;
         }
+
+        /* Keep the "Manage Attachments" button and its count badge on one line. */
+        .attachments-cell {
+            white-space: nowrap;
+        }
+
+        /* jQuery UI renders the dialog close control as a fixed ~20px square, which
+           crushes the "Save and Close" label onto multiple overflowing lines. Let it
+           grow to fit the text (matches the Consult/eForm attachment dialog). */
+        .save-and-close-button {
+            width: auto !important;
+            white-space: nowrap;
+            padding: 0 8px !important;
+        }
       </style>
       <link href="<%=request.getContextPath()%>/share/css/dateTimeQuickPick.css" rel="stylesheet" type="text/css" />
       <link href="<%= request.getContextPath() %>/library/bootstrap/3.0.0/css/bootstrap.css" rel="stylesheet" type="text/css">
+      <link href="<%=request.getContextPath() %>/library/jquery/jquery-ui-1.12.1.min.css" rel="stylesheet" type="text/css">
       <script type="text/javascript" src="<%=request.getContextPath()%>/share/javascript/dateTimeQuickPick.js"></script>
+      <script type="text/javascript" src="<%=request.getContextPath()%>/library/jquery/jquery-3.6.4.min.js"></script>
+      <script type="text/javascript" src="<%=request.getContextPath()%>/library/jquery/jquery-ui-1.12.1.min.js"></script>
+      <script type="text/javascript" src="<%=request.getContextPath()%>/js/jquery_oscar_defaults.js"></script>
 
       <script>
         function pasteMessageText() {
@@ -557,7 +575,7 @@
                 </tr>
             </table>
         </form>
-        <form name="serviceform" method="post">
+        <form name="serviceform" id="serviceform" method="post">
             <input type="hidden" name="parentAjaxId" value="<%=Encode.forHtmlAttribute(parentAjaxId)%>">
             <input type="hidden" name="updateParent" value="<%=Encode.forHtmlAttribute(updateParent)%>">
             <input type="hidden" name="user_no" value="<%=Encode.forHtmlAttribute(user_no)%>">
@@ -726,6 +744,15 @@
                     </td>
                 </tr>
                 <tr>
+                    <td><label>Attachments:</label></td>
+                    <td class="attachments-cell">
+                        <button type="button" class="btn" id="manageAttachmentsBtn" title="Manage Attachments">
+                            <i class="glyphicon glyphicon-paperclip"></i> Manage Attachments
+                        </button>
+                        <span id="attachmentCount" class="badge">0</span>
+                    </td>
+                </tr>
+                <tr>
                     <td colspan="2"><input type="button" name="Button" class="btn btn-primary"
                                value="<fmt:setBundle basename="oscarResources"/><fmt:message key="tickler.ticklerAdd.btnSubmit"/>"
                                onclick="validate(this.form);">
@@ -739,7 +766,80 @@
                 </tr>
 
             </table>
+            <div id="attachDocumentDisplay" style="display:none;"></div>
         </form>
     </div>
+
+    <jsp:include page="/images/spinner.jsp" flush="true"/>
+
+    <script type="text/javascript">
+        /**
+         * Tickler document attachment dialog (Add screen).
+         *
+         * Mirrors the edit screen: the shared attachment picker (attachDocument.jsp) is loaded into a
+         * jQuery UI dialog. Because a new tickler has no id yet, the picker is loaded with only the
+         * patient's demographicNo and the checked items are written back to the add form as hidden
+         * ".delegateAttachment" inputs (docNo / labNo / eFormNo / hrmNo / formNo). dbTicklerAdd.jsp
+         * reads those parameters after the tickler is created and persists them to ticklerdocs.
+         *
+         * The demographic is resolved at click time rather than page-render time, since the patient
+         * may be selected (via the search form) after this page first loads.
+         */
+        jQuery(document).on('click', '#manageAttachmentsBtn', function () {
+            var $form = jQuery('#serviceform');
+            var trigger = jQuery(this);
+            var title = trigger.attr("title");
+            var demographicNo = $form.find('input[name="demographic_no"]').val();
+
+            if (!demographicNo) {
+                alert("Please select a patient before managing attachments.");
+                return;
+            }
+
+            var poload = '<%=request.getContextPath()%>/previewDocs.do?method=fetchTicklerDocuments&demographicNo='
+                + encodeURIComponent(demographicNo);
+
+            jQuery("#attachDocumentDisplay").load(poload, function (response, status, xhr) {
+                if (status === "success") {
+                    // Pre-check the picker boxes for attachments already staged on this add form.
+                    $form.find(".delegateAttachment").each(function () {
+                        var checkboxId = this.name + this.value;
+                        jQuery('#attachDocumentsForm').find('#' + jQuery.escapeSelector(checkboxId)).prop('checked', true);
+                    });
+                }
+            }).dialog({
+                title: title,
+                modal: true,
+                closeText: "Save and Close",
+                height: 'auto',
+                width: 'auto',
+                resizable: true,
+                open: function (event, ui) {
+                    jQuery(this).parent().css({top: 0, left: 0});
+                    var closeBtn = jQuery(this).parent().find(".ui-dialog-titlebar-close");
+                    closeBtn.removeClass("ui-button-icon-only");
+                    closeBtn.addClass("save-and-close-button");
+                    closeBtn.html("Save and Close");
+                },
+                beforeClose: function (event, ui) {
+                    // Rebuild the add form's staged attachment set from the picker's checked boxes.
+                    $form.find(".delegateAttachment").remove();
+                    jQuery('#attachDocumentsForm')
+                        .find(".document_check:checked, .lab_check:checked, .form_check:checked, .eForm_check:checked, .hrm_check:checked")
+                        .each(function () {
+                            var element = jQuery(this);
+                            jQuery("<input />", {
+                                type: 'hidden',
+                                name: element.attr('name'),
+                                value: element.val(),
+                                id: "delegate_" + element.attr('name') + element.val(),
+                                "class": 'delegateAttachment'
+                            }).appendTo($form);
+                        });
+                    jQuery('#attachmentCount').text($form.find(".delegateAttachment").length);
+                }
+            });
+        });
+    </script>
     </body>
 </html>

--- a/src/main/webapp/tickler/ticklerDemoMain.jsp
+++ b/src/main/webapp/tickler/ticklerDemoMain.jsp
@@ -78,8 +78,6 @@
 <%@ page import="ca.openosp.openo.commn.model.TicklerComment" %>
 <%@ page import="ca.openosp.openo.commn.model.TicklerUpdate" %>
 <%@ page import="ca.openosp.openo.managers.TicklerManager" %>
-<%@ page import="ca.openosp.openo.commn.model.TicklerLink" %>
-<%@ page import="ca.openosp.openo.commn.dao.TicklerLinkDao" %>
 <%@ page import="ca.openosp.openo.lab.ca.on.*" %>
 <%@ page import="ca.openosp.openo.lab.ca.on.LabResultData" %>
 <%@ page import="org.owasp.encoder.Encode" %>
@@ -90,7 +88,8 @@
     OscarAppointmentDao appointmentDao = SpringUtils.getBean(OscarAppointmentDao.class);
     DemographicDao demographicDao = SpringUtils.getBean(DemographicDao.class);
 
-    TicklerLinkDao ticklerLinkDao = (TicklerLinkDao) SpringUtils.getBean(TicklerLinkDao.class);
+    ca.openosp.openo.commn.dao.TicklerDocsDao ticklerDocsDao = SpringUtils.getBean(ca.openosp.openo.commn.dao.TicklerDocsDao.class);
+    ca.openosp.openo.commn.dao.PatientLabRoutingDao patientLabRoutingDao = SpringUtils.getBean(ca.openosp.openo.commn.dao.PatientLabRoutingDao.class);
 %>
 
 
@@ -937,39 +936,53 @@
                             <TD ROWSPAN="1" class="<%=Encode.forHtmlAttribute(String.valueOf(cellColour))%>"><%=Encode.forHtml(String.valueOf(t.getMessage()))%>
 
                                 <%
-                                    List<TicklerLink> linkList = ticklerLinkDao.getLinkByTickler(t.getId().intValue());
-                                    if (linkList != null) {
-                                        for (TicklerLink tl : linkList) {
-                                            String type = tl.getTableName();
+                                    // Render the tickler's attachments from the modern attachment store (ticklerdocs).
+                                    // Lab sub-type is recovered from patient_lab_routing to pick the correct viewer.
+                                    List<ca.openosp.openo.commn.model.TicklerDocs> ticklerDocsList =
+                                            ticklerDocsDao.findByTicklerId(t.getId());
+                                    for (ca.openosp.openo.commn.model.TicklerDocs td : ticklerDocsList) {
+                                        String dtype = td.getDocType();
+                                        String docNoStr = String.valueOf(td.getDocumentNo());
+                                        String href;
+                                        if (ca.openosp.openo.commn.model.TicklerDocs.DOCTYPE_DOC.equals(dtype)) {
+                                            href = request.getContextPath() + "/documentManager/ManageDocument.do?method=display&doc_no="
+                                                    + Encode.forUriComponent(docNoStr) + "&providerNo=" + Encode.forUriComponent(String.valueOf(user_no))
+                                                    + "&searchProviderNo=" + Encode.forUriComponent(String.valueOf(user_no)) + "&status=";
+                                        } else if (ca.openosp.openo.commn.model.TicklerDocs.DOCTYPE_HRM.equals(dtype)) {
+                                            href = request.getContextPath() + "/hospitalReportManager/Display.do?id=" + Encode.forUriComponent(docNoStr);
+                                        } else if (ca.openosp.openo.commn.model.TicklerDocs.DOCTYPE_EFORM.equals(dtype)) {
+                                            href = request.getContextPath() + "/eform/efmshowform_data.jsp?fdid=" + Encode.forUriComponent(docNoStr);
+                                        } else if (ca.openosp.openo.commn.model.TicklerDocs.DOCTYPE_FORM.equals(dtype)) {
+                                            href = null;
+                                        } else {
+                                            ca.openosp.openo.commn.model.PatientLabRouting plr =
+                                                    patientLabRoutingDao.findByLabNo(td.getDocumentNo());
+                                            String labType = (plr != null) ? plr.getLabType() : null;
+                                            if (LabResultData.MDS.equals(labType)) {
+                                                href = "SegmentDisplay.jsp?segmentID=" + Encode.forUriComponent(docNoStr)
+                                                        + "&providerNo=" + Encode.forUriComponent(String.valueOf(user_no))
+                                                        + "&searchProviderNo=" + Encode.forUriComponent(String.valueOf(user_no)) + "&status=";
+                                            } else if (LabResultData.CML.equals(labType)) {
+                                                href = request.getContextPath() + "/lab/CA/ON/CMLDisplay.jsp?segmentID=" + Encode.forUriComponent(docNoStr)
+                                                        + "&providerNo=" + Encode.forUriComponent(String.valueOf(user_no))
+                                                        + "&searchProviderNo=" + Encode.forUriComponent(String.valueOf(user_no)) + "&status=";
+                                            } else if (LabResultData.HL7TEXT.equals(labType)) {
+                                                href = request.getContextPath() + "/lab/CA/ALL/labDisplay.jsp?segmentID=" + Encode.forUriComponent(docNoStr)
+                                                        + "&providerNo=" + Encode.forUriComponent(String.valueOf(user_no))
+                                                        + "&searchProviderNo=" + Encode.forUriComponent(String.valueOf(user_no)) + "&status=";
+                                            } else {
+                                                href = request.getContextPath() + "/lab/CA/BC/labDisplay.jsp?segmentID=" + Encode.forUriComponent(docNoStr)
+                                                        + "&providerNo=" + Encode.forUriComponent(String.valueOf(user_no))
+                                                        + "&searchProviderNo=" + Encode.forUriComponent(String.valueOf(user_no)) + "&status=";
+                                            }
+                                        }
+                                        if (href != null) {
                                 %>
-
+                                <a href="javascript:reportWindow('<%=Encode.forJavaScript(href)%>')">ATT</a>
                                 <%
-                                    if (LabResultData.isMDS(type)) {
+                                        } else {
                                 %>
-                                <a href="javascript:reportWindow('SegmentDisplay.jsp?segmentID=<%=Encode.forUriComponent(String.valueOf(tl.getTableId()))%>&providerNo=<%=Encode.forUriComponent(String.valueOf(user_no))%>&searchProviderNo=<%=Encode.forUriComponent(String.valueOf(user_no))%>&status=')">ATT</a>
-                                <%
-                                } else if (LabResultData.isCML(type)) {
-                                %>
-                                <a href="javascript:reportWindow('<%= request.getContextPath() %>/lab/CA/ON/CMLDisplay.jsp?segmentID=<%=Encode.forUriComponent(String.valueOf(tl.getTableId()))%>&providerNo=<%=Encode.forUriComponent(String.valueOf(user_no))%>&searchProviderNo=<%=Encode.forUriComponent(String.valueOf(user_no))%>&status=')">ATT</a>
-                                <%
-                                } else if (LabResultData.isHL7TEXT(type)) {
-                                %>
-                                <a href="javascript:reportWindow('<%= request.getContextPath() %>/lab/CA/ALL/labDisplay.jsp?segmentID=<%=Encode.forUriComponent(String.valueOf(tl.getTableId()))%>&providerNo=<%=Encode.forUriComponent(String.valueOf(user_no))%>&searchProviderNo=<%=Encode.forUriComponent(String.valueOf(user_no))%>&status=')">ATT</a>
-                                <%
-                                } else if (LabResultData.isDocument(type)) {
-                                %>
-                                <a href="javascript:reportWindow('<%=request.getContextPath()%>/documentManager/ManageDocument.do?method=display&doc_no=<%=Encode.forUriComponent(String.valueOf(tl.getTableId()))%>&providerNo=<%=Encode.forUriComponent(String.valueOf(user_no))%>&searchProviderNo=<%=Encode.forUriComponent(String.valueOf(user_no))%>&status=')">ATT</a>
-                                <%
-                                } else if (LabResultData.isHRM(type)) {
-                                %>
-                                <a href="javascript:reportWindow('<%=request.getContextPath()%>/hospitalReportManager/Display.do?id=<%=Encode.forUriComponent(String.valueOf(tl.getTableId()))%>')">ATT</a>
-                                <%
-                                } else {
-                                %>
-                                <a href="javascript:reportWindow('<%= request.getContextPath() %>/lab/CA/BC/labDisplay.jsp?segmentID=<%=Encode.forUriComponent(String.valueOf(tl.getTableId()))%>&providerNo=<%=Encode.forUriComponent(String.valueOf(user_no))%>&searchProviderNo=<%=Encode.forUriComponent(String.valueOf(user_no))%>&status=')">ATT</a>
-                                <%
-                                    }
-                                %>
+                                <span title="Attached form">ATT</span>
                                 <%
                                         }
                                     }

--- a/src/main/webapp/tickler/ticklerDemoMain.jsp
+++ b/src/main/webapp/tickler/ticklerDemoMain.jsp
@@ -900,7 +900,7 @@
                             <TD ROWSPAN="1" class="<%=Encode.forHtmlAttribute(String.valueOf(cellColour))%>">
                                 <%if (Boolean.parseBoolean(OscarProperties.getInstance().getProperty("tickler_edit_enabled"))) {%>
                                 <a href=#
-                                   onClick="popupPage(600,800, '<%= request.getContextPath() %>/tickler/ticklerEdit.jsp?tickler_no=<%=Encode.forJavaScript(String.valueOf(t.getId()))%>')"><fmt:setBundle basename="oscarResources"/><fmt:message key="tickler.ticklerMain.editTickler"/></a>
+                                   onClick="popupPage(600,960, '<%= request.getContextPath() %>/tickler/ticklerEdit.jsp?tickler_no=<%=Encode.forJavaScript(String.valueOf(t.getId()))%>')"><fmt:setBundle basename="oscarResources"/><fmt:message key="tickler.ticklerMain.editTickler"/></a>
                                 <% } %>
                             </TD>
                             <TD ROWSPAN="1" class="<%=Encode.forHtmlAttribute(String.valueOf(cellColour))%>"><a

--- a/src/main/webapp/tickler/ticklerEdit.jsp
+++ b/src/main/webapp/tickler/ticklerEdit.jsp
@@ -44,10 +44,13 @@
 <%@page import="ca.openosp.openo.utility.LoggedInInfo" %>
 <%@page import="ca.openosp.openo.managers.TicklerManager" %>
 <%@page import="ca.openosp.openo.managers.DemographicManager" %>
+<%@page import="ca.openosp.openo.documentManager.DocumentAttachmentManager" %>
+<%@page import="ca.openosp.openo.commn.model.enumerator.DocumentType" %>
 <%@page import="ca.openosp.OscarProperties" %>
 <%
     TicklerManager ticklerManager = SpringUtils.getBean(TicklerManager.class);
     DemographicManager demographicManager = SpringUtils.getBean(DemographicManager.class);
+    DocumentAttachmentManager documentAttachmentManager = SpringUtils.getBean(DocumentAttachmentManager.class);
     LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
 %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
@@ -293,11 +296,17 @@
         <link href="<%= request.getContextPath() %>/library/bootstrap/3.0.0/css/bootstrap.css" rel="stylesheet"
               type="text/css">
 
+        <script type="text/javascript" src="<%=request.getContextPath()%>/library/jquery/jquery-3.6.4.min.js"></script>
+        <script type="text/javascript" src="<%=request.getContextPath()%>/library/jquery/jquery-ui-1.12.1.min.js"></script>
+        <script type="text/javascript" src="<%=request.getContextPath()%>/js/jquery_oscar_defaults.js"></script>
+        <link href="<%=request.getContextPath() %>/library/jquery/jquery-ui-1.12.1.min.css" rel="stylesheet"
+              type="text/css">
+
     </head>
 
     <body>
     <div class="container">
-        <form name="serviceform" action="${pageContext.request.contextPath}/tickler/EditTickler.do" method="post">
+        <form id="ticklerEditForm" name="serviceform" action="${pageContext.request.contextPath}/tickler/EditTickler.do" method="post">
             <input type="hidden" name="method" value="editTickler"/>
             <input type="hidden" name="ticklerNo" value="<%=Encode.forHtmlAttribute(String.valueOf(ticklerNo))%>"/>
             <input type="hidden" name="parentAjaxId" value="<e:forHtml value='${param.parentAjaxId}' />"/>
@@ -507,6 +516,43 @@
                         </div>
                     </td>
                 </tr>
+                <%
+                    // Build the hidden "delegate" inputs representing the tickler's current attachments.
+                    // These mirror the attachment picker's checkbox names (docNo/labNo/eFormNo/hrmNo/formNo)
+                    // so the dialog can pre-check them and EditTickler2Action can re-read the full selection.
+                    java.util.LinkedHashMap<DocumentType, String> ticklerAttachTypes = new java.util.LinkedHashMap<DocumentType, String>();
+                    ticklerAttachTypes.put(DocumentType.DOC, "docNo");
+                    ticklerAttachTypes.put(DocumentType.LAB, "labNo");
+                    ticklerAttachTypes.put(DocumentType.EFORM, "eFormNo");
+                    ticklerAttachTypes.put(DocumentType.HRM, "hrmNo");
+                    ticklerAttachTypes.put(DocumentType.FORM, "formNo");
+
+                    StringBuilder delegateInputs = new StringBuilder();
+                    int attachmentCount = 0;
+                    for (java.util.Map.Entry<DocumentType, String> attachEntry : ticklerAttachTypes.entrySet()) {
+                        String paramName = attachEntry.getValue();
+                        for (String docId : documentAttachmentManager.getTicklerAttachments(loggedInInfo, ticklerNo, attachEntry.getKey(), t.getDemographicNo())) {
+                            attachmentCount++;
+                            delegateInputs.append("<input type=\"hidden\" class=\"delegateAttachment\" name=\"")
+                                    .append(paramName)
+                                    .append("\" value=\"").append(Encode.forHtmlAttribute(docId))
+                                    .append("\" id=\"delegate_").append(Encode.forHtmlAttribute(paramName + docId))
+                                    .append("\">");
+                        }
+                    }
+                %>
+                <tr>
+                    <th colspan="2" style="background-color: #666699;color:white;">Attachments</th>
+                    <td colspan="2">
+                        <button type="button" class="btn" id="manageAttachmentsBtn"
+                                title="Manage Attachments"
+                                data-poload="${pageContext.request.contextPath}/previewDocs.do?method=fetchTicklerDocuments&amp;demographicNo=<%=Encode.forHtmlAttribute(String.valueOf(d.getDemographicNo()))%>&amp;ticklerId=<%=Encode.forHtmlAttribute(String.valueOf(ticklerNo))%>">
+                            <i class="glyphicon glyphicon-paperclip"></i> Manage Attachments
+                        </button>
+                        <span id="attachmentCount" class="badge"><%=attachmentCount%></span>
+                        <%=delegateInputs.toString()%>
+                    </td>
+                </tr>
                 <tr>
                     <td colspan="2" style="vertical-align: bottom;text-align:right; padding-top:15px; border:none;">
                         <oscar:oscarPropertiesCheck property="tickler_email_enabled" value="true">
@@ -521,8 +567,71 @@
                     </td>
                 </tr>
             </table>
+            <div id="attachDocumentDisplay" style="display:none;"></div>
         </form>
     </div>
+
+    <jsp:include page="/images/spinner.jsp" flush="true"/>
+
+    <script type="text/javascript">
+        /**
+         * Tickler document attachment dialog.
+         *
+         * Loads the shared attachment picker (attachDocument.jsp) into a jQuery UI dialog. Existing
+         * attachments are pre-checked from the hidden ".delegateAttachment" inputs rendered in the
+         * tickler form. On "Save and Close" the full set of checked items is written back as
+         * ".delegateAttachment" hidden inputs, which EditTickler2Action reads to synchronise the
+         * tickler's attachments (the manager soft-deletes any that were removed).
+         */
+        jQuery(document).on('click', '#manageAttachmentsBtn', function () {
+            var $form = jQuery('#ticklerEditForm');
+            var trigger = jQuery(this);
+            var title = trigger.attr("title");
+
+            jQuery("#attachDocumentDisplay").load(trigger.data('poload'), function (response, status, xhr) {
+                if (status === "success") {
+                    // Pre-check the picker boxes for attachments already on this tickler.
+                    $form.find(".delegateAttachment").each(function () {
+                        var checkboxId = this.name + this.value;
+                        jQuery('#attachDocumentsForm').find('#' + jQuery.escapeSelector(checkboxId)).prop('checked', true);
+                    });
+                }
+            }).dialog({
+                title: title,
+                modal: true,
+                closeText: "Save and Close",
+                height: 'auto',
+                width: 'auto',
+                resizable: true,
+                open: function (event, ui) {
+                    jQuery(this).parent().css({top: 0, left: 0});
+                    var closeBtn = jQuery(this).parent().find(".ui-dialog-titlebar-close");
+                    closeBtn.removeClass("ui-button-icon-only");
+                    closeBtn.addClass("save-and-close-button");
+                    closeBtn.html("Save and Close");
+                },
+                beforeClose: function (event, ui) {
+                    // Rebuild the tickler form's attachment set from the picker's checked boxes.
+                    // attachToTickler() diffs this against the stored set, so submitting the full
+                    // current selection per type is sufficient for both adds and removals.
+                    $form.find(".delegateAttachment").remove();
+                    jQuery('#attachDocumentsForm')
+                        .find(".document_check:checked, .lab_check:checked, .form_check:checked, .eForm_check:checked, .hrm_check:checked")
+                        .each(function () {
+                            var element = jQuery(this);
+                            jQuery("<input />", {
+                                type: 'hidden',
+                                name: element.attr('name'),
+                                value: element.val(),
+                                id: "delegate_" + element.attr('name') + element.val(),
+                                "class": 'delegateAttachment'
+                            }).appendTo($form);
+                        });
+                    jQuery('#attachmentCount').text($form.find(".delegateAttachment").length);
+                }
+            });
+        });
+    </script>
 
     </body>
 </html>

--- a/src/main/webapp/tickler/ticklerEdit.jsp
+++ b/src/main/webapp/tickler/ticklerEdit.jsp
@@ -130,6 +130,27 @@
               font-size: 12px !important;
             }
 
+            /* Give the edit popup a little more room so the attachment count badge
+               stays beside the "Manage Attachments" button instead of wrapping under it. */
+            .container {
+                width: auto;
+                max-width: 940px;
+            }
+
+            /* Keep the "Manage Attachments" button and its count badge on one line. */
+            .attachments-cell {
+                white-space: nowrap;
+            }
+
+            /* jQuery UI renders the dialog close control as a fixed ~20px square, which
+               crushes the "Save and Close" label onto multiple overflowing lines. Let it
+               grow to fit the text (matches the Consult/eForm attachment dialog). */
+            .save-and-close-button {
+                width: auto !important;
+                white-space: nowrap;
+                padding: 0 8px !important;
+            }
+
             /*.grid {*/
             /*    display: grid;*/
             /*    grid-template-columns: repeat(10, 1fr);*/
@@ -543,7 +564,7 @@
                 %>
                 <tr>
                     <th colspan="2" style="background-color: #666699;color:white;">Attachments</th>
-                    <td colspan="2">
+                    <td colspan="2" class="attachments-cell">
                         <button type="button" class="btn" id="manageAttachmentsBtn"
                                 title="Manage Attachments"
                                 data-poload="${pageContext.request.contextPath}/previewDocs.do?method=fetchTicklerDocuments&amp;demographicNo=<%=Encode.forHtmlAttribute(String.valueOf(d.getDemographicNo()))%>&amp;ticklerId=<%=Encode.forHtmlAttribute(String.valueOf(ticklerNo))%>">

--- a/src/main/webapp/tickler/ticklerMain.jsp
+++ b/src/main/webapp/tickler/ticklerMain.jsp
@@ -879,7 +879,7 @@
                                                        class="noprint"></td>
                     <td class="<%=Encode.forHtmlAttribute(String.valueOf(cellColour))%>">
                         <a href="javascript:void(0)" title="<fmt:setBundle basename="oscarResources"/><fmt:message key="tickler.ticklerMain.editTickler"/>"
-                           onClick="window.open('<%= request.getContextPath() %>/tickler/ticklerEdit.jsp?tickler_no=<%=Encode.forJavaScript(String.valueOf(tickler.getId()))%>', 'edit_tickler', 'width=800, height=650')">
+                           onClick="window.open('<%= request.getContextPath() %>/tickler/ticklerEdit.jsp?tickler_no=<%=Encode.forJavaScript(String.valueOf(tickler.getId()))%>', 'edit_tickler', 'width=960, height=650')">
                             <span class="glyphicon glyphicon-pencil"></span>
                         </a>
                     </td>

--- a/src/main/webapp/tickler/ticklerMain.jsp
+++ b/src/main/webapp/tickler/ticklerMain.jsp
@@ -41,7 +41,6 @@
 <%@ page import="ca.openosp.openo.managers.TicklerManager" %>
 <%@ page import="ca.openosp.openo.tickler.dto.TicklerListDTO" %>
 <%@ page import="ca.openosp.openo.tickler.dto.TicklerCommentDTO" %>
-<%@ page import="ca.openosp.openo.tickler.dto.TicklerLinkDTO" %>
 <%@ page import="java.text.DateFormat" %>
 <%@ page import="java.text.SimpleDateFormat" %>
 <%@ page import="org.owasp.encoder.Encode" %>
@@ -72,6 +71,8 @@
 <%!
     TicklerManager ticklerManager = SpringUtils.getBean(TicklerManager.class);
     ViewDao viewDao = SpringUtils.getBean(ViewDao.class);
+    ca.openosp.openo.commn.dao.TicklerDocsDao ticklerDocsDao = SpringUtils.getBean(ca.openosp.openo.commn.dao.TicklerDocsDao.class);
+    ca.openosp.openo.commn.dao.PatientLabRoutingDao patientLabRoutingDao = SpringUtils.getBean(ca.openosp.openo.commn.dao.PatientLabRoutingDao.class);
 %>
 
 <%
@@ -902,51 +903,60 @@
                             style="white-space:pre-wrap"><%=Encode.forHtmlContent(tickler.getMessage())%></span>
 
                         <%
-                            List<TicklerLinkDTO> linkList = tickler.getLinks();
-                            if (linkList != null) {
-                                for (TicklerLinkDTO tl : linkList) {
-                                    String type = tl.getTableName();
-                        %>
-
-                        <%
-                            if (LabResultData.isMDS(type)) {
+                            // Render the tickler's attachments from the modern attachment store (ticklerdocs).
+                            // Lab sub-type (MDS/CML/HL7/BC) is recovered from patient_lab_routing so the correct
+                            // viewer is opened, mirroring the routing that the legacy tickler_link display used.
+                            List<ca.openosp.openo.commn.model.TicklerDocs> ticklerDocsList =
+                                    ticklerDocsDao.findByTicklerId(tickler.getId());
+                            for (ca.openosp.openo.commn.model.TicklerDocs td : ticklerDocsList) {
+                                String dtype = td.getDocType();
+                                String docNoStr = String.valueOf(td.getDocumentNo());
+                                String href;
+                                if (ca.openosp.openo.commn.model.TicklerDocs.DOCTYPE_DOC.equals(dtype)) {
+                                    href = request.getContextPath() + "/documentManager/ManageDocument.do?method=display&doc_no="
+                                            + Encode.forUriComponent(docNoStr) + "&providerNo=" + Encode.forUriComponent(String.valueOf(user_no))
+                                            + "&searchProviderNo=" + Encode.forUriComponent(String.valueOf(user_no)) + "&status=";
+                                } else if (ca.openosp.openo.commn.model.TicklerDocs.DOCTYPE_HRM.equals(dtype)) {
+                                    href = request.getContextPath() + "/hospitalReportManager/Display.do?id="
+                                            + Encode.forUriComponent(docNoStr) + "&segmentID=" + Encode.forUriComponent(docNoStr);
+                                } else if (ca.openosp.openo.commn.model.TicklerDocs.DOCTYPE_EFORM.equals(dtype)) {
+                                    href = request.getContextPath() + "/eform/efmshowform_data.jsp?fdid=" + Encode.forUriComponent(docNoStr);
+                                } else if (ca.openosp.openo.commn.model.TicklerDocs.DOCTYPE_FORM.equals(dtype)) {
+                                    // Encounter forms cannot be reliably opened from a form id alone; show an
+                                    // indicator only (the attachment is fully viewable from the edit dialog).
+                                    href = null;
+                                } else {
+                                    // Lab: recover the source lab type to pick the correct viewer.
+                                    ca.openosp.openo.commn.model.PatientLabRouting plr =
+                                            patientLabRoutingDao.findByLabNo(td.getDocumentNo());
+                                    String labType = (plr != null) ? plr.getLabType() : null;
+                                    if (LabResultData.MDS.equals(labType)) {
+                                        href = "SegmentDisplay.jsp?segmentID=" + Encode.forUriComponent(docNoStr)
+                                                + "&providerNo=" + Encode.forUriComponent(String.valueOf(user_no))
+                                                + "&searchProviderNo=" + Encode.forUriComponent(String.valueOf(user_no)) + "&status=";
+                                    } else if (LabResultData.CML.equals(labType)) {
+                                        href = request.getContextPath() + "/lab/CA/ON/CMLDisplay.jsp?segmentID=" + Encode.forUriComponent(docNoStr)
+                                                + "&providerNo=" + Encode.forUriComponent(String.valueOf(user_no))
+                                                + "&searchProviderNo=" + Encode.forUriComponent(String.valueOf(user_no)) + "&status=";
+                                    } else if (LabResultData.HL7TEXT.equals(labType)) {
+                                        href = request.getContextPath() + "/lab/CA/ALL/labDisplay.jsp?segmentID=" + Encode.forUriComponent(docNoStr)
+                                                + "&providerNo=" + Encode.forUriComponent(String.valueOf(user_no))
+                                                + "&searchProviderNo=" + Encode.forUriComponent(String.valueOf(user_no)) + "&status=";
+                                    } else {
+                                        href = request.getContextPath() + "/lab/CA/BC/labDisplay.jsp?segmentID=" + Encode.forUriComponent(docNoStr)
+                                                + "&providerNo=" + Encode.forUriComponent(String.valueOf(user_no))
+                                                + "&searchProviderNo=" + Encode.forUriComponent(String.valueOf(user_no)) + "&status=";
+                                    }
+                                }
+                                if (href != null) {
                         %>
                         <a title="View attachment"
-                           href="javascript:reportWindow('SegmentDisplay.jsp?segmentID=<%=Encode.forUriComponent(String.valueOf(tl.getTableId()))%>&providerNo=<%=Encode.forUriComponent(String.valueOf(user_no))%>&searchProviderNo=<%=Encode.forUriComponent(String.valueOf(user_no))%>&status=')"><i
+                           href="javascript:reportWindow('<%=Encode.forJavaScript(href)%>')"><i
                                 class="glyphicon glyphicon-paperclip"></i></a>
                         <%
-                        } else if (LabResultData.isCML(type)) {
+                                } else {
                         %>
-                        <a title="View attachment"
-                           href="javascript:reportWindow('<%= request.getContextPath() %>/lab/CA/ON/CMLDisplay.jsp?segmentID=<%=Encode.forUriComponent(String.valueOf(tl.getTableId()))%>&providerNo=<%=Encode.forUriComponent(String.valueOf(user_no))%>&searchProviderNo=<%=Encode.forUriComponent(String.valueOf(user_no))%>&status=')"><i
-                                class="glyphicon glyphicon-paperclip"></i></a>
-                        <%
-                        } else if (LabResultData.isHL7TEXT(type)) {
-                        %>
-                        <a title="View attachment"
-                           href="javascript:reportWindow('<%= request.getContextPath() %>/lab/CA/ALL/labDisplay.jsp?segmentID=<%=Encode.forUriComponent(String.valueOf(tl.getTableId()))%>&providerNo=<%=Encode.forUriComponent(String.valueOf(user_no))%>&searchProviderNo=<%=Encode.forUriComponent(String.valueOf(user_no))%>&status=')"><i
-                                class="glyphicon glyphicon-paperclip"></i></a>
-                        <%
-                        } else if (LabResultData.isDocument(type)) {
-                        %>
-                        <a title="View attachment"
-                           href="javascript:reportWindow('<%=request.getContextPath()%>/documentManager/ManageDocument.do?method=display&doc_no=<%=Encode.forUriComponent(String.valueOf(tl.getTableId()))%>&providerNo=<%=Encode.forUriComponent(String.valueOf(user_no))%>&searchProviderNo=<%=Encode.forUriComponent(String.valueOf(user_no))%>&status=')"><i
-                                class="glyphicon glyphicon-paperclip"></i></a>
-                        <%
-                        } else if (LabResultData.isHRM(type)) {
-                        %>
-                        <a title="View attachment"
-                           href="javascript:reportWindow('<%=request.getContextPath()%>/hospitalReportManager/Display.do?id=<%=Encode.forUriComponent(String.valueOf(tl.getTableId()))%>&segmentID=<%=Encode.forUriComponent(String.valueOf(tl.getTableId()))%>')"><i
-                                class="glyphicon glyphicon-paperclip"></i></a>
-                        <%
-                        } else {
-                        %>
-                        <a title="View attachment"
-                           href="javascript:reportWindow('<%= request.getContextPath() %>/lab/CA/BC/labDisplay.jsp?segmentID=<%=Encode.forUriComponent(String.valueOf(tl.getTableId()))%>&providerNo=<%=Encode.forUriComponent(String.valueOf(user_no))%>&searchProviderNo=<%=Encode.forUriComponent(String.valueOf(user_no))%>&status=')"><i
-                                class="glyphicon glyphicon-paperclip"></i></a>
-                        <%
-                            }
-                        %>
+                        <i class="glyphicon glyphicon-paperclip" title="Attached form"></i>
                         <%
                                 }
                             }

--- a/src/test-modern/java/ca/openosp/openo/tickler/dao/TicklerDocsDaoIntegrationTest.java
+++ b/src/test-modern/java/ca/openosp/openo/tickler/dao/TicklerDocsDaoIntegrationTest.java
@@ -1,0 +1,142 @@
+/**
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ * <p>
+ * This software was written for
+ * Magenta Health
+ * Toronto, Ontario, Canada
+ */
+package ca.openosp.openo.tickler.dao;
+
+import ca.openosp.openo.commn.dao.TicklerDocsDao;
+import ca.openosp.openo.commn.model.TicklerDocs;
+import ca.openosp.openo.test.base.OpenOTestBase;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link TicklerDocsDao}, the data access layer behind the modern
+ * Tickler document attachment component (issue #2476).
+ *
+ * <p>Verifies the three finders and confirms that soft-deleted rows ({@code deleted = 'Y'})
+ * are excluded from query results.</p>
+ *
+ * @since 2026-06-12
+ * @see TicklerDocsDao
+ * @see TicklerDocs
+ */
+@Tag("integration")
+@Tag("database")
+@Tag("slow")
+@Tag("dao")
+@Tag("tickler")
+@Transactional
+class TicklerDocsDaoIntegrationTest extends OpenOTestBase {
+
+    @Autowired
+    private TicklerDocsDao ticklerDocsDao;
+
+    @PersistenceContext(unitName = "entityManagerFactory")
+    private EntityManager entityManager;
+
+    private static final int TICKLER_ID = 5000;
+    private static final String PROVIDER_NO = "999998";
+
+    private TicklerDocs persistAttachment(int ticklerId, int documentNo, String docType) {
+        TicklerDocs ticklerDocs = new TicklerDocs(ticklerId, documentNo, docType, PROVIDER_NO);
+        ticklerDocsDao.persist(ticklerDocs);
+        entityManager.flush();
+        return ticklerDocs;
+    }
+
+    @Test
+    @DisplayName("should persist and find tickler attachment by id")
+    void shouldPersistAndFindAttachment_whenAttachmentSaved() {
+        TicklerDocs saved = persistAttachment(TICKLER_ID, 11, TicklerDocs.DOCTYPE_DOC);
+
+        TicklerDocs found = ticklerDocsDao.find(saved.getId());
+
+        assertThat(found).isNotNull();
+        assertThat(found.getTicklerId()).isEqualTo(TICKLER_ID);
+        assertThat(found.getDocumentNo()).isEqualTo(11);
+        assertThat(found.getDocType()).isEqualTo(TicklerDocs.DOCTYPE_DOC);
+    }
+
+    @Test
+    @DisplayName("should return all non-deleted attachments for a tickler")
+    @Tag("read")
+    void shouldReturnAllAttachments_whenFindingByTicklerId() {
+        persistAttachment(TICKLER_ID, 11, TicklerDocs.DOCTYPE_DOC);
+        persistAttachment(TICKLER_ID, 22, TicklerDocs.DOCTYPE_LAB);
+        persistAttachment(TICKLER_ID + 1, 33, TicklerDocs.DOCTYPE_DOC);
+
+        List<TicklerDocs> results = ticklerDocsDao.findByTicklerId(TICKLER_ID);
+
+        assertThat(results).hasSize(2);
+        assertThat(results).extracting(TicklerDocs::getDocumentNo).containsExactlyInAnyOrder(11, 22);
+    }
+
+    @Test
+    @DisplayName("should filter attachments by document type")
+    @Tag("read")
+    @Tag("filter")
+    void shouldFilterByDocType_whenFindingByTicklerIdDocType() {
+        persistAttachment(TICKLER_ID, 11, TicklerDocs.DOCTYPE_DOC);
+        persistAttachment(TICKLER_ID, 22, TicklerDocs.DOCTYPE_LAB);
+
+        List<TicklerDocs> docs = ticklerDocsDao.findByTicklerIdDocType(TICKLER_ID, TicklerDocs.DOCTYPE_DOC);
+
+        assertThat(docs).hasSize(1);
+        assertThat(docs.get(0).getDocumentNo()).isEqualTo(11);
+    }
+
+    @Test
+    @DisplayName("should find a specific attachment by tickler id, document number and type")
+    @Tag("read")
+    void shouldFindSpecificAttachment_whenFindingByTicklerIdDocNoDocType() {
+        persistAttachment(TICKLER_ID, 11, TicklerDocs.DOCTYPE_DOC);
+
+        List<TicklerDocs> results = ticklerDocsDao.findByTicklerIdDocNoDocType(TICKLER_ID, 11, TicklerDocs.DOCTYPE_DOC);
+
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0).getDocType()).isEqualTo(TicklerDocs.DOCTYPE_DOC);
+    }
+
+    @Test
+    @DisplayName("should exclude soft-deleted attachments from finder results")
+    @Tag("read")
+    @Tag("delete")
+    void shouldExcludeSoftDeleted_whenAttachmentMarkedDeleted() {
+        TicklerDocs attachment = persistAttachment(TICKLER_ID, 11, TicklerDocs.DOCTYPE_DOC);
+
+        attachment.setDeleted(TicklerDocs.DELETED);
+        ticklerDocsDao.merge(attachment);
+        entityManager.flush();
+
+        assertThat(ticklerDocsDao.findByTicklerId(TICKLER_ID)).isEmpty();
+        assertThat(ticklerDocsDao.findByTicklerIdDocType(TICKLER_ID, TicklerDocs.DOCTYPE_DOC)).isEmpty();
+        assertThat(ticklerDocsDao.findByTicklerIdDocNoDocType(TICKLER_ID, 11, TicklerDocs.DOCTYPE_DOC)).isEmpty();
+    }
+}

--- a/src/test-modern/java/ca/openosp/openo/util/Doc2PDFIntegrationTest.java
+++ b/src/test-modern/java/ca/openosp/openo/util/Doc2PDFIntegrationTest.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
-import ca.openosp.openo.test.integration.OpenOTestBase;
+import ca.openosp.openo.test.base.OpenOTestBase;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/src/test-modern/resources/META-INF/persistence.xml
+++ b/src/test-modern/resources/META-INF/persistence.xml
@@ -22,6 +22,7 @@
         <class>ca.openosp.openo.commn.model.TicklerCategory</class>
         <class>ca.openosp.openo.commn.model.TicklerComment</class>
         <class>ca.openosp.openo.commn.model.TicklerLink</class>
+        <class>ca.openosp.openo.commn.model.TicklerDocs</class>
         <class>ca.openosp.openo.commn.model.CustomFilter</class>
         <class>ca.openosp.openo.commn.model.Admission</class>
         <class>ca.openosp.openo.commn.model.OscarLog</class>

--- a/src/test-modern/resources/test-context-full.xml
+++ b/src/test-modern/resources/test-context-full.xml
@@ -185,6 +185,7 @@
     <bean id="ticklerDao" class="ca.openosp.openo.commn.dao.TicklerDaoImpl" autowire="byName" />
     <bean id="ticklerCommentDao" class="ca.openosp.openo.commn.dao.TicklerCommentDaoImpl" autowire="byName" />
     <bean id="ticklerLinkDao" class="ca.openosp.openo.commn.dao.TicklerLinkDaoImpl" autowire="byName" />
+    <bean id="ticklerDocsDao" class="ca.openosp.openo.commn.dao.TicklerDocsDaoImpl" autowire="byName" />
     <bean id="ticklerUpdateDao" class="ca.openosp.openo.commn.dao.TicklerUpdateDaoImpl" autowire="byName" />
     <bean id="ticklerTextSuggestDao" class="ca.openosp.openo.commn.dao.TicklerTextSuggestDaoImpl" autowire="byName" />
     <bean id="ticklerCategoryDao" class="ca.openosp.openo.commn.dao.TicklerCategoryDaoImpl" autowire="byName" />


### PR DESCRIPTION
## Summary by Sourcery

Integrate the shared document attachment component into the Tickler workflow, migrating storage to the new ticklerdocs model and wiring it through the UI, services, and database.

New Features:
- Add a Manage Attachments dialog to tickler add and edit screens using the shared document attachment picker with per-type selection and counts.
- Expose tickler-specific attachment operations via DocumentAttachmentManager and DocumentPreview2Action to retrieve and manage tickler document sets.
- Introduce the TicklerDocs JPA entity, DAO, and database table as the dedicated store for tickler document attachments, including an integration-tested data access layer.

Enhancements:
- Render tickler attachments in main and demo tickler lists from the new ticklerdocs store, including correct viewers for documents, labs, HRM, eForms, and encounter forms.
- Update tickler creation and editing flows to synchronise attachments via the new attachment manager, replacing legacy TicklerLink usage and soft-deleting removed items.
- Improve tickler add/edit UI layout with jQuery UI resources and styling tweaks to keep the Manage Attachments controls on a single line and expand the edit popup width.
- Update report macro tickler creation to use the new TicklerDocs store for lab attachments.

Build:
- Add database migration script to create the ticklerdocs table, index it, and backfill data from the legacy tickler_link table.

Tests:
- Add integration tests for TicklerDocsDao to verify persistence, filtering, and exclusion of soft-deleted attachments.
- Adjust Doc2PDFIntegrationTest base class and test configuration to register the new TicklerDocs entity and DAO in the modern test context.