### PR TITLE
Feat/tickler attachment component develop

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+# Build output — not needed by any Docker build context (e.g. the db image),
+# and can contain root-owned/unreadable files that break `docker compose build`
+# context tarring.
+target/
+
+# VCS metadata and IDE/editor state
+.git/
+.idea/
+.vscode/
+*.iml
+
+# Local build/tooling artifacts
+node_modules/
+*.log

--- a/database/mysql/oscarinit.sql
+++ b/database/mysql/oscarinit.sql
@@ -8127,6 +8127,21 @@ CREATE TABLE IF NOT EXISTS `consultdocs` (
   `provider_no` varchar(6) NOT NULL
 );
 
+--
+-- CREATE TABLE IF NOT EXISTS ticklerdocs
+--
+CREATE TABLE IF NOT EXISTS `ticklerdocs` (
+  `id` int(10) NOT NULL auto_increment PRIMARY KEY,
+  `tickler_id` int(10) NOT NULL,
+  `document_no` int(10) NOT NULL,
+  `doctype` char(1) NOT NULL,
+  `deleted` char(1) DEFAULT NULL,
+  `attach_date` date,
+  `provider_no` varchar(6) NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS `idx_ticklerdocs_tickler_id` ON `ticklerdocs` (`tickler_id`);
+
 CREATE TABLE IF NOT EXISTS report_letters(
     ID int(10) auto_increment primary key,
     provider_no varchar(6),

--- a/database/mysql/updates/update-2026-06-12-tickler-docs.sql
+++ b/database/mysql/updates/update-2026-06-12-tickler-docs.sql
@@ -25,16 +25,31 @@ CREATE TABLE IF NOT EXISTS `ticklerdocs` (
 CREATE INDEX IF NOT EXISTS `idx_ticklerdocs_tickler_id` ON `ticklerdocs` (`tickler_id`);
 
 -- Backfill existing attachments from tickler_link.
+-- The match deliberately ignores `deleted`: an attachment that was backfilled and later
+-- detached must not be resurrected by a second run.
 INSERT INTO `ticklerdocs` (`tickler_id`, `document_no`, `doctype`, `deleted`, `attach_date`, `provider_no`)
 SELECT
-  tl.`tickler_no`,
-  tl.`table_id`,
-  CASE
-    WHEN tl.`table_name` = 'DOC' THEN 'D'
-    WHEN tl.`table_name` = 'HRM' THEN 'H'
-    ELSE 'L'
-  END,
+  src.`tickler_no`,
+  src.`table_id`,
+  src.`doctype`,
   NULL,
   CURDATE(),
   ''
-FROM `tickler_link` tl;
+FROM (
+  SELECT DISTINCT
+    tl.`tickler_no`,
+    tl.`table_id`,
+    CASE
+      WHEN tl.`table_name` = 'DOC' THEN 'D'
+      WHEN tl.`table_name` = 'HRM' THEN 'H'
+      ELSE 'L'
+    END AS `doctype`
+  FROM `tickler_link` tl
+) src
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM `ticklerdocs` td
+  WHERE td.`tickler_id`  = src.`tickler_no`
+    AND td.`document_no` = src.`table_id`
+    AND td.`doctype`     = src.`doctype`
+);

--- a/database/mysql/updates/update-2026-06-12-tickler-docs.sql
+++ b/database/mysql/updates/update-2026-06-12-tickler-docs.sql
@@ -1,0 +1,40 @@
+-- Issue #2476: Migrate Tickler to the Consult/EForm document attachment component.
+--
+-- Introduces the `ticklerdocs` table (mirrors `consultdocs`/`EFormDocs`) which replaces
+-- the legacy `tickler_link` table as the Tickler attachment store. Existing `tickler_link`
+-- rows are copied into `ticklerdocs` so historical attachments remain visible.
+--
+-- Legacy `tickler_link.table_name` (char(3)) -> new `ticklerdocs.doctype` (char(1)) mapping:
+--   DOC                 -> D (document)
+--   HRM                 -> H (hospital report)
+--   HL7, MDS, CML, BCP  -> L (lab)  (and any other lab source code)
+--
+-- The `tickler_link` table itself is intentionally left in place (REST/Integrator code
+-- still references it); it is simply no longer used by the Tickler UI.
+
+CREATE TABLE IF NOT EXISTS `ticklerdocs` (
+  `id` int(10) NOT NULL auto_increment PRIMARY KEY,
+  `tickler_id` int(10) NOT NULL,
+  `document_no` int(10) NOT NULL,
+  `doctype` char(1) NOT NULL,
+  `deleted` char(1) DEFAULT NULL,
+  `attach_date` date,
+  `provider_no` varchar(6) NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS `idx_ticklerdocs_tickler_id` ON `ticklerdocs` (`tickler_id`);
+
+-- Backfill existing attachments from tickler_link.
+INSERT INTO `ticklerdocs` (`tickler_id`, `document_no`, `doctype`, `deleted`, `attach_date`, `provider_no`)
+SELECT
+  tl.`tickler_no`,
+  tl.`table_id`,
+  CASE
+    WHEN tl.`table_name` = 'DOC' THEN 'D'
+    WHEN tl.`table_name` = 'HRM' THEN 'H'
+    ELSE 'L'
+  END,
+  NULL,
+  CURDATE(),
+  ''
+FROM `tickler_link` tl;

--- a/src/main/java/ca/openosp/openo/commn/dao/PatientLabRoutingDao.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/PatientLabRoutingDao.java
@@ -21,6 +21,15 @@ public interface PatientLabRoutingDao extends AbstractDao<PatientLabRouting> {
 
     public PatientLabRouting findByLabNo(int labNo);
 
+    /**
+     * Batch-finds routing records for a set of lab numbers in a single query, to avoid
+     * per-row lookups when resolving lab sub-types for a page of results.
+     *
+     * @param labNos List&lt;Integer&gt; the lab numbers to fetch routing records for
+     * @return List&lt;PatientLabRouting&gt; routing records matching the given lab numbers (empty if none found)
+     */
+    public List<PatientLabRouting> findByLabNos(List<Integer> labNos);
+
     public List<PatientLabRouting> findByLabNoAndLabType(int labNo, String labType);
 
     public List<Object[]> findUniqueTestNames(Integer demoId, String labType);

--- a/src/main/java/ca/openosp/openo/commn/dao/PatientLabRoutingDaoImpl.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/PatientLabRoutingDaoImpl.java
@@ -20,7 +20,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public class PatientLabRoutingDaoImpl extends AbstractDaoImpl<PatientLabRouting> implements PatientLabRoutingDao {
 
-
     public PatientLabRoutingDaoImpl() {
         super(PatientLabRouting.class);
     }
@@ -73,6 +72,17 @@ public class PatientLabRoutingDaoImpl extends AbstractDaoImpl<PatientLabRouting>
         Query q = entityManager.createQuery(query);
         q.setParameter(1, labNo);
         return this.getSingleResultOrNull(q);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public List<PatientLabRouting> findByLabNos(List<Integer> labNos) {
+        if (labNos == null || labNos.isEmpty()) {
+            return Collections.emptyList();
+        }
+        Query q = entityManager.createQuery("select x from PatientLabRouting x where x.labNo in (:labNos)");
+        q.setParameter("labNos", labNos);
+        return q.getResultList();
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/ca/openosp/openo/commn/dao/TicklerDocsDao.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/TicklerDocsDao.java
@@ -15,9 +15,39 @@ import ca.openosp.openo.commn.model.TicklerDocs;
  * @since 2026-06-12
  */
 public interface TicklerDocsDao extends AbstractDao<TicklerDocs> {
+    /**
+     * Finds a specific non-deleted attachment for a tickler.
+     *
+     * @param ticklerId Integer the tickler's unique identifier
+     * @param documentNo Integer the attached document/lab/eForm/HRM/form identifier
+     * @param docType String the attachment type (see {@link TicklerDocs} DOCTYPE_* constants)
+     * @return List&lt;TicklerDocs&gt; matching, non-deleted attachments (empty if none found)
+     */
     List<TicklerDocs> findByTicklerIdDocNoDocType(Integer ticklerId, Integer documentNo, String docType);
 
+    /**
+     * Finds all non-deleted attachments of a given type for a tickler.
+     *
+     * @param ticklerId Integer the tickler's unique identifier
+     * @param docType String the attachment type (see {@link TicklerDocs} DOCTYPE_* constants)
+     * @return List&lt;TicklerDocs&gt; matching, non-deleted attachments (empty if none found)
+     */
     List<TicklerDocs> findByTicklerIdDocType(Integer ticklerId, String docType);
 
+    /**
+     * Finds all non-deleted attachments for a tickler, regardless of type.
+     *
+     * @param ticklerId Integer the tickler's unique identifier
+     * @return List&lt;TicklerDocs&gt; all non-deleted attachments for the tickler (empty if none found)
+     */
     List<TicklerDocs> findByTicklerId(Integer ticklerId);
+
+    /**
+     * Batch-finds all non-deleted attachments for a set of ticklers in a single query, to avoid
+     * per-row lookups when rendering a page of tickler list results.
+     *
+     * @param ticklerIds List&lt;Integer&gt; the tickler identifiers to fetch attachments for
+     * @return List&lt;TicklerDocs&gt; all non-deleted attachments across the given ticklers (empty if none found)
+     */
+    List<TicklerDocs> findByTicklerIds(List<Integer> ticklerIds);
 }

--- a/src/main/java/ca/openosp/openo/commn/dao/TicklerDocsDao.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/TicklerDocsDao.java
@@ -1,0 +1,23 @@
+//CHECKSTYLE:OFF
+
+package ca.openosp.openo.commn.dao;
+
+import java.util.List;
+
+import ca.openosp.openo.commn.model.TicklerDocs;
+
+/**
+ * Data access for {@link TicklerDocs} (Tickler document attachments).
+ *
+ * <p>Tickler counterpart of {@code ConsultDocsDao}/{@code EFormDocsDao}. All finders exclude
+ * soft-deleted rows ({@code deleted is NULL}).</p>
+ *
+ * @since 2026-06-12
+ */
+public interface TicklerDocsDao extends AbstractDao<TicklerDocs> {
+    List<TicklerDocs> findByTicklerIdDocNoDocType(Integer ticklerId, Integer documentNo, String docType);
+
+    List<TicklerDocs> findByTicklerIdDocType(Integer ticklerId, String docType);
+
+    List<TicklerDocs> findByTicklerId(Integer ticklerId);
+}

--- a/src/main/java/ca/openosp/openo/commn/dao/TicklerDocsDaoImpl.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/TicklerDocsDaoImpl.java
@@ -44,9 +44,6 @@ public class TicklerDocsDaoImpl extends AbstractDaoImpl<TicklerDocs> implements 
         query.setParameter(2, docType);
 
         List<TicklerDocs> results = query.getResultList();
-        if (results == null) {
-            return Collections.emptyList();
-        }
         return results;
     }
 
@@ -55,6 +52,19 @@ public class TicklerDocsDaoImpl extends AbstractDaoImpl<TicklerDocs> implements 
         String sql = "select x from TicklerDocs x where x.ticklerId=?1 and x.deleted is NULL";
         Query query = entityManager.createQuery(sql);
         query.setParameter(1, ticklerId);
+
+        List<TicklerDocs> results = query.getResultList();
+        return results;
+    }
+
+    @Override
+    public List<TicklerDocs> findByTicklerIds(List<Integer> ticklerIds) {
+        if (ticklerIds == null || ticklerIds.isEmpty()) {
+            return Collections.emptyList();
+        }
+        String sql = "select x from TicklerDocs x where x.ticklerId in (:ticklerIds) and x.deleted is NULL";
+        Query query = entityManager.createQuery(sql);
+        query.setParameter("ticklerIds", ticklerIds);
 
         List<TicklerDocs> results = query.getResultList();
         return results;

--- a/src/main/java/ca/openosp/openo/commn/dao/TicklerDocsDaoImpl.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/TicklerDocsDaoImpl.java
@@ -1,0 +1,59 @@
+//CHECKSTYLE:OFF
+
+package ca.openosp.openo.commn.dao;
+
+import java.util.Collections;
+import java.util.List;
+
+import javax.persistence.Query;
+
+import ca.openosp.openo.commn.model.TicklerDocs;
+import org.springframework.stereotype.Repository;
+
+/**
+ * Default {@link TicklerDocsDao} implementation. Mirrors {@code ConsultDocsDaoImpl}; every query
+ * filters out soft-deleted rows with {@code x.deleted is NULL}.
+ *
+ * @since 2026-06-12
+ */
+@Repository
+@SuppressWarnings("unchecked")
+public class TicklerDocsDaoImpl extends AbstractDaoImpl<TicklerDocs> implements TicklerDocsDao {
+
+    public TicklerDocsDaoImpl() {
+        super(TicklerDocs.class);
+    }
+
+    public List<TicklerDocs> findByTicklerIdDocNoDocType(Integer ticklerId, Integer documentNo, String docType) {
+        String sql = "select x from TicklerDocs x where x.ticklerId=?1 and x.documentNo=?2 and x.docType=?3 and x.deleted is NULL";
+        Query query = entityManager.createQuery(sql);
+        query.setParameter(1, ticklerId);
+        query.setParameter(2, documentNo);
+        query.setParameter(3, docType);
+
+        List<TicklerDocs> results = query.getResultList();
+        return results;
+    }
+
+    public List<TicklerDocs> findByTicklerIdDocType(Integer ticklerId, String docType) {
+        String sql = "select x from TicklerDocs x where x.ticklerId=?1 and x.docType=?2 and x.deleted is NULL";
+        Query query = entityManager.createQuery(sql);
+        query.setParameter(1, ticklerId);
+        query.setParameter(2, docType);
+
+        List<TicklerDocs> results = query.getResultList();
+        if (results == null) {
+            return Collections.emptyList();
+        }
+        return results;
+    }
+
+    public List<TicklerDocs> findByTicklerId(Integer ticklerId) {
+        String sql = "select x from TicklerDocs x where x.ticklerId=?1 and x.deleted is NULL";
+        Query query = entityManager.createQuery(sql);
+        query.setParameter(1, ticklerId);
+
+        List<TicklerDocs> results = query.getResultList();
+        return results;
+    }
+}

--- a/src/main/java/ca/openosp/openo/commn/dao/TicklerDocsDaoImpl.java
+++ b/src/main/java/ca/openosp/openo/commn/dao/TicklerDocsDaoImpl.java
@@ -24,6 +24,7 @@ public class TicklerDocsDaoImpl extends AbstractDaoImpl<TicklerDocs> implements 
         super(TicklerDocs.class);
     }
 
+    @Override
     public List<TicklerDocs> findByTicklerIdDocNoDocType(Integer ticklerId, Integer documentNo, String docType) {
         String sql = "select x from TicklerDocs x where x.ticklerId=?1 and x.documentNo=?2 and x.docType=?3 and x.deleted is NULL";
         Query query = entityManager.createQuery(sql);
@@ -35,6 +36,7 @@ public class TicklerDocsDaoImpl extends AbstractDaoImpl<TicklerDocs> implements 
         return results;
     }
 
+    @Override
     public List<TicklerDocs> findByTicklerIdDocType(Integer ticklerId, String docType) {
         String sql = "select x from TicklerDocs x where x.ticklerId=?1 and x.docType=?2 and x.deleted is NULL";
         Query query = entityManager.createQuery(sql);
@@ -48,6 +50,7 @@ public class TicklerDocsDaoImpl extends AbstractDaoImpl<TicklerDocs> implements 
         return results;
     }
 
+    @Override
     public List<TicklerDocs> findByTicklerId(Integer ticklerId) {
         String sql = "select x from TicklerDocs x where x.ticklerId=?1 and x.deleted is NULL";
         Query query = entityManager.createQuery(sql);

--- a/src/main/java/ca/openosp/openo/commn/model/TicklerDocs.java
+++ b/src/main/java/ca/openosp/openo/commn/model/TicklerDocs.java
@@ -1,0 +1,149 @@
+//CHECKSTYLE:OFF
+/**
+ * Copyright (c) 2001-2002. Department of Family Medicine, McMaster University. All Rights Reserved.
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ * <p>
+ * This software was written for the
+ * Department of Family Medicine
+ * McMaster University
+ * Hamilton
+ * Ontario, Canada
+ */
+
+
+package ca.openosp.openo.commn.model;
+
+import java.util.Date;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+
+/**
+ * Links a document (document, lab, eForm, HRM report or encounter form) to a Tickler.
+ *
+ * <p>This is the Tickler counterpart of {@link ConsultDocs} and {@code EFormDocs}; it backs the
+ * shared document attachment component (see {@code documentManager/attachDocument.jsp}). Detached
+ * attachments are soft-deleted by setting {@link #deleted} to {@link #DELETED} rather than being
+ * physically removed.</p>
+ *
+ * @since 2026-06-12
+ */
+@Entity
+@Table(name = "ticklerdocs")
+public class TicklerDocs extends AbstractModel<Integer> {
+    public static final String DOCTYPE_DOC = "D";
+    public static final String DOCTYPE_EFORM = "E";
+    public static final String DOCTYPE_LAB = "L";
+
+    public static final String DOCTYPE_FORM = "F";
+    public static final String DOCTYPE_HRM = "H";
+    public static final String DELETED = "Y";
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @Column(name = "tickler_id")
+    private int ticklerId;
+
+    @Column(name = "document_no")
+    private int documentNo;
+
+    @Column(name = "doctype")
+    private String docType;
+
+    private String deleted;
+
+    @Column(name = "attach_date")
+    @Temporal(TemporalType.DATE)
+    private Date attachDate;
+
+    @Column(name = "provider_no")
+    private String providerNo;
+
+    public TicklerDocs() {
+    }
+
+    public TicklerDocs(int ticklerId, int documentNo, String docType, String providerNo) {
+        setTicklerId(ticklerId);
+        setDocumentNo(documentNo);
+        setDocType(docType);
+        setProviderNo(providerNo);
+        setAttachDate(new Date());
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public int getTicklerId() {
+        return ticklerId;
+    }
+
+    public void setTicklerId(int ticklerId) {
+        this.ticklerId = ticklerId;
+    }
+
+    public int getDocumentNo() {
+        return documentNo;
+    }
+
+    public void setDocumentNo(int documentNo) {
+        this.documentNo = documentNo;
+    }
+
+    public String getDocType() {
+        return docType;
+    }
+
+    public void setDocType(String docType) {
+        this.docType = docType;
+    }
+
+    public String getDeleted() {
+        return deleted;
+    }
+
+    public void setDeleted(String deleted) {
+        this.deleted = deleted;
+    }
+
+    public Date getAttachDate() {
+        return attachDate;
+    }
+
+    public void setAttachDate(Date attachDate) {
+        this.attachDate = attachDate;
+    }
+
+    public String getProviderNo() {
+        return providerNo;
+    }
+
+    public void setProviderNo(String providerNo) {
+        this.providerNo = providerNo;
+    }
+}

--- a/src/main/java/ca/openosp/openo/commn/model/TicklerDocs.java
+++ b/src/main/java/ca/openosp/openo/commn/model/TicklerDocs.java
@@ -91,6 +91,7 @@ public class TicklerDocs extends AbstractModel<Integer> {
         setAttachDate(new Date());
     }
 
+    @Override
     public Integer getId() {
         return id;
     }

--- a/src/main/java/ca/openosp/openo/commn/model/enumerator/DocumentType.java
+++ b/src/main/java/ca/openosp/openo/commn/model/enumerator/DocumentType.java
@@ -23,4 +23,19 @@ public enum DocumentType {
     public String getName() {
         return this.name;
     }
+
+    /**
+     * Resolves a DocumentType from its single-letter type code.
+     *
+     * @param type String the type code (e.g. "D", "L")
+     * @return DocumentType the matching type, or null if unknown
+     */
+    public static DocumentType fromType(String type) {
+        for (DocumentType documentType : values()) {
+            if (documentType.type.equals(type)) {
+                return documentType;
+            }
+        }
+        return null;
+    }
 }

--- a/src/main/java/ca/openosp/openo/documentManager/DocumentAttach.java
+++ b/src/main/java/ca/openosp/openo/documentManager/DocumentAttach.java
@@ -145,7 +145,7 @@ public class DocumentAttach {
             }
             List<TicklerDocs> detachList = ticklerDocsDao.findByTicklerIdDocNoDocType(ticklerId, Integer.valueOf(docId), documentType.getType());
             for (TicklerDocs ticklerDoc : detachList) {
-                ticklerDoc.setDeleted("Y");
+                ticklerDoc.setDeleted(TicklerDocs.DELETED);
                 ticklerDocsDao.merge(ticklerDoc);
             }
         }

--- a/src/main/java/ca/openosp/openo/documentManager/DocumentAttach.java
+++ b/src/main/java/ca/openosp/openo/documentManager/DocumentAttach.java
@@ -3,8 +3,10 @@ package ca.openosp.openo.documentManager;
 
 import ca.openosp.openo.commn.dao.ConsultDocsDao;
 import ca.openosp.openo.commn.dao.EFormDocsDao;
+import ca.openosp.openo.commn.dao.TicklerDocsDao;
 import ca.openosp.openo.commn.model.ConsultDocs;
 import ca.openosp.openo.commn.model.EFormDocs;
+import ca.openosp.openo.commn.model.TicklerDocs;
 import ca.openosp.openo.commn.model.enumerator.DocumentType;
 import ca.openosp.openo.utility.SpringUtils;
 
@@ -17,6 +19,7 @@ import java.util.List;
 public class DocumentAttach {
     private final ConsultDocsDao consultDocsDao = SpringUtils.getBean(ConsultDocsDao.class);
     private final EFormDocsDao eFormDocsDao = SpringUtils.getBean(EFormDocsDao.class);
+    private final TicklerDocsDao ticklerDocsDao = SpringUtils.getBean(TicklerDocsDao.class);
 
     /*
      * When editOnOcean is set to false, it signifies a normal consult request, performing just attach or detach operations on the consult request form.
@@ -110,6 +113,40 @@ public class DocumentAttach {
             for (EFormDocs eFormDoc : detachList) {
                 eFormDoc.setDeleted("Y");
                 eFormDocsDao.merge(eFormDoc);
+            }
+        }
+    }
+
+    public void attachToTickler(String[] attachments, DocumentType documentType, String providerNo, Integer ticklerId) {
+        List<String> currentList = new ArrayList<>(Arrays.asList(attachments));
+        List<TicklerDocs> ticklerDocsList = ticklerDocsDao.findByTicklerIdDocType(ticklerId, documentType.getType());
+        List<String> oldList = new ArrayList<>();
+        for (TicklerDocs ticklerDoc : ticklerDocsList) {
+            oldList.add(Integer.toString(ticklerDoc.getDocumentNo()));
+        }
+        detachFromTickler(currentList, oldList, documentType, ticklerId);
+        attachToTickler(currentList, oldList, documentType, providerNo, ticklerId);
+    }
+
+    private void attachToTickler(List<String> currentList, List<String> oldList, DocumentType documentType, String providerNo, Integer ticklerId) {
+        for (String docId : currentList) {
+            if (oldList.contains(docId)) {
+                continue;
+            }
+            TicklerDocs ticklerDocs = new TicklerDocs(ticklerId, Integer.parseInt(docId), documentType.getType(), providerNo);
+            ticklerDocsDao.persist(ticklerDocs);
+        }
+    }
+
+    private void detachFromTickler(List<String> currentList, List<String> oldList, DocumentType documentType, Integer ticklerId) {
+        for (String docId : oldList) {
+            if (currentList.contains(docId)) {
+                continue;
+            }
+            List<TicklerDocs> detachList = ticklerDocsDao.findByTicklerIdDocNoDocType(ticklerId, Integer.valueOf(docId), documentType.getType());
+            for (TicklerDocs ticklerDoc : detachList) {
+                ticklerDoc.setDeleted("Y");
+                ticklerDocsDao.merge(ticklerDoc);
             }
         }
     }

--- a/src/main/java/ca/openosp/openo/documentManager/DocumentAttachmentManager.java
+++ b/src/main/java/ca/openosp/openo/documentManager/DocumentAttachmentManager.java
@@ -92,6 +92,19 @@ public interface DocumentAttachmentManager {
     public List<EctFormData.PatientForm> getFormsAttachedToEForms(LoggedInInfo loggedInInfo, Integer fdid, DocumentType documentType, Integer demographicNo);
 
     /**
+     * Maps every encounter form belonging to a patient to its form name, keyed by form id.
+     *
+     * <p>Attachment tables store only {@code (document_no, doctype)}, which cannot identify a form
+     * because encounter forms span roughly forty tables with independent id sequences.</p>
+     *
+     * @param loggedInInfo LoggedInInfo the current user's session information
+     * @param demographicNo Integer the patient's unique demographic identifier
+     * @return Map&lt;String, String&gt; form id to form name; empty when the demographic is null or
+     *         the user lacks "_form" read, so callers should render the attachment as non-clickable
+     */
+    public Map<String, String> getFormNamesByFormId(LoggedInInfo loggedInInfo, Integer demographicNo);
+
+    /**
      * This method is responsible for lab version sorting and is intended for use in the attachment window (attachDocument.jsp).
      * In other parts of the application, developers should utilize CommonLabResultData.populateLabResultsData() to access all available lab data.
      */

--- a/src/main/java/ca/openosp/openo/documentManager/DocumentAttachmentManager.java
+++ b/src/main/java/ca/openosp/openo/documentManager/DocumentAttachmentManager.java
@@ -3,6 +3,7 @@ package ca.openosp.openo.documentManager;
 
 import ca.openosp.openo.commn.model.EFormData;
 import ca.openosp.openo.documentManager.data.AttachmentLabResultData;
+import ca.openosp.openo.documentManager.data.TicklerAttachmentData;
 import ca.openosp.openo.commn.model.enumerator.DocumentType;
 import ca.openosp.openo.utility.LoggedInInfo;
 import ca.openosp.openo.utility.PDFGenerationException;
@@ -177,6 +178,17 @@ public interface DocumentAttachmentManager {
      * @return List&lt;String&gt; list of document identifiers attached to the tickler
      */
     public List<String> getTicklerAttachments(LoggedInInfo loggedInInfo, Integer ticklerId, DocumentType documentType, Integer demographicNo);
+
+    /**
+     * Retrieves every attachment on a tickler, of all types, with display names resolved.
+     * Used to render the named attachment lists in the Add/Edit Tickler windows.
+     *
+     * @param loggedInInfo LoggedInInfo the current user's session information
+     * @param ticklerId Integer the unique identifier of the tickler
+     * @param demographicNo Integer the patient's unique demographic identifier
+     * @return List&lt;TicklerAttachmentData&gt; all attachments with display names (empty if none)
+     */
+    public List<TicklerAttachmentData> getTicklerAttachmentDetails(LoggedInInfo loggedInInfo, Integer ticklerId, Integer demographicNo);
 
     /**
      * Attaches documents to a tickler.

--- a/src/main/java/ca/openosp/openo/documentManager/DocumentAttachmentManager.java
+++ b/src/main/java/ca/openosp/openo/documentManager/DocumentAttachmentManager.java
@@ -164,6 +164,37 @@ public interface DocumentAttachmentManager {
     public void attachToEForm(LoggedInInfo loggedInInfo, DocumentType documentType, String[] attachments, String providerNo, Integer fdid, Integer demographicNo);
 
     /**
+     * Retrieves all attachments of a given type associated with a specific tickler.
+     *
+     * <p>Tickler counterpart of {@link #getConsultAttachments} and {@link #getEFormAttachments}.
+     * Returns the document identifiers currently attached to the tickler for the requested
+     * document type (document, lab, eForm, HRM report or encounter form).</p>
+     *
+     * @param loggedInInfo LoggedInInfo the current user's session information for security and audit purposes
+     * @param ticklerId Integer the unique identifier of the tickler
+     * @param documentType DocumentType the type of documents to retrieve
+     * @param demographicNo Integer the patient's unique demographic identifier
+     * @return List&lt;String&gt; list of document identifiers attached to the tickler
+     */
+    public List<String> getTicklerAttachments(LoggedInInfo loggedInInfo, Integer ticklerId, DocumentType documentType, Integer demographicNo);
+
+    /**
+     * Attaches documents to a tickler.
+     *
+     * <p>Tickler counterpart of {@link #attachToConsult} and {@link #attachToEForm}. Synchronises the
+     * supplied set of document identifiers with the tickler's existing attachments of the given type:
+     * new identifiers are persisted and identifiers no longer present are soft-deleted.</p>
+     *
+     * @param loggedInInfo LoggedInInfo the current user's session information for security and audit purposes
+     * @param documentType DocumentType the type of documents being attached
+     * @param attachments String[] array of document identifiers that should be attached to the tickler
+     * @param providerNo String the provider number performing the attachment operation
+     * @param ticklerId Integer the unique identifier of the tickler
+     * @param demographicNo Integer the patient's unique demographic identifier
+     */
+    public void attachToTickler(LoggedInInfo loggedInInfo, DocumentType documentType, String[] attachments, String providerNo, Integer ticklerId, Integer demographicNo);
+
+    /**
      * Concatenates multiple PDF documents into a single PDF file.
      *
      * <p>This method combines a list of PDF document objects into a single consolidated PDF file.

--- a/src/main/java/ca/openosp/openo/documentManager/DocumentAttachmentManager.java
+++ b/src/main/java/ca/openosp/openo/documentManager/DocumentAttachmentManager.java
@@ -95,7 +95,8 @@ public interface DocumentAttachmentManager {
      * Maps every encounter form belonging to a patient to its form name, keyed by form id.
      *
      * <p>Attachment tables store only {@code (document_no, doctype)}, which cannot identify a form
-     * because encounter forms span roughly forty tables with independent id sequences.</p>
+     * because encounter forms span roughly forty tables with independent id sequences. Ids shared
+     * by two form types are therefore omitted rather than resolved to one of them at random.</p>
      *
      * @param loggedInInfo LoggedInInfo the current user's session information
      * @param demographicNo Integer the patient's unique demographic identifier
@@ -103,6 +104,19 @@ public interface DocumentAttachmentManager {
      *         the user lacks "_form" read, so callers should render the attachment as non-clickable
      */
     public Map<String, String> getFormNamesByFormId(LoggedInInfo loggedInInfo, Integer demographicNo);
+
+    /**
+     * Batched form of {@link #getFormNamesByFormId}, for rendering lists spanning many patients.
+     *
+     * <p>Reads the encounter form configuration once for the whole batch rather than once per
+     * patient, which is where nearly all of the per-patient cost otherwise goes.</p>
+     *
+     * @param loggedInInfo LoggedInInfo the current user's session information
+     * @param demographicNos Collection&lt;Integer&gt; the patients to resolve; may be empty
+     * @return Map&lt;Integer, Map&lt;String, String&gt;&gt; demographic number to that patient's form
+     *         id to form name lookup; empty when the user lacks "_form" read
+     */
+    public Map<Integer, Map<String, String>> getFormNamesByDemographic(LoggedInInfo loggedInInfo, Collection<Integer> demographicNos);
 
     /**
      * This method is responsible for lab version sorting and is intended for use in the attachment window (attachDocument.jsp).

--- a/src/main/java/ca/openosp/openo/documentManager/DocumentAttachmentManagerImpl.java
+++ b/src/main/java/ca/openosp/openo/documentManager/DocumentAttachmentManagerImpl.java
@@ -191,6 +191,28 @@ public class DocumentAttachmentManagerImpl implements DocumentAttachmentManager 
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Map<String, String> getFormNamesByFormId(LoggedInInfo loggedInInfo, Integer demographicNo) {
+        // FormsManager throws when "_form" read is missing, which would abort whatever list is
+        // being rendered. Degrade to unresolved names instead, checking the same way it does.
+        if (demographicNo == null
+                || !securityInfoManager.hasPrivilege(loggedInInfo, "_form", SecurityInfoManager.READ, null)) {
+            return Collections.emptyMap();
+        }
+
+        Map<String, String> formNames = new HashMap<>();
+        // getAllVersions must stay true: an attached form stops being the patient's latest as soon
+        // as a newer one of the same type is created, and it still has to resolve.
+        for (EctFormData.PatientForm form
+                : formsManager.getEncounterFormsbyDemographicNumber(loggedInInfo, demographicNo, true, true)) {
+            formNames.put(form.getFormId(), form.getFormName());
+        }
+        return formNames;
+    }
+
+    /**
      * Retrieves all laboratory results for a patient, sorted and grouped by version relationships.
      *
      * This method is specifically designed for the attachment window (attachDocument.jsp) to present
@@ -423,7 +445,7 @@ public class DocumentAttachmentManagerImpl implements DocumentAttachmentManager 
         List<TicklerAttachmentData> attachmentDetails = new ArrayList<>();
         Map<String, String> labNamesBySegmentId = null;
         ArrayList<HashMap<String, ? extends Object>> allHrmDocuments = null;
-        List<EctFormData.PatientForm> allForms = null;
+        Map<String, String> formNamesByFormId = null;
 
         for (TicklerDocs ticklerDoc : ticklerDocsDao.findByTicklerId(ticklerId)) {
             DocumentType documentType = DocumentType.fromType(ticklerDoc.getDocType());
@@ -464,15 +486,10 @@ public class DocumentAttachmentManagerImpl implements DocumentAttachmentManager 
                     }
                     break;
                 case FORM:
-                    if (allForms == null) {
-                        allForms = formsManager.getEncounterFormsbyDemographicNumber(loggedInInfo, demographicNo, false, true);
+                    if (formNamesByFormId == null) {
+                        formNamesByFormId = getFormNamesByFormId(loggedInInfo, demographicNo);
                     }
-                    for (EctFormData.PatientForm form : allForms) {
-                        if (documentId.equals(form.getFormId())) {
-                            displayName = form.getFormName();
-                            break;
-                        }
-                    }
+                    displayName = formNamesByFormId.get(documentId);
                     break;
             }
 

--- a/src/main/java/ca/openosp/openo/documentManager/DocumentAttachmentManagerImpl.java
+++ b/src/main/java/ca/openosp/openo/documentManager/DocumentAttachmentManagerImpl.java
@@ -6,6 +6,8 @@ import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.interactive.form.PDAcroForm;
 import ca.openosp.openo.commn.dao.ConsultDocsDao;
 import ca.openosp.openo.commn.dao.EFormDocsDao;
+import ca.openosp.openo.commn.dao.TicklerDocsDao;
+import ca.openosp.openo.commn.model.TicklerDocs;
 import ca.openosp.openo.commn.model.ConsultDocs;
 import ca.openosp.openo.commn.model.EFormData;
 import ca.openosp.openo.commn.model.EFormDocs;
@@ -75,6 +77,8 @@ public class DocumentAttachmentManagerImpl implements DocumentAttachmentManager 
     private ca.openosp.openo.commn.dao.PatientLabRoutingDao patientLabRoutingDao;
     @Autowired
     private ca.openosp.openo.commn.dao.EFormDataDao eFormDataDao;
+    @Autowired
+    private TicklerDocsDao ticklerDocsDao;
 
     @Autowired
     private ConsultationManager consultationManager;
@@ -369,6 +373,56 @@ public class DocumentAttachmentManagerImpl implements DocumentAttachmentManager 
 
         DocumentAttach documentAttach = new DocumentAttach();
         documentAttach.attachToEForm(attachments, documentType, providerNo, fdid);
+    }
+
+    /**
+     * Retrieves a list of document IDs attached to a specific tickler.
+     *
+     * Tickler counterpart of {@link #getConsultAttachments} and {@link #getEFormAttachments}. Security
+     * checks ensure the user has read access to tickler data for the specified patient.
+     *
+     * @param loggedInInfo LoggedInInfo the current user's session information
+     * @param ticklerId Integer the unique identifier of the tickler
+     * @param documentType DocumentType the type of documents to retrieve (e.g., DOC, LAB, EFORM, HRM, FORM)
+     * @param demographicNo Integer the patient's demographic number for security validation
+     * @return List&lt;String&gt; a list of document IDs as strings attached to the tickler
+     * @throws RuntimeException if the user lacks the required "_tickler" read privilege
+     */
+    public List<String> getTicklerAttachments(LoggedInInfo loggedInInfo, Integer ticklerId, DocumentType documentType, Integer demographicNo) {
+        if (!securityInfoManager.hasPrivilege(loggedInInfo, "_tickler", SecurityInfoManager.READ, demographicNo)) {
+            throw new RuntimeException("missing required sec object (_tickler)");
+        }
+
+        List<String> ticklerAttachments = new ArrayList<>();
+        List<TicklerDocs> ticklerDocs = ticklerDocsDao.findByTicklerIdDocType(ticklerId, documentType.getType());
+        for (TicklerDocs ticklerDocs1 : ticklerDocs) {
+            ticklerAttachments.add(String.valueOf(ticklerDocs1.getDocumentNo()));
+        }
+        return ticklerAttachments;
+    }
+
+    /**
+     * Attaches documents to a tickler.
+     *
+     * Tickler counterpart of {@link #attachToConsult} and {@link #attachToEForm}. Synchronises the supplied
+     * set of document IDs with the tickler's existing attachments of the given type, persisting new
+     * attachments and soft-deleting those no longer present.
+     *
+     * @param loggedInInfo LoggedInInfo the current user's session information
+     * @param documentType DocumentType the type of documents being attached
+     * @param attachments String[] an array of document IDs to attach to the tickler
+     * @param providerNo String the provider number performing the attachment operation
+     * @param ticklerId Integer the unique identifier of the tickler
+     * @param demographicNo Integer the patient's demographic number for security validation
+     * @throws RuntimeException if the user lacks the required "_tickler" write privilege
+     */
+    public void attachToTickler(LoggedInInfo loggedInInfo, DocumentType documentType, String[] attachments, String providerNo, Integer ticklerId, Integer demographicNo) {
+        if (!securityInfoManager.hasPrivilege(loggedInInfo, "_tickler", SecurityInfoManager.WRITE, demographicNo)) {
+            throw new RuntimeException("missing required sec object (_tickler)");
+        }
+
+        DocumentAttach documentAttach = new DocumentAttach();
+        documentAttach.attachToTickler(attachments, documentType, providerNo, ticklerId);
     }
 
     /**

--- a/src/main/java/ca/openosp/openo/documentManager/DocumentAttachmentManagerImpl.java
+++ b/src/main/java/ca/openosp/openo/documentManager/DocumentAttachmentManagerImpl.java
@@ -388,6 +388,7 @@ public class DocumentAttachmentManagerImpl implements DocumentAttachmentManager 
      * @return List&lt;String&gt; a list of document IDs as strings attached to the tickler
      * @throws RuntimeException if the user lacks the required "_tickler" read privilege
      */
+    @Override
     public List<String> getTicklerAttachments(LoggedInInfo loggedInInfo, Integer ticklerId, DocumentType documentType, Integer demographicNo) {
         if (!securityInfoManager.hasPrivilege(loggedInInfo, "_tickler", SecurityInfoManager.READ, demographicNo)) {
             throw new RuntimeException("missing required sec object (_tickler)");
@@ -416,6 +417,7 @@ public class DocumentAttachmentManagerImpl implements DocumentAttachmentManager 
      * @param demographicNo Integer the patient's demographic number for security validation
      * @throws RuntimeException if the user lacks the required "_tickler" write privilege
      */
+    @Override
     public void attachToTickler(LoggedInInfo loggedInInfo, DocumentType documentType, String[] attachments, String providerNo, Integer ticklerId, Integer demographicNo) {
         if (!securityInfoManager.hasPrivilege(loggedInInfo, "_tickler", SecurityInfoManager.WRITE, demographicNo)) {
             throw new RuntimeException("missing required sec object (_tickler)");

--- a/src/main/java/ca/openosp/openo/documentManager/DocumentAttachmentManagerImpl.java
+++ b/src/main/java/ca/openosp/openo/documentManager/DocumentAttachmentManagerImpl.java
@@ -195,20 +195,52 @@ public class DocumentAttachmentManagerImpl implements DocumentAttachmentManager 
      */
     @Override
     public Map<String, String> getFormNamesByFormId(LoggedInInfo loggedInInfo, Integer demographicNo) {
+        if (demographicNo == null) {
+            return Collections.emptyMap();
+        }
+        return getFormNamesByDemographic(loggedInInfo, Collections.singletonList(demographicNo))
+                .getOrDefault(demographicNo, Collections.emptyMap());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Map<Integer, Map<String, String>> getFormNamesByDemographic(LoggedInInfo loggedInInfo,
+                                                                       Collection<Integer> demographicNos) {
         // FormsManager throws when "_form" read is missing, which would abort whatever list is
         // being rendered. Degrade to unresolved names instead, checking the same way it does.
-        if (demographicNo == null
+        if (demographicNos == null || demographicNos.isEmpty()
                 || !securityInfoManager.hasPrivilege(loggedInInfo, "_form", SecurityInfoManager.READ, null)) {
             return Collections.emptyMap();
         }
 
-        Map<String, String> formNames = new HashMap<>();
         // getAllVersions must stay true: an attached form stops being the patient's latest as soon
         // as a newer one of the same type is created, and it still has to resolve.
-        for (EctFormData.PatientForm form
-                : formsManager.getEncounterFormsbyDemographicNumber(loggedInInfo, demographicNo, true, true)) {
-            formNames.put(form.getFormId(), form.getFormName());
+        Map<Integer, List<EctFormData.PatientForm>> formsByDemographic =
+                formsManager.getEncounterFormsByDemographicNumbers(loggedInInfo, demographicNos, true, true);
+
+        Map<Integer, Map<String, String>> formNamesByDemographic = new HashMap<>();
+        for (Map.Entry<Integer, List<EctFormData.PatientForm>> entry : formsByDemographic.entrySet()) {
+            formNamesByDemographic.put(entry.getKey(), toFormNamesByFormId(entry.getValue()));
         }
+        return formNamesByDemographic;
+    }
+
+    /**
+     * Keys one patient's forms by form id, dropping ids claimed by more than one form type.
+     */
+    private Map<String, String> toFormNamesByFormId(List<EctFormData.PatientForm> forms) {
+        Map<String, String> formNames = new HashMap<>();
+        Set<String> ambiguousFormIds = new HashSet<>();
+        for (EctFormData.PatientForm form : forms) {
+            // A repeated id means two form types claim it and the attachment cannot say which.
+            // Dropping both is safer than linking to another form's record.
+            if (formNames.put(form.getFormId(), form.getFormName()) != null) {
+                ambiguousFormIds.add(form.getFormId());
+            }
+        }
+        formNames.keySet().removeAll(ambiguousFormIds);
         return formNames;
     }
 

--- a/src/main/java/ca/openosp/openo/documentManager/DocumentAttachmentManagerImpl.java
+++ b/src/main/java/ca/openosp/openo/documentManager/DocumentAttachmentManagerImpl.java
@@ -7,6 +7,7 @@ import org.apache.pdfbox.pdmodel.interactive.form.PDAcroForm;
 import ca.openosp.openo.commn.dao.ConsultDocsDao;
 import ca.openosp.openo.commn.dao.EFormDocsDao;
 import ca.openosp.openo.commn.dao.TicklerDocsDao;
+import ca.openosp.openo.commn.model.Document;
 import ca.openosp.openo.commn.model.TicklerDocs;
 import ca.openosp.openo.commn.model.ConsultDocs;
 import ca.openosp.openo.commn.model.EFormData;
@@ -14,6 +15,7 @@ import ca.openosp.openo.commn.model.EFormDocs;
 import ca.openosp.openo.hospitalReportManager.HRMUtil;
 import ca.openosp.openo.commn.model.enumerator.DocumentType;
 import ca.openosp.openo.documentManager.data.AttachmentLabResultData;
+import ca.openosp.openo.documentManager.data.TicklerAttachmentData;
 import ca.openosp.openo.utility.DateUtils;
 import ca.openosp.openo.utility.LoggedInInfo;
 import ca.openosp.openo.utility.PDFGenerationException;
@@ -400,6 +402,104 @@ public class DocumentAttachmentManagerImpl implements DocumentAttachmentManager 
             ticklerAttachments.add(String.valueOf(ticklerDocs1.getDocumentNo()));
         }
         return ticklerAttachments;
+    }
+
+    /**
+     * Retrieves every attachment on a tickler with its display name resolved. Patient-wide
+     * lookups (labs, HRM, forms) are loaded lazily, only when that type is attached.
+     *
+     * @param loggedInInfo LoggedInInfo the current user's session information
+     * @param ticklerId Integer the unique identifier of the tickler
+     * @param demographicNo Integer the patient's demographic number for security validation
+     * @return List&lt;TicklerAttachmentData&gt; all attachments with display names (empty if none)
+     * @throws RuntimeException if the user lacks the required "_tickler" read privilege
+     */
+    @Override
+    public List<TicklerAttachmentData> getTicklerAttachmentDetails(LoggedInInfo loggedInInfo, Integer ticklerId, Integer demographicNo) {
+        if (!securityInfoManager.hasPrivilege(loggedInInfo, "_tickler", SecurityInfoManager.READ, demographicNo)) {
+            throw new RuntimeException("missing required sec object (_tickler)");
+        }
+
+        List<TicklerAttachmentData> attachmentDetails = new ArrayList<>();
+        Map<String, String> labNamesBySegmentId = null;
+        ArrayList<HashMap<String, ? extends Object>> allHrmDocuments = null;
+        List<EctFormData.PatientForm> allForms = null;
+
+        for (TicklerDocs ticklerDoc : ticklerDocsDao.findByTicklerId(ticklerId)) {
+            DocumentType documentType = DocumentType.fromType(ticklerDoc.getDocType());
+            if (documentType == null) {
+                continue;
+            }
+            String documentId = String.valueOf(ticklerDoc.getDocumentNo());
+            String displayName = null;
+
+            switch (documentType) {
+                case DOC:
+                    Document document = documentDao.getDocument(documentId);
+                    if (document != null) {
+                        displayName = document.getDocdesc();
+                    }
+                    break;
+                case LAB:
+                    if (labNamesBySegmentId == null) {
+                        labNamesBySegmentId = buildLabNamesBySegmentId(loggedInInfo, demographicNo);
+                    }
+                    displayName = labNamesBySegmentId.get(documentId);
+                    break;
+                case EFORM:
+                    EFormData eForm = eFormDataDao.find(ticklerDoc.getDocumentNo());
+                    if (eForm != null) {
+                        displayName = eForm.getFormName();
+                    }
+                    break;
+                case HRM:
+                    if (allHrmDocuments == null) {
+                        allHrmDocuments = HRMUtil.listHRMDocuments(loggedInInfo, "report_date", false, String.valueOf(demographicNo), false);
+                    }
+                    for (HashMap<String, ? extends Object> hrmDocument : allHrmDocuments) {
+                        if (documentId.equals(String.valueOf(hrmDocument.get("id")))) {
+                            displayName = String.valueOf(hrmDocument.get("name"));
+                            break;
+                        }
+                    }
+                    break;
+                case FORM:
+                    if (allForms == null) {
+                        allForms = formsManager.getEncounterFormsbyDemographicNumber(loggedInInfo, demographicNo, false, true);
+                    }
+                    for (EctFormData.PatientForm form : allForms) {
+                        if (documentId.equals(form.getFormId())) {
+                            displayName = form.getFormName();
+                            break;
+                        }
+                    }
+                    break;
+            }
+
+            if (StringUtils.isNullOrEmpty(displayName)) {
+                displayName = documentType.getName() + " #" + documentId;
+            }
+            attachmentDetails.add(new TicklerAttachmentData(documentType, documentId, displayName));
+        }
+        return attachmentDetails;
+    }
+
+    /**
+     * Maps every lab segment id to its display name; older versions are prefixed "vN"
+     * to match the attachment picker's labels.
+     */
+    private Map<String, String> buildLabNamesBySegmentId(LoggedInInfo loggedInInfo, Integer demographicNo) {
+        Map<String, String> labNames = new HashMap<>();
+        for (AttachmentLabResultData lab : getAllLabsSortedByVersions(loggedInInfo, String.valueOf(demographicNo))) {
+            labNames.put(lab.getSegmentID(), lab.getLabName());
+            int totalVersions = lab.getLabVersionIds().size();
+            int index = 0;
+            for (String versionSegmentId : lab.getLabVersionIds().keySet()) {
+                labNames.put(versionSegmentId, "v" + (totalVersions - index) + " " + lab.getLabName());
+                index++;
+            }
+        }
+        return labNames;
     }
 
     /**

--- a/src/main/java/ca/openosp/openo/documentManager/EDocUtil.java
+++ b/src/main/java/ca/openosp/openo/documentManager/EDocUtil.java
@@ -1138,6 +1138,9 @@ public final class EDocUtil {
     public static String getHtmlTicklers(LoggedInInfo loggedInInfo, String docId) {
 
         Long table_id = Long.valueOf(docId);
+        // TODO: only reads legacy tickler_link rows. Document attachments created via the new
+        // ticklerdocs-based attachment component are not returned here. Needs a TicklerDocsDao
+        // reverse lookup (by documentNo/docType) merged into this result.
         List<TicklerLink> linkList = ticklerLinkDao.getLinkByTableId("DOC", table_id);
         String HtmlTickler = "";
         Integer ticklerNo;

--- a/src/main/java/ca/openosp/openo/documentManager/actions/DocumentPreview2Action.java
+++ b/src/main/java/ca/openosp/openo/documentManager/actions/DocumentPreview2Action.java
@@ -17,6 +17,7 @@ import ca.openosp.openo.documentManager.EDocUtil;
 import ca.openosp.openo.documentManager.data.AttachmentLabResultData;
 import ca.openosp.openo.hospitalReportManager.HRMUtil;
 import ca.openosp.openo.managers.FormsManager;
+import ca.openosp.openo.managers.SecurityInfoManager;
 import ca.openosp.openo.utility.LoggedInInfo;
 import ca.openosp.openo.utility.MiscUtils;
 import ca.openosp.openo.utility.PathValidationUtils;
@@ -66,6 +67,7 @@ public class DocumentPreview2Action extends ActionSupport {
     private static final Logger logger = MiscUtils.getLogger();
     private final DocumentAttachmentManager documentAttachmentManager = SpringUtils.getBean(DocumentAttachmentManager.class);
     private final FormsManager formsManager = SpringUtils.getBean(FormsManager.class);
+    private final SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     /**
@@ -389,11 +391,16 @@ public class DocumentPreview2Action extends ActionSupport {
      * - demographicNo: String the patient's demographic number (defaults to "0" if not provided)
      *
      * @return String "fetchDocuments" result name for Struts2 result mapping
+     * @throws SecurityException if the user lacks the required "_tickler" read privilege
      */
     public String fetchTicklerDocuments() {
         LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
 
         String demographicNo = StringUtils.isNullOrEmpty(request.getParameter("demographicNo")) ? "0" : request.getParameter("demographicNo");
+
+        if (!securityInfoManager.hasPrivilege(loggedInInfo, "_tickler", SecurityInfoManager.READ, demographicNo)) {
+            throw new SecurityException("missing required sec object (_tickler)");
+        }
 
         populateCommonDocs(loggedInInfo, demographicNo);
         List<EFormData> allEForms = EFormUtil.listPatientEformsCurrent(Integer.valueOf(demographicNo), true);

--- a/src/main/java/ca/openosp/openo/documentManager/actions/DocumentPreview2Action.java
+++ b/src/main/java/ca/openosp/openo/documentManager/actions/DocumentPreview2Action.java
@@ -116,6 +116,8 @@ public class DocumentPreview2Action extends ActionSupport {
             }
             else if (method.equalsIgnoreCase("fetchConsultDocuments"))
                 return fetchConsultDocuments();
+            else if (method.equalsIgnoreCase("fetchTicklerDocuments"))
+                return fetchTicklerDocuments();
         }
 
         return fetchConsultDocuments();
@@ -370,6 +372,31 @@ public class DocumentPreview2Action extends ActionSupport {
 
         populateCommonDocs(loggedInInfo, demographicNo);
 		List<EFormData> allEForms = EFormUtil.listPatientEformsCurrent(Integer.valueOf(demographicNo), true);
+        request.setAttribute("allEForms", allEForms);
+
+        return "fetchDocuments";
+    }
+
+    /**
+     * Fetches the documents available for attaching to a tickler.
+     *
+     * <p>Tickler counterpart of {@link #fetchConsultDocuments()}. Populates the patient's documents,
+     * HRM reports, labs and encounter forms (via {@link #populateCommonDocs}) plus the full list of
+     * current eForms, then forwards to the shared attachment picker ({@code attachDocument.jsp}). Unlike
+     * {@link #fetchEFormDocuments()} there is no self-exclusion, since a tickler is not itself an eForm.</p>
+     *
+     * Request parameters:
+     * - demographicNo: String the patient's demographic number (defaults to "0" if not provided)
+     *
+     * @return String "fetchDocuments" result name for Struts2 result mapping
+     */
+    public String fetchTicklerDocuments() {
+        LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
+
+        String demographicNo = StringUtils.isNullOrEmpty(request.getParameter("demographicNo")) ? "0" : request.getParameter("demographicNo");
+
+        populateCommonDocs(loggedInInfo, demographicNo);
+        List<EFormData> allEForms = EFormUtil.listPatientEformsCurrent(Integer.valueOf(demographicNo), true);
         request.setAttribute("allEForms", allEForms);
 
         return "fetchDocuments";

--- a/src/main/java/ca/openosp/openo/documentManager/actions/DocumentPreview2Action.java
+++ b/src/main/java/ca/openosp/openo/documentManager/actions/DocumentPreview2Action.java
@@ -38,6 +38,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -415,7 +416,10 @@ public class DocumentPreview2Action extends ActionSupport {
             throw new SecurityException("missing required sec object (_tickler)");
         }
 
-        populateCommonDocs(loggedInInfo, demographicNo);
+        // No tickler equivalent of getAttachedDocsForConsult/getAttachedDocsForEForm yet, so the
+        // picker shows the patient's documents only. A document attached by another provider from
+        // their private set is therefore not listed here.
+        populateCommonDocs(loggedInInfo, demographicNo, Collections.emptyList());
         List<EFormData> allEForms = EFormUtil.listPatientEformsCurrent(Integer.valueOf(demographicNo), true);
         request.setAttribute("allEForms", allEForms);
 

--- a/src/main/java/ca/openosp/openo/documentManager/data/TicklerAttachmentData.java
+++ b/src/main/java/ca/openosp/openo/documentManager/data/TicklerAttachmentData.java
@@ -1,0 +1,48 @@
+//CHECKSTYLE:OFF
+package ca.openosp.openo.documentManager.data;
+
+import ca.openosp.openo.commn.model.enumerator.DocumentType;
+
+/**
+ * A tickler attachment's type, id and human-readable display name.
+ *
+ * @since 2026-07-19
+ */
+public class TicklerAttachmentData {
+    private DocumentType documentType;
+    private String documentId;
+    private String displayName;
+
+    public TicklerAttachmentData() {
+    }
+
+    public TicklerAttachmentData(DocumentType documentType, String documentId, String displayName) {
+        this.documentType = documentType;
+        this.documentId = documentId;
+        this.displayName = displayName;
+    }
+
+    public DocumentType getDocumentType() {
+        return documentType;
+    }
+
+    public void setDocumentType(DocumentType documentType) {
+        this.documentType = documentType;
+    }
+
+    public String getDocumentId() {
+        return documentId;
+    }
+
+    public void setDocumentId(String documentId) {
+        this.documentId = documentId;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+}

--- a/src/main/java/ca/openosp/openo/managers/FormsManager.java
+++ b/src/main/java/ca/openosp/openo/managers/FormsManager.java
@@ -4,7 +4,9 @@ package ca.openosp.openo.managers;
 
 
 import java.nio.file.Path;
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 import ca.openosp.openo.commn.dao.EFormDao.EFormSortOrder;
 import ca.openosp.openo.commn.model.EForm;
@@ -41,6 +43,20 @@ public interface FormsManager {
     public List<EncounterForm> getSelectedEncounterForms();
 
     public List<PatientForm> getEncounterFormsbyDemographicNumber(LoggedInInfo loggedInInfo, Integer demographicId, boolean getAllVersions, boolean getOnlyPDFReadyForms);
+
+    /**
+     * Batched form of {@link #getEncounterFormsbyDemographicNumber}, grouped by demographic.
+     *
+     * <p>The encounter form configuration is read once for the whole batch instead of once per
+     * patient, which is what makes this worth using when rendering a list spanning many patients.</p>
+     *
+     * @param loggedInInfo LoggedInInfo the current user's session information
+     * @param demographicIds Collection&lt;Integer&gt; the patients to look up; may be empty
+     * @param getAllVersions boolean true to return every version, false for the most recent only
+     * @param getOnlyPDFReadyForms boolean true to restrict to PDF-ready forms
+     * @return Map&lt;Integer, List&lt;PatientForm&gt;&gt; forms grouped by demographic number
+     */
+    public Map<Integer, List<PatientForm>> getEncounterFormsByDemographicNumbers(LoggedInInfo loggedInInfo, Collection<Integer> demographicIds, boolean getAllVersions, boolean getOnlyPDFReadyForms);
 
     public Integer saveFormDataAsEDoc(LoggedInInfo loggedInInfo, FormTransportContainer formTransportContainer);
 

--- a/src/main/java/ca/openosp/openo/managers/FormsManagerImpl.java
+++ b/src/main/java/ca/openosp/openo/managers/FormsManagerImpl.java
@@ -6,9 +6,11 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.logging.log4j.Logger;
 import ca.openosp.openo.commn.dao.EFormDao;
@@ -142,29 +144,72 @@ public class FormsManagerImpl implements FormsManager {
         return processEncounterForms(loggedInInfo, demographicId, getAllVersions, getOnlyPDFReadyForms);
     }
 
+    @Override
+    public Map<Integer, List<PatientForm>> getEncounterFormsByDemographicNumbers(LoggedInInfo loggedInInfo,
+                                                                                 Collection<Integer> demographicIds,
+                                                                                 boolean getAllVersions,
+                                                                                 boolean getOnlyPDFReadyForms) {
+        if (!securityInfoManager.hasPrivilege(loggedInInfo, "_form", SecurityInfoManager.READ, null)) {
+            throw new RuntimeException("missing required sec object (_form)");
+        }
+        if (demographicIds == null || demographicIds.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        // Read the encounter form configuration once for the whole batch. Doing it per patient
+        // dominates the cost of rendering a list: it is a static ~40 row table, and re-reading it
+        // per patient measured ~100x slower than the per-patient form queries themselves.
+        List<EncounterForm> encounterFormList = filterToRequestedForms(getOnlyPDFReadyForms);
+
+        Map<Integer, List<PatientForm>> formsByDemographic = new HashMap<>();
+        for (Integer demographicId : demographicIds) {
+            formsByDemographic.put(demographicId,
+                    collectPatientForms(encounterFormList, demographicId, getAllVersions));
+        }
+        return formsByDemographic;
+    }
+
     private List<PatientForm> processEncounterForms(LoggedInInfo loggedInInfo, Integer demographicId,
                                                     boolean getAllVersions, boolean getOnlyPDFReadyForms) {
-        List<PatientForm> patientFormList = new ArrayList<PatientForm>();
+        return collectPatientForms(filterToRequestedForms(getOnlyPDFReadyForms), demographicId, getAllVersions);
+    }
+
+    /**
+     * Returns the encounter form configuration, narrowed to the PDF-ready forms when requested.
+     */
+    private List<EncounterForm> filterToRequestedForms(boolean getOnlyPDFReadyForms) {
         List<EncounterForm> encounterFormList = getAllEncounterForms();
-        String[] pdfReadyFormNames = {"Annual"};
+        if (!getOnlyPDFReadyForms) {
+            return encounterFormList;
+        }
 
+        List<String> pdfReadyFormNames = getPDFReadyFormNames();
+        List<EncounterForm> pdfReadyForms = new ArrayList<>();
         for (EncounterForm encounterForm : encounterFormList) {
-            String formName = encounterForm.getFormName();
-            if (getOnlyPDFReadyForms && !Arrays.asList(pdfReadyFormNames).contains(formName)) {
-                continue;
+            if (pdfReadyFormNames.contains(encounterForm.getFormName())) {
+                pdfReadyForms.add(encounterForm);
             }
+        }
+        return pdfReadyForms;
+    }
 
+    /**
+     * Reads one patient's instances of each supplied form, one query per form table.
+     */
+    private List<PatientForm> collectPatientForms(List<EncounterForm> encounterFormList, Integer demographicId,
+                                                  boolean getAllVersions) {
+        List<PatientForm> patientFormList = new ArrayList<PatientForm>();
+        for (EncounterForm encounterForm : encounterFormList) {
             String table = encounterForm.getFormTable();
             PatientForm[] patientFormArray = EctFormData.getPatientForms(demographicId + "", table);
             int maxFormsToProcess = getAllVersions ? patientFormArray.length : Math.min(1, patientFormArray.length);
             for (int i = 0; i < maxFormsToProcess; i++) {
                 PatientForm patientForm = patientFormArray[i];
                 patientForm.setTable(table);
-                patientForm.setFormName(formName);
+                patientForm.setFormName(encounterForm.getFormName());
                 patientFormList.add(patientForm);
             }
         }
-
         return patientFormList;
     }
 

--- a/src/main/java/ca/openosp/openo/managers/TicklerManager.java
+++ b/src/main/java/ca/openosp/openo/managers/TicklerManager.java
@@ -15,7 +15,6 @@ import java.util.Map;
 import ca.openosp.openo.commn.model.CustomFilter;
 import ca.openosp.openo.commn.model.Tickler;
 import ca.openosp.openo.commn.model.TicklerCategory;
-import ca.openosp.openo.commn.model.TicklerLink;
 import ca.openosp.openo.commn.model.TicklerTextSuggest;
 import ca.openosp.openo.tickler.dto.TicklerListDTO;
 import ca.openosp.openo.utility.LoggedInInfo;
@@ -37,8 +36,6 @@ public interface TicklerManager {
     public List<TicklerCategory> getActiveTicklerCategories(LoggedInInfo loggedInInfo);
 
     public boolean validateTicklerIsValid(Tickler tickler);
-
-    public boolean addTicklerLink(LoggedInInfo loggedInInfo, TicklerLink ticklerLink);
 
     public boolean addTickler(LoggedInInfo loggedInInfo, Tickler tickler);
 

--- a/src/main/java/ca/openosp/openo/managers/TicklerManagerImpl.java
+++ b/src/main/java/ca/openosp/openo/managers/TicklerManagerImpl.java
@@ -116,18 +116,6 @@ public class TicklerManagerImpl implements TicklerManager {
     }
 
     @Override
-    public boolean addTicklerLink(LoggedInInfo loggedInInfo, TicklerLink ticklerLink) {
-        checkPrivilege(loggedInInfo, PRIVILEGE_WRITE);
-        ticklerDao.persist(ticklerLink);
-
-        // --- log action ---
-        LogAction.addLogSynchronous(loggedInInfo, "TicklerManager.addTicklerLink",
-                "ticklerLinkId=" + ticklerLink.getId());
-
-        return true;
-    }
-
-    @Override
     public boolean addTickler(LoggedInInfo loggedInInfo, Tickler tickler) {
         checkPrivilege(loggedInInfo, PRIVILEGE_WRITE);
 
@@ -204,6 +192,9 @@ public class TicklerManagerImpl implements TicklerManager {
         checkPrivilege(loggedInInfo, PRIVILEGE_READ);
         String providerNo = loggedInInfo.getLoggedInProviderNo();
 
+        // TODO: only reads legacy tickler_link rows. Lab attachments created via the new
+        // ticklerdocs-based attachment component (e.g. ReportMacro2Action) are not returned here.
+        // Needs a TicklerDocsDao reverse lookup (by documentNo/docType) merged into this result.
         List<TicklerLink> links = ticklerLinkDao.getLinkByTableId("HL7", Long.valueOf(labId));
 
         ArrayList<Tickler> results = new ArrayList<Tickler>();
@@ -224,6 +215,9 @@ public class TicklerManagerImpl implements TicklerManager {
         checkPrivilege(loggedInInfo, PRIVILEGE_READ);
         String providerNo = loggedInInfo.getLoggedInProviderNo();
 
+        // TODO: only reads legacy tickler_link rows. Lab attachments created via the new
+        // ticklerdocs-based attachment component (e.g. ReportMacro2Action) are not returned here.
+        // Needs a TicklerDocsDao reverse lookup (by documentNo/docType) merged into this result.
         List<TicklerLink> links = ticklerLinkDao.getLinkByTableId("HL7", Long.valueOf(labId));
 
         ArrayList<Tickler> results = new ArrayList<Tickler>();

--- a/src/main/java/ca/openosp/openo/mds/pageUtil/ReportMacro2Action.java
+++ b/src/main/java/ca/openosp/openo/mds/pageUtil/ReportMacro2Action.java
@@ -139,7 +139,10 @@ public class ReportMacro2Action extends ActionSupport {
                 ticklerDao.persist(t);
 
                 // Attach the lab to the tickler using the modern attachment store (ticklerdocs).
-                TicklerDocs ticklerDocs = new TicklerDocs(t.getId(), Integer.parseInt(segmentID), TicklerDocs.DOCTYPE_LAB, providerNo);
+                // Use the authenticated provider (not the raw request param) for the audit trail,
+                // matching the tickler creator above.
+                String loggedInProviderNo = LoggedInInfo.getLoggedInInfoFromSession(request).getLoggedInProviderNo();
+                TicklerDocs ticklerDocs = new TicklerDocs(t.getId(), Integer.parseInt(segmentID), TicklerDocs.DOCTYPE_LAB, loggedInProviderNo);
                 ticklerDocsDao.persist(ticklerDocs);
             } else {
                 logger.info("Cannot sent tickler. Not enough information in macro definition. providers taskAssignedTo and message");

--- a/src/main/java/ca/openosp/openo/mds/pageUtil/ReportMacro2Action.java
+++ b/src/main/java/ca/openosp/openo/mds/pageUtil/ReportMacro2Action.java
@@ -33,10 +33,10 @@ import javax.servlet.http.HttpServletResponse;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 import ca.openosp.openo.commn.dao.TicklerDao;
-import ca.openosp.openo.commn.dao.TicklerLinkDao;
+import ca.openosp.openo.commn.dao.TicklerDocsDao;
 import ca.openosp.openo.commn.dao.UserPropertyDAO;
 import ca.openosp.openo.commn.model.Tickler;
-import ca.openosp.openo.commn.model.TicklerLink;
+import ca.openosp.openo.commn.model.TicklerDocs;
 import ca.openosp.openo.commn.model.UserProperty;
 import ca.openosp.openo.managers.SecurityInfoManager;
 import ca.openosp.openo.utility.LoggedInInfo;
@@ -61,7 +61,7 @@ public class ReportMacro2Action extends ActionSupport {
 
     private SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
     private TicklerDao ticklerDao = SpringUtils.getBean(TicklerDao.class);
-    private TicklerLinkDao ticklerLinkDao = SpringUtils.getBean(TicklerLinkDao.class);
+    private TicklerDocsDao ticklerDocsDao = SpringUtils.getBean(TicklerDocsDao.class);
 
     
     private static final ObjectMapper objectMapper = new ObjectMapper();
@@ -138,11 +138,9 @@ public class ReportMacro2Action extends ActionSupport {
                 t.setCreator(LoggedInInfo.getLoggedInInfoFromSession(request).getLoggedInProviderNo());
                 ticklerDao.persist(t);
 
-                TicklerLink tl = new TicklerLink();
-                tl.setTableId(Long.valueOf(segmentID));
-                tl.setTableName(LabResultData.HL7TEXT);
-                tl.setTicklerNo(t.getId());
-                ticklerLinkDao.persist(tl);
+                // Attach the lab to the tickler using the modern attachment store (ticklerdocs).
+                TicklerDocs ticklerDocs = new TicklerDocs(t.getId(), Integer.parseInt(segmentID), TicklerDocs.DOCTYPE_LAB, providerNo);
+                ticklerDocsDao.persist(ticklerDocs);
             } else {
                 logger.info("Cannot sent tickler. Not enough information in macro definition. providers taskAssignedTo and message");
             }

--- a/src/main/java/ca/openosp/openo/tickler/pageUtil/EditTickler2Action.java
+++ b/src/main/java/ca/openosp/openo/tickler/pageUtil/EditTickler2Action.java
@@ -33,6 +33,8 @@ import ca.openosp.openo.commn.model.Tickler;
 import ca.openosp.openo.commn.model.TicklerComment;
 import ca.openosp.openo.commn.model.TicklerTextSuggest;
 import ca.openosp.openo.commn.model.TicklerUpdate;
+import ca.openosp.openo.commn.model.enumerator.DocumentType;
+import ca.openosp.openo.documentManager.DocumentAttachmentManager;
 import ca.openosp.openo.managers.SecurityInfoManager;
 import ca.openosp.openo.managers.TicklerManager;
 import ca.openosp.openo.utility.LoggedInInfo;
@@ -51,6 +53,7 @@ public class EditTickler2Action extends ActionSupport {
     private static final Logger logger = MiscUtils.getLogger();
     private TicklerManager ticklerManager = SpringUtils.getBean(TicklerManager.class);
     private SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
+    private DocumentAttachmentManager documentAttachmentManager = SpringUtils.getBean(DocumentAttachmentManager.class);
 
     public String execute() {
         if ("editTickler".equals(request.getParameter("method"))) {
@@ -180,6 +183,10 @@ public class EditTickler2Action extends ActionSupport {
             ticklerManager.updateTickler(loggedInInfo, t);
         }
 
+        // Process document attachments unconditionally: a user may change only the attachments
+        // without touching any other tickler field, so this must not be gated on isUpdate/isComment.
+        processAttachments(loggedInInfo, t, providerNo);
+
         if (emailFailed) {
             addActionError(getText("tickler.ticklerEdit.emailFailed.error"));
             return "failure";
@@ -191,6 +198,32 @@ public class EditTickler2Action extends ActionSupport {
 
         return "close";
 
+    }
+
+    /**
+     * Synchronises the tickler's document attachments with the values submitted by the
+     * attachment picker. Each document type is processed independently; a {@code null} array
+     * (the type was not present in the submission) is treated as an empty selection so that
+     * de-selecting all attachments of a type correctly soft-deletes them.
+     *
+     * @param loggedInInfo LoggedInInfo the current user's session information
+     * @param t Tickler the tickler being edited
+     * @param providerNo String the provider performing the attachment operation
+     */
+    private void processAttachments(LoggedInInfo loggedInInfo, Tickler t, String providerNo) {
+        Integer ticklerId = t.getId();
+        Integer demographicNo = t.getDemographicNo();
+
+        documentAttachmentManager.attachToTickler(loggedInInfo, DocumentType.DOC, attachmentValues("docNo"), providerNo, ticklerId, demographicNo);
+        documentAttachmentManager.attachToTickler(loggedInInfo, DocumentType.LAB, attachmentValues("labNo"), providerNo, ticklerId, demographicNo);
+        documentAttachmentManager.attachToTickler(loggedInInfo, DocumentType.EFORM, attachmentValues("eFormNo"), providerNo, ticklerId, demographicNo);
+        documentAttachmentManager.attachToTickler(loggedInInfo, DocumentType.HRM, attachmentValues("hrmNo"), providerNo, ticklerId, demographicNo);
+        documentAttachmentManager.attachToTickler(loggedInInfo, DocumentType.FORM, attachmentValues("formNo"), providerNo, ticklerId, demographicNo);
+    }
+
+    private String[] attachmentValues(String parameterName) {
+        String[] values = request.getParameterValues(parameterName);
+        return values == null ? new String[0] : values;
     }
 
     public String updateTextSuggest() {

--- a/src/main/java/ca/openosp/openo/tickler/pageUtil/TicklerList2Action.java
+++ b/src/main/java/ca/openosp/openo/tickler/pageUtil/TicklerList2Action.java
@@ -6,8 +6,11 @@ import java.text.SimpleDateFormat;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -106,12 +109,16 @@ public class TicklerList2Action extends ActionSupport {
         DateFormat dateOnlyFormat = new SimpleDateFormat("yyyy-MM-dd", locale);
         DateFormat timeOnlyFormat = new SimpleDateFormat("HH:mm:ss", locale);
 
+        Map<Integer, List<TicklerDocs>> ticklerDocsByTicklerId = loadTicklerDocsByTicklerId(ticklers);
+        Map<Integer, String> labTypeByDocumentNo = loadLabTypesByDocumentNo(ticklerDocsByTicklerId);
+
         ArrayNode dataArray = objectMapper.createArrayNode();
         ObjectNode commentsMap = objectMapper.createObjectNode();
 
         for (TicklerListDTO tickler : ticklers) {
             boolean warning = isWarning(tickler.getServiceDate(), ticklerWarnDays);
-            dataArray.add(buildTicklerRow(tickler, warning, datetimeFormat, dateOnlyFormat, locale));
+            List<TicklerDocs> ticklerDocs = ticklerDocsByTicklerId.getOrDefault(tickler.getId(), Collections.emptyList());
+            dataArray.add(buildTicklerRow(tickler, warning, datetimeFormat, dateOnlyFormat, locale, ticklerDocs, labTypeByDocumentNo));
 
             List<TicklerCommentDTO> tcomments = tickler.getComments();
             if (tcomments != null && !tcomments.isEmpty()) {
@@ -159,11 +166,16 @@ public class TicklerList2Action extends ActionSupport {
      * @param datetimeFormat DateFormat for full datetime display
      * @param dateOnlyFormat DateFormat for date-only display
      * @param locale Locale for localized status text
+     * @param ticklerDocs List&lt;TicklerDocs&gt; this tickler's attachments, pre-fetched in bulk by
+     *        {@link #loadTicklerDocsByTicklerId}
+     * @param labTypeByDocumentNo Map&lt;Integer, String&gt; lab document number to lab sub-type,
+     *        pre-fetched in bulk by {@link #loadLabTypesByDocumentNo}
      * @return ObjectNode the JSON row
      */
     private ObjectNode buildTicklerRow(TicklerListDTO tickler, boolean warning,
                                        DateFormat datetimeFormat, DateFormat dateOnlyFormat,
-                                       Locale locale) {
+                                       Locale locale, List<TicklerDocs> ticklerDocs,
+                                       Map<Integer, String> labTypeByDocumentNo) {
         ObjectNode row = objectMapper.createObjectNode();
         row.put("id", tickler.getId());
         row.put("demoNo", tickler.getDemographicNo());
@@ -181,10 +193,9 @@ public class TicklerList2Action extends ActionSupport {
         row.put("warning", warning);
 
         ArrayNode linksArray = objectMapper.createArrayNode();
-        List<TicklerDocs> ticklerDocsList = ticklerDocsDao.findByTicklerId(tickler.getId());
-        for (TicklerDocs td : ticklerDocsList) {
+        for (TicklerDocs td : ticklerDocs) {
             ObjectNode linkNode = objectMapper.createObjectNode();
-            linkNode.put("tableName", resolveAttachmentType(td));
+            linkNode.put("tableName", resolveAttachmentType(td, labTypeByDocumentNo));
             linkNode.put("tableId", td.getDocumentNo());
             linksArray.add(linkNode);
         }
@@ -194,14 +205,64 @@ public class TicklerList2Action extends ActionSupport {
     }
 
     /**
+     * Batch-loads {@link TicklerDocs} attachments for a page of tickler results in a single query,
+     * grouped by tickler id, to avoid an N+1 query pattern when rendering the list.
+     *
+     * @param ticklers List&lt;TicklerListDTO&gt; the page of ticklers being rendered
+     * @return Map&lt;Integer, List&lt;TicklerDocs&gt;&gt; attachments grouped by tickler id
+     */
+    private Map<Integer, List<TicklerDocs>> loadTicklerDocsByTicklerId(List<TicklerListDTO> ticklers) {
+        List<Integer> ticklerIds = ticklers.stream()
+                .map(TicklerListDTO::getId)
+                .collect(Collectors.toList());
+        List<TicklerDocs> ticklerDocs = ticklerDocsDao.findByTicklerIds(ticklerIds);
+        return ticklerDocs.stream().collect(Collectors.groupingBy(TicklerDocs::getTicklerId));
+    }
+
+    /**
+     * Batch-loads lab sub-types (MDS/CML/HL7/BC) for every lab attachment across a page of tickler
+     * results in a single query, to avoid an N+1 query pattern when resolving attachment link types.
+     *
+     * @param ticklerDocsByTicklerId Map&lt;Integer, List&lt;TicklerDocs&gt;&gt; attachments grouped by
+     *        tickler id, as returned by {@link #loadTicklerDocsByTicklerId}
+     * @return Map&lt;Integer, String&gt; lab document number to lab sub-type
+     */
+    private Map<Integer, String> loadLabTypesByDocumentNo(Map<Integer, List<TicklerDocs>> ticklerDocsByTicklerId) {
+        List<Integer> labDocumentNos = ticklerDocsByTicklerId.values().stream()
+                .flatMap(List::stream)
+                .filter(td -> isLabDocType(td.getDocType()))
+                .map(TicklerDocs::getDocumentNo)
+                .collect(Collectors.toList());
+        List<PatientLabRouting> routings = patientLabRoutingDao.findByLabNos(labDocumentNos);
+        return routings.stream().collect(Collectors.toMap(
+                PatientLabRouting::getLabNo, PatientLabRouting::getLabType, (first, second) -> first));
+    }
+
+    /**
+     * Checks whether a {@link TicklerDocs} doctype represents a lab attachment (as opposed to a
+     * document, HRM report, eForm, or encounter form).
+     *
+     * @param docType String the doctype to check (see {@link TicklerDocs} DOCTYPE_* constants)
+     * @return boolean true if the doctype is a lab attachment
+     */
+    private boolean isLabDocType(String docType) {
+        return !TicklerDocs.DOCTYPE_DOC.equals(docType)
+                && !TicklerDocs.DOCTYPE_HRM.equals(docType)
+                && !TicklerDocs.DOCTYPE_EFORM.equals(docType)
+                && !TicklerDocs.DOCTYPE_FORM.equals(docType);
+    }
+
+    /**
      * Resolves the attachment type string used by the client-side link renderer for a
      * tickler document attachment. Lab attachments are resolved to their originating lab
-     * sub-type (MDS/CML/HL7/BC) via {@link PatientLabRoutingDao}.
+     * sub-type (MDS/CML/HL7/BC) via a pre-fetched batch lookup.
      *
      * @param ticklerDoc TicklerDocs the attachment to resolve
+     * @param labTypeByDocumentNo Map&lt;Integer, String&gt; lab document number to lab sub-type,
+     *        pre-fetched in bulk by {@link #loadLabTypesByDocumentNo}
      * @return String the attachment type understood by buildAttachmentLink() in ticklerMain.jsp
      */
-    private String resolveAttachmentType(TicklerDocs ticklerDoc) {
+    private String resolveAttachmentType(TicklerDocs ticklerDoc, Map<Integer, String> labTypeByDocumentNo) {
         String docType = ticklerDoc.getDocType();
         if (TicklerDocs.DOCTYPE_DOC.equals(docType)) {
             return "DOC";
@@ -215,8 +276,7 @@ public class TicklerList2Action extends ActionSupport {
         if (TicklerDocs.DOCTYPE_FORM.equals(docType)) {
             return "FORM";
         }
-        PatientLabRouting plr = patientLabRoutingDao.findByLabNo(ticklerDoc.getDocumentNo());
-        String labType = (plr != null) ? plr.getLabType() : null;
+        String labType = labTypeByDocumentNo.get(ticklerDoc.getDocumentNo());
         if (LabResultData.MDS.equals(labType)) {
             return "MDS";
         }

--- a/src/main/java/ca/openosp/openo/tickler/pageUtil/TicklerList2Action.java
+++ b/src/main/java/ca/openosp/openo/tickler/pageUtil/TicklerList2Action.java
@@ -7,9 +7,12 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import javax.servlet.http.HttpServletRequest;
@@ -28,6 +31,7 @@ import ca.openosp.openo.commn.dao.TicklerDocsDao;
 import ca.openosp.openo.commn.model.CustomFilter;
 import ca.openosp.openo.commn.model.PatientLabRouting;
 import ca.openosp.openo.commn.model.TicklerDocs;
+import ca.openosp.openo.documentManager.DocumentAttachmentManager;
 import ca.openosp.openo.lab.ca.on.LabResultData;
 import ca.openosp.openo.log.LogAction;
 import ca.openosp.openo.managers.SecurityInfoManager;
@@ -53,6 +57,7 @@ public class TicklerList2Action extends ActionSupport {
     private SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
     private TicklerDocsDao ticklerDocsDao = SpringUtils.getBean(TicklerDocsDao.class);
     private PatientLabRoutingDao patientLabRoutingDao = SpringUtils.getBean(PatientLabRoutingDao.class);
+    private DocumentAttachmentManager documentAttachmentManager = SpringUtils.getBean(DocumentAttachmentManager.class);
 
     /**
      * Handles DataTables server-side processing requests. Accepts standard
@@ -111,6 +116,8 @@ public class TicklerList2Action extends ActionSupport {
 
         Map<Integer, List<TicklerDocs>> ticklerDocsByTicklerId = loadTicklerDocsByTicklerId(ticklers);
         Map<Integer, String> labTypeByDocumentNo = loadLabTypesByDocumentNo(ticklerDocsByTicklerId);
+        Map<Integer, Map<String, String>> formNamesByDemographic =
+                loadFormNamesByDemographic(loggedInInfo, ticklers, ticklerDocsByTicklerId);
 
         ArrayNode dataArray = objectMapper.createArrayNode();
         ObjectNode commentsMap = objectMapper.createObjectNode();
@@ -118,7 +125,9 @@ public class TicklerList2Action extends ActionSupport {
         for (TicklerListDTO tickler : ticklers) {
             boolean warning = isWarning(tickler.getServiceDate(), ticklerWarnDays);
             List<TicklerDocs> ticklerDocs = ticklerDocsByTicklerId.getOrDefault(tickler.getId(), Collections.emptyList());
-            dataArray.add(buildTicklerRow(tickler, warning, datetimeFormat, dateOnlyFormat, locale, ticklerDocs, labTypeByDocumentNo));
+            Map<String, String> formNames = formNamesByDemographic
+                    .getOrDefault(tickler.getDemographicNo(), Collections.emptyMap());
+            dataArray.add(buildTicklerRow(tickler, warning, datetimeFormat, dateOnlyFormat, locale, ticklerDocs, labTypeByDocumentNo, formNames));
 
             List<TicklerCommentDTO> tcomments = tickler.getComments();
             if (tcomments != null && !tcomments.isEmpty()) {
@@ -170,12 +179,15 @@ public class TicklerList2Action extends ActionSupport {
      *        {@link #loadTicklerDocsByTicklerId}
      * @param labTypeByDocumentNo Map&lt;Integer, String&gt; lab document number to lab sub-type,
      *        pre-fetched in bulk by {@link #loadLabTypesByDocumentNo}
+     * @param formNames Map&lt;String, String&gt; form id to form name for <em>this tickler's patient</em>,
+     *        pre-fetched by {@link #loadFormNamesByDemographic}
      * @return ObjectNode the JSON row
      */
     private ObjectNode buildTicklerRow(TicklerListDTO tickler, boolean warning,
                                        DateFormat datetimeFormat, DateFormat dateOnlyFormat,
                                        Locale locale, List<TicklerDocs> ticklerDocs,
-                                       Map<Integer, String> labTypeByDocumentNo) {
+                                       Map<Integer, String> labTypeByDocumentNo,
+                                       Map<String, String> formNames) {
         ObjectNode row = objectMapper.createObjectNode();
         row.put("id", tickler.getId());
         row.put("demoNo", tickler.getDemographicNo());
@@ -197,6 +209,14 @@ public class TicklerList2Action extends ActionSupport {
             ObjectNode linkNode = objectMapper.createObjectNode();
             linkNode.put("tableName", resolveAttachmentType(td, labTypeByDocumentNo));
             linkNode.put("tableId", td.getDocumentNo());
+            if (TicklerDocs.DOCTYPE_FORM.equals(td.getDocType())) {
+                // Left absent when the form no longer resolves; the client then renders an
+                // unlinked icon rather than a URL that cannot identify a form.
+                String formName = formNames.get(String.valueOf(td.getDocumentNo()));
+                if (formName != null) {
+                    linkNode.put("formName", formName);
+                }
+            }
             linksArray.add(linkNode);
         }
         row.set("links", linksArray);
@@ -236,6 +256,48 @@ public class TicklerList2Action extends ActionSupport {
         List<PatientLabRouting> routings = patientLabRoutingDao.findByLabNos(labDocumentNos);
         return routings.stream().collect(Collectors.toMap(
                 PatientLabRouting::getLabNo, PatientLabRouting::getLabType, (first, second) -> first));
+    }
+
+    /**
+     * Loads encounter form names for every patient on this page that has a form attachment.
+     *
+     * <p>Keyed by demographic, not by document number like {@link #loadLabTypesByDocumentNo}: form
+     * ids are unique only within one form's table, so a flat map would label one patient's form
+     * with another patient's form name. Skipped entirely when the page has no form attachments.</p>
+     *
+     * @param loggedInInfo LoggedInInfo the current user's session information
+     * @param ticklers List&lt;TicklerListDTO&gt; the page of ticklers being rendered
+     * @param ticklerDocsByTicklerId Map&lt;Integer, List&lt;TicklerDocs&gt;&gt; attachments grouped by
+     *        tickler id, as returned by {@link #loadTicklerDocsByTicklerId}
+     * @return Map&lt;Integer, Map&lt;String, String&gt;&gt; demographic number to that patient's form
+     *         id to form name lookup
+     */
+    private Map<Integer, Map<String, String>> loadFormNamesByDemographic(
+            LoggedInInfo loggedInInfo, List<TicklerListDTO> ticklers,
+            Map<Integer, List<TicklerDocs>> ticklerDocsByTicklerId) {
+        Set<Integer> demographicNos = ticklers.stream()
+                .filter(tickler -> hasFormAttachment(ticklerDocsByTicklerId.get(tickler.getId())))
+                .map(TicklerListDTO::getDemographicNo)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+
+        Map<Integer, Map<String, String>> formNamesByDemographic = new HashMap<>();
+        for (Integer demographicNo : demographicNos) {
+            formNamesByDemographic.put(demographicNo,
+                    documentAttachmentManager.getFormNamesByFormId(loggedInInfo, demographicNo));
+        }
+        return formNamesByDemographic;
+    }
+
+    /**
+     * Checks whether any of a tickler's attachments is an encounter form.
+     *
+     * @param ticklerDocs List&lt;TicklerDocs&gt; the tickler's attachments, may be null
+     * @return boolean true if at least one attachment is an encounter form
+     */
+    private boolean hasFormAttachment(List<TicklerDocs> ticklerDocs) {
+        return ticklerDocs != null && ticklerDocs.stream()
+                .anyMatch(td -> TicklerDocs.DOCTYPE_FORM.equals(td.getDocType()));
     }
 
     /**

--- a/src/main/java/ca/openosp/openo/tickler/pageUtil/TicklerList2Action.java
+++ b/src/main/java/ca/openosp/openo/tickler/pageUtil/TicklerList2Action.java
@@ -20,12 +20,16 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.opensymphony.xwork2.ActionSupport;
 
 import ca.openosp.OscarProperties;
+import ca.openosp.openo.commn.dao.PatientLabRoutingDao;
+import ca.openosp.openo.commn.dao.TicklerDocsDao;
 import ca.openosp.openo.commn.model.CustomFilter;
+import ca.openosp.openo.commn.model.PatientLabRouting;
+import ca.openosp.openo.commn.model.TicklerDocs;
+import ca.openosp.openo.lab.ca.on.LabResultData;
 import ca.openosp.openo.log.LogAction;
 import ca.openosp.openo.managers.SecurityInfoManager;
 import ca.openosp.openo.managers.TicklerManager;
 import ca.openosp.openo.tickler.dto.TicklerCommentDTO;
-import ca.openosp.openo.tickler.dto.TicklerLinkDTO;
 import ca.openosp.openo.tickler.dto.TicklerListDTO;
 import ca.openosp.openo.utility.LoggedInInfo;
 import ca.openosp.openo.utility.SpringUtils;
@@ -44,6 +48,8 @@ public class TicklerList2Action extends ActionSupport {
 
     private TicklerManager ticklerManager = SpringUtils.getBean(TicklerManager.class);
     private SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
+    private TicklerDocsDao ticklerDocsDao = SpringUtils.getBean(TicklerDocsDao.class);
+    private PatientLabRoutingDao patientLabRoutingDao = SpringUtils.getBean(PatientLabRoutingDao.class);
 
     /**
      * Handles DataTables server-side processing requests. Accepts standard
@@ -175,18 +181,52 @@ public class TicklerList2Action extends ActionSupport {
         row.put("warning", warning);
 
         ArrayNode linksArray = objectMapper.createArrayNode();
-        List<TicklerLinkDTO> linkList = tickler.getLinks();
-        if (linkList != null) {
-            for (TicklerLinkDTO tl : linkList) {
-                ObjectNode linkNode = objectMapper.createObjectNode();
-                linkNode.put("tableName", tl.getTableName());
-                linkNode.put("tableId", tl.getTableId());
-                linksArray.add(linkNode);
-            }
+        List<TicklerDocs> ticklerDocsList = ticklerDocsDao.findByTicklerId(tickler.getId());
+        for (TicklerDocs td : ticklerDocsList) {
+            ObjectNode linkNode = objectMapper.createObjectNode();
+            linkNode.put("tableName", resolveAttachmentType(td));
+            linkNode.put("tableId", td.getDocumentNo());
+            linksArray.add(linkNode);
         }
         row.set("links", linksArray);
 
         return row;
+    }
+
+    /**
+     * Resolves the attachment type string used by the client-side link renderer for a
+     * tickler document attachment. Lab attachments are resolved to their originating lab
+     * sub-type (MDS/CML/HL7/BC) via {@link PatientLabRoutingDao}.
+     *
+     * @param ticklerDoc TicklerDocs the attachment to resolve
+     * @return String the attachment type understood by buildAttachmentLink() in ticklerMain.jsp
+     */
+    private String resolveAttachmentType(TicklerDocs ticklerDoc) {
+        String docType = ticklerDoc.getDocType();
+        if (TicklerDocs.DOCTYPE_DOC.equals(docType)) {
+            return "DOC";
+        }
+        if (TicklerDocs.DOCTYPE_HRM.equals(docType)) {
+            return "HRM";
+        }
+        if (TicklerDocs.DOCTYPE_EFORM.equals(docType)) {
+            return "EFORM";
+        }
+        if (TicklerDocs.DOCTYPE_FORM.equals(docType)) {
+            return "FORM";
+        }
+        PatientLabRouting plr = patientLabRoutingDao.findByLabNo(ticklerDoc.getDocumentNo());
+        String labType = (plr != null) ? plr.getLabType() : null;
+        if (LabResultData.MDS.equals(labType)) {
+            return "MDS";
+        }
+        if (LabResultData.CML.equals(labType)) {
+            return "CML";
+        }
+        if (LabResultData.HL7TEXT.equals(labType)) {
+            return "HL7";
+        }
+        return "BC";
     }
 
     /**

--- a/src/main/java/ca/openosp/openo/tickler/pageUtil/TicklerList2Action.java
+++ b/src/main/java/ca/openosp/openo/tickler/pageUtil/TicklerList2Action.java
@@ -251,6 +251,7 @@ public class TicklerList2Action extends ActionSupport {
                 .flatMap(List::stream)
                 .filter(td -> isLabDocType(td.getDocType()))
                 .map(TicklerDocs::getDocumentNo)
+                .distinct()
                 .collect(Collectors.toList());
         List<PatientLabRouting> routings = patientLabRoutingDao.findByLabNos(labDocumentNos);
         return routings.stream().collect(Collectors.toMap(

--- a/src/main/java/ca/openosp/openo/tickler/pageUtil/TicklerList2Action.java
+++ b/src/main/java/ca/openosp/openo/tickler/pageUtil/TicklerList2Action.java
@@ -7,7 +7,6 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -263,7 +262,9 @@ public class TicklerList2Action extends ActionSupport {
      *
      * <p>Keyed by demographic, not by document number like {@link #loadLabTypesByDocumentNo}: form
      * ids are unique only within one form's table, so a flat map would label one patient's form
-     * with another patient's form name. Skipped entirely when the page has no form attachments.</p>
+     * with another patient's form name. Resolved in one batched call, since reading the encounter
+     * form configuration per patient measured ~100x slower across a full page. Skipped entirely
+     * when the page has no form attachments.</p>
      *
      * @param loggedInInfo LoggedInInfo the current user's session information
      * @param ticklers List&lt;TicklerListDTO&gt; the page of ticklers being rendered
@@ -281,12 +282,10 @@ public class TicklerList2Action extends ActionSupport {
                 .filter(Objects::nonNull)
                 .collect(Collectors.toSet());
 
-        Map<Integer, Map<String, String>> formNamesByDemographic = new HashMap<>();
-        for (Integer demographicNo : demographicNos) {
-            formNamesByDemographic.put(demographicNo,
-                    documentAttachmentManager.getFormNamesByFormId(loggedInInfo, demographicNo));
+        if (demographicNos.isEmpty()) {
+            return Collections.emptyMap();
         }
-        return formNamesByDemographic;
+        return documentAttachmentManager.getFormNamesByDemographic(loggedInInfo, demographicNos);
     }
 
     /**

--- a/src/main/java/ca/openosp/openo/webserv/rest/conversion/TicklerConverter.java
+++ b/src/main/java/ca/openosp/openo/webserv/rest/conversion/TicklerConverter.java
@@ -111,6 +111,8 @@ public class TicklerConverter extends AbstractConverter<Tickler, TicklerTo1> {
         }
 
         if (includeLinks) {
+            // TODO: still reads from the legacy tickler_link table via TicklerLinkDao.
+            // Update to use TicklerDocsDao/ticklerdocs as part of a future REST API migration.
             List<TicklerLink> links = ticklerLinkDao.getLinkByTickler(d.getId());
             TicklerLinkConverter tlc = new TicklerLinkConverter();
             d.setTicklerLinks(tlc.getAllAsTransferObjects(loggedInInfo, links));

--- a/src/main/webapp/documentManager/attachDocument.jsp
+++ b/src/main/webapp/documentManager/attachDocument.jsp
@@ -70,6 +70,24 @@
             background-color: white !important;
         }
 
+        /* Pin weights and margins so the picker renders the same in every host page
+           (Consult loads no Bootstrap; the Tickler windows load Bootstrap 3). */
+        .attachmentContainer h2 {
+            font-weight: bold;
+            margin: 0.83em 0;
+        }
+
+        .attachmentContainer label {
+            font-weight: normal;
+            display: inline;
+            margin-bottom: 0;
+            max-width: none;
+        }
+
+        .attachmentContainer ul {
+            margin: 1em 0;
+        }
+
         .attachmentContainer {
             display: flex;
             width: 95vw;

--- a/src/main/webapp/tickler/dbTicklerAdd.jsp
+++ b/src/main/webapp/tickler/dbTicklerAdd.jsp
@@ -142,8 +142,10 @@
                     ids.add(docId.trim());
                 }
 
+                // Audit the authenticated provider, not the submitted user_no, which reaches us
+                // through a hidden field and so is client-controlled. Matches EditTickler2Action.
                 documentAttachmentManager.attachToTickler(loggedInInfo, attachmentType,
-                        ids.toArray(new String[0]), doccreator, ticklerNo, tickler.getDemographicNo());
+                        ids.toArray(new String[0]), loggedInInfo.getLoggedInProviderNo(), ticklerNo, tickler.getDemographicNo());
             }
         } catch (Exception e) {
             MiscUtils.getLogger().error("Unable to attach documents to tickler " + ticklerNo, e);

--- a/src/main/webapp/tickler/dbTicklerAdd.jsp
+++ b/src/main/webapp/tickler/dbTicklerAdd.jsp
@@ -30,8 +30,8 @@
 <%@ page import="org.springframework.web.context.WebApplicationContext" %>
 <%@ page import="ca.openosp.openo.utility.SpringUtils" %>
 <%@ page import="ca.openosp.openo.commn.model.Tickler" %>
-<%@ page import="ca.openosp.openo.commn.model.TicklerLink" %>
-<%@ page import="ca.openosp.openo.commn.dao.TicklerLinkDao" %>
+<%@ page import="ca.openosp.openo.commn.model.enumerator.DocumentType" %>
+<%@ page import="ca.openosp.openo.documentManager.DocumentAttachmentManager" %>
 <%@ page import="ca.openosp.openo.util.UtilDateUtilities" %>
 <%@page import="ca.openosp.openo.utility.MiscUtils" %>
 <%@ page import="ca.openosp.openo.utility.LoggedInInfo" %>
@@ -99,12 +99,19 @@
     if (docType != null && docId != null && !docType.trim().equals("") && !docId.trim().equals("") && !docId.equalsIgnoreCase("null")) {
         if (ticklerNo > 0) {
             try {
-                TicklerLink tLink = new TicklerLink();
-                tLink.setTableId(Long.parseLong(docId));
-                tLink.setTableName(docType);
-                tLink.setTicklerNo(new Long(ticklerNo).intValue());
-                TicklerLinkDao ticklerLinkDao = (TicklerLinkDao) SpringUtils.getBean(TicklerLinkDao.class);
-                ticklerLinkDao.save(tLink);
+                // Attach the source document to the tickler using the modern attachment store (ticklerdocs).
+                // The legacy docType is a table_name code (DOC / HRM / HL7 / MDS / CML / ...); anything that
+                // is not a document or HRM report is treated as a lab.
+                DocumentType attachmentType;
+                if ("DOC".equalsIgnoreCase(docType)) {
+                    attachmentType = DocumentType.DOC;
+                } else if ("HRM".equalsIgnoreCase(docType)) {
+                    attachmentType = DocumentType.HRM;
+                } else {
+                    attachmentType = DocumentType.LAB;
+                }
+                DocumentAttachmentManager documentAttachmentManager = SpringUtils.getBean(DocumentAttachmentManager.class);
+                documentAttachmentManager.attachToTickler(loggedInInfo, attachmentType, new String[]{docId}, doccreator, ticklerNo, tickler.getDemographicNo());
             } catch (Exception e) {
                 MiscUtils.getLogger().error("No link with this tickler", e);
             }

--- a/src/main/webapp/tickler/dbTicklerAdd.jsp
+++ b/src/main/webapp/tickler/dbTicklerAdd.jsp
@@ -96,25 +96,57 @@
     ticklerManager.addTickler(loggedInInfo, tickler);
 
     int ticklerNo = tickler.getId();
-    if (docType != null && docId != null && !docType.trim().equals("") && !docId.trim().equals("") && !docId.equalsIgnoreCase("null")) {
-        if (ticklerNo > 0) {
-            try {
-                // Attach the source document to the tickler using the modern attachment store (ticklerdocs).
-                // The legacy docType is a table_name code (DOC / HRM / HL7 / MDS / CML / ...); anything that
-                // is not a document or HRM report is treated as a lab.
-                DocumentType attachmentType;
+    if (ticklerNo > 0) {
+        try {
+            DocumentAttachmentManager documentAttachmentManager = SpringUtils.getBean(DocumentAttachmentManager.class);
+
+            // Map the legacy forward-from-document docType (a table_name code: DOC / HRM / HL7 / MDS /
+            // CML / ...) to a DocumentType so it can be merged into the matching picker selection.
+            // Anything that is not a document or HRM report is treated as a lab.
+            DocumentType forwardedType = null;
+            if (docType != null && docId != null && !docType.trim().isEmpty()
+                    && !docId.trim().isEmpty() && !docId.equalsIgnoreCase("null")) {
                 if ("DOC".equalsIgnoreCase(docType)) {
-                    attachmentType = DocumentType.DOC;
+                    forwardedType = DocumentType.DOC;
                 } else if ("HRM".equalsIgnoreCase(docType)) {
-                    attachmentType = DocumentType.HRM;
+                    forwardedType = DocumentType.HRM;
                 } else {
-                    attachmentType = DocumentType.LAB;
+                    forwardedType = DocumentType.LAB;
                 }
-                DocumentAttachmentManager documentAttachmentManager = SpringUtils.getBean(DocumentAttachmentManager.class);
-                documentAttachmentManager.attachToTickler(loggedInInfo, attachmentType, new String[]{docId}, doccreator, ticklerNo, tickler.getDemographicNo());
-            } catch (Exception e) {
-                MiscUtils.getLogger().error("No link with this tickler", e);
             }
+
+            // The interactive attachment picker (ticklerAdd.jsp) submits one parameter per document
+            // type. attachToTickler performs a full per-type sync (it soft-deletes any stored doc of
+            // that type not in the submitted array), so each type is synced exactly once and the
+            // forwarded document is unioned into its type's list rather than attached separately.
+            java.util.LinkedHashMap<DocumentType, String> attachParams = new java.util.LinkedHashMap<DocumentType, String>();
+            attachParams.put(DocumentType.DOC, "docNo");
+            attachParams.put(DocumentType.LAB, "labNo");
+            attachParams.put(DocumentType.EFORM, "eFormNo");
+            attachParams.put(DocumentType.HRM, "hrmNo");
+            attachParams.put(DocumentType.FORM, "formNo");
+
+            for (java.util.Map.Entry<DocumentType, String> entry : attachParams.entrySet()) {
+                DocumentType attachmentType = entry.getKey();
+                String[] picked = request.getParameterValues(entry.getValue());
+
+                java.util.LinkedHashSet<String> ids = new java.util.LinkedHashSet<String>();
+                if (picked != null) {
+                    for (String id : picked) {
+                        if (id != null && !id.trim().isEmpty()) {
+                            ids.add(id.trim());
+                        }
+                    }
+                }
+                if (forwardedType == attachmentType) {
+                    ids.add(docId.trim());
+                }
+
+                documentAttachmentManager.attachToTickler(loggedInInfo, attachmentType,
+                        ids.toArray(new String[0]), doccreator, ticklerNo, tickler.getDemographicNo());
+            }
+        } catch (Exception e) {
+            MiscUtils.getLogger().error("Unable to attach documents to tickler " + ticklerNo, e);
         }
     }
 

--- a/src/main/webapp/tickler/ticklerAdd.jsp
+++ b/src/main/webapp/tickler/ticklerAdd.jsp
@@ -186,10 +186,28 @@
         table tr td {
           border:none !important;
         }
+
+        /* Keep the "Manage Attachments" button and its count badge on one line. */
+        .attachments-cell {
+            white-space: nowrap;
+        }
+
+        /* jQuery UI renders the dialog close control as a fixed ~20px square, which
+           crushes the "Save and Close" label onto multiple overflowing lines. Let it
+           grow to fit the text (matches the Consult/eForm attachment dialog). */
+        .save-and-close-button {
+            width: auto !important;
+            white-space: nowrap;
+            padding: 0 8px !important;
+        }
       </style>
       <link href="<%=request.getContextPath()%>/share/css/dateTimeQuickPick.css" rel="stylesheet" type="text/css" />
       <link href="<%= request.getContextPath() %>/library/bootstrap/3.0.0/css/bootstrap.css" rel="stylesheet" type="text/css">
+      <link href="<%=request.getContextPath() %>/library/jquery/jquery-ui-1.12.1.min.css" rel="stylesheet" type="text/css">
       <script type="text/javascript" src="<%=request.getContextPath()%>/share/javascript/dateTimeQuickPick.js"></script>
+      <script type="text/javascript" src="<%=request.getContextPath()%>/library/jquery/jquery-3.6.4.min.js"></script>
+      <script type="text/javascript" src="<%=request.getContextPath()%>/library/jquery/jquery-ui-1.12.1.min.js"></script>
+      <script type="text/javascript" src="<%=request.getContextPath()%>/js/jquery_oscar_defaults.js"></script>
 
       <script>
         function pasteMessageText() {
@@ -559,7 +577,7 @@
                 </tr>
             </table>
         </form>
-        <form name="serviceform" method="post">
+        <form name="serviceform" id="serviceform" method="post">
             <input type="hidden" name="parentAjaxId" value="<%=Encode.forHtmlAttribute(parentAjaxId)%>">
             <input type="hidden" name="updateParent" value="<%=Encode.forHtmlAttribute(updateParent)%>">
             <input type="hidden" name="user_no" value="<%=Encode.forHtmlAttribute(user_no)%>">
@@ -727,6 +745,15 @@
                     </td>
                 </tr>
                 <tr>
+                    <td><label>Attachments:</label></td>
+                    <td class="attachments-cell">
+                        <button type="button" class="btn" id="manageAttachmentsBtn" title="Manage Attachments">
+                            <i class="glyphicon glyphicon-paperclip"></i> Manage Attachments
+                        </button>
+                        <span id="attachmentCount" class="badge">0</span>
+                    </td>
+                </tr>
+                <tr>
                     <td colspan="2"><input type="button" name="Button" class="btn btn-primary"
                                value="<fmt:setBundle basename="oscarResources"/><fmt:message key="tickler.ticklerAdd.btnSubmit"/>"
                                onclick="validate(this.form);">
@@ -737,7 +764,80 @@
                 </tr>
 
             </table>
+            <div id="attachDocumentDisplay" style="display:none;"></div>
         </form>
     </div>
+
+    <jsp:include page="/images/spinner.jsp" flush="true"/>
+
+    <script type="text/javascript">
+        /**
+         * Tickler document attachment dialog (Add screen).
+         *
+         * Mirrors the edit screen: the shared attachment picker (attachDocument.jsp) is loaded into a
+         * jQuery UI dialog. Because a new tickler has no id yet, the picker is loaded with only the
+         * patient's demographicNo and the checked items are written back to the add form as hidden
+         * ".delegateAttachment" inputs (docNo / labNo / eFormNo / hrmNo / formNo). dbTicklerAdd.jsp
+         * reads those parameters after the tickler is created and persists them to ticklerdocs.
+         *
+         * The demographic is resolved at click time rather than page-render time, since the patient
+         * may be selected (via the search form) after this page first loads.
+         */
+        jQuery(document).on('click', '#manageAttachmentsBtn', function () {
+            var $form = jQuery('#serviceform');
+            var trigger = jQuery(this);
+            var title = trigger.attr("title");
+            var demographicNo = $form.find('input[name="demographic_no"]').val();
+
+            if (!demographicNo) {
+                alert("Please select a patient before managing attachments.");
+                return;
+            }
+
+            var poload = '<%=request.getContextPath()%>/previewDocs.do?method=fetchTicklerDocuments&demographicNo='
+                + encodeURIComponent(demographicNo);
+
+            jQuery("#attachDocumentDisplay").load(poload, function (response, status, xhr) {
+                if (status === "success") {
+                    // Pre-check the picker boxes for attachments already staged on this add form.
+                    $form.find(".delegateAttachment").each(function () {
+                        var checkboxId = this.name + this.value;
+                        jQuery('#attachDocumentsForm').find('#' + jQuery.escapeSelector(checkboxId)).prop('checked', true);
+                    });
+                }
+            }).dialog({
+                title: title,
+                modal: true,
+                closeText: "Save and Close",
+                height: 'auto',
+                width: 'auto',
+                resizable: true,
+                open: function (event, ui) {
+                    jQuery(this).parent().css({top: 0, left: 0});
+                    var closeBtn = jQuery(this).parent().find(".ui-dialog-titlebar-close");
+                    closeBtn.removeClass("ui-button-icon-only");
+                    closeBtn.addClass("save-and-close-button");
+                    closeBtn.html("Save and Close");
+                },
+                beforeClose: function (event, ui) {
+                    // Rebuild the add form's staged attachment set from the picker's checked boxes.
+                    $form.find(".delegateAttachment").remove();
+                    jQuery('#attachDocumentsForm')
+                        .find(".document_check:checked, .lab_check:checked, .form_check:checked, .eForm_check:checked, .hrm_check:checked")
+                        .each(function () {
+                            var element = jQuery(this);
+                            jQuery("<input />", {
+                                type: 'hidden',
+                                name: element.attr('name'),
+                                value: element.val(),
+                                id: "delegate_" + element.attr('name') + element.val(),
+                                "class": 'delegateAttachment'
+                            }).appendTo($form);
+                        });
+                    jQuery('#attachmentCount').text($form.find(".delegateAttachment").length);
+                }
+            });
+        });
+    </script>
     </body>
 </html>

--- a/src/main/webapp/tickler/ticklerAdd.jsp
+++ b/src/main/webapp/tickler/ticklerAdd.jsp
@@ -179,7 +179,8 @@
         <title><fmt:setBundle basename="oscarResources"/><fmt:message key="tickler.ticklerAdd.title"/></title>
 
       <style>
-        *:not(h2):not(.btn) {
+        /* Don't compress the attachment picker dialog — it styles itself. */
+        *:not(h2):not(.btn):not(.ui-dialog):not(.ui-dialog *) {
           line-height: 1 !important;
           font-size: 12px !important;
         }
@@ -190,6 +191,27 @@
         /* Keep the "Manage Attachments" button and its count badge on one line. */
         .attachments-cell {
             white-space: nowrap;
+        }
+
+        /* Visible list of attachment names below the "Manage Attachments" button. */
+        #attachmentNames {
+            white-space: normal;
+            margin-top: 6px;
+        }
+
+        #attachmentNames .attachment-group-heading {
+            font-weight: bold;
+            margin-top: 4px;
+        }
+
+        #attachmentNames ul {
+            list-style: none;
+            margin: 2px 0 4px;
+            padding-left: 1.5em;
+        }
+
+        #attachmentNames li {
+            padding: 2px 0;
         }
 
         /* jQuery UI renders the dialog close control as a fixed ~20px square, which
@@ -751,6 +773,29 @@
                             <i class="glyphicon glyphicon-paperclip"></i> Manage Attachments
                         </button>
                         <span id="attachmentCount" class="badge">0</span>
+                        <%-- Staged attachment names by type; filled by the picker dialog's beforeClose handler. --%>
+                        <div id="attachmentNames">
+                            <div class="attachment-group" id="attachmentGroup_eFormNo" style="display:none;">
+                                <div class="attachment-group-heading">eForms</div>
+                                <ul id="attachmentNames_eFormNo"></ul>
+                            </div>
+                            <div class="attachment-group" id="attachmentGroup_docNo" style="display:none;">
+                                <div class="attachment-group-heading">Documents</div>
+                                <ul id="attachmentNames_docNo"></ul>
+                            </div>
+                            <div class="attachment-group" id="attachmentGroup_labNo" style="display:none;">
+                                <div class="attachment-group-heading">Labs</div>
+                                <ul id="attachmentNames_labNo"></ul>
+                            </div>
+                            <div class="attachment-group" id="attachmentGroup_hrmNo" style="display:none;">
+                                <div class="attachment-group-heading">HRM</div>
+                                <ul id="attachmentNames_hrmNo"></ul>
+                            </div>
+                            <div class="attachment-group" id="attachmentGroup_formNo" style="display:none;">
+                                <div class="attachment-group-heading">Forms</div>
+                                <ul id="attachmentNames_formNo"></ul>
+                            </div>
+                        </div>
                     </td>
                 </tr>
                 <tr>
@@ -822,6 +867,7 @@
                 beforeClose: function (event, ui) {
                     // Rebuild the add form's staged attachment set from the picker's checked boxes.
                     $form.find(".delegateAttachment").remove();
+                    jQuery('#attachmentNames ul').empty();
                     jQuery('#attachDocumentsForm')
                         .find(".document_check:checked, .lab_check:checked, .form_check:checked, .eForm_check:checked, .hrm_check:checked")
                         .each(function () {
@@ -833,7 +879,11 @@
                                 id: "delegate_" + element.attr('name') + element.val(),
                                 "class": 'delegateAttachment'
                             }).appendTo($form);
+                            jQuery("<li>").text(element.attr('title')).appendTo('#attachmentNames_' + element.attr('name'));
                         });
+                    jQuery('#attachmentNames .attachment-group').each(function () {
+                        jQuery(this).toggle(jQuery(this).find('li').length > 0);
+                    });
                     jQuery('#attachmentCount').text($form.find(".delegateAttachment").length);
                 }
             });

--- a/src/main/webapp/tickler/ticklerDemoMain.jsp
+++ b/src/main/webapp/tickler/ticklerDemoMain.jsp
@@ -959,7 +959,7 @@
                                                     patientLabRoutingDao.findByLabNo(td.getDocumentNo());
                                             String labType = (plr != null) ? plr.getLabType() : null;
                                             if (LabResultData.MDS.equals(labType)) {
-                                                href = "SegmentDisplay.jsp?segmentID=" + Encode.forUriComponent(docNoStr)
+                                                href = request.getContextPath() + "/oscarMDS/SegmentDisplay.jsp?segmentID=" + Encode.forUriComponent(docNoStr)
                                                         + "&providerNo=" + Encode.forUriComponent(String.valueOf(user_no))
                                                         + "&searchProviderNo=" + Encode.forUriComponent(String.valueOf(user_no)) + "&status=";
                                             } else if (LabResultData.CML.equals(labType)) {

--- a/src/main/webapp/tickler/ticklerDemoMain.jsp
+++ b/src/main/webapp/tickler/ticklerDemoMain.jsp
@@ -900,7 +900,7 @@
                             <TD ROWSPAN="1" class="<%=Encode.forHtmlAttribute(String.valueOf(cellColour))%>">
                                 <%if (Boolean.parseBoolean(OscarProperties.getInstance().getProperty("tickler_edit_enabled"))) {%>
                                 <a href=#
-                                   onClick="popupPage(600,800, '<%= request.getContextPath() %>/tickler/ticklerEdit.jsp?tickler_no=<%=Encode.forUriComponent(String.valueOf(t.getId()))%>')"><fmt:setBundle basename="oscarResources"/><fmt:message key="tickler.ticklerMain.editTickler"/></a>
+                                   onClick="popupPage(600,960, '<%= request.getContextPath() %>/tickler/ticklerEdit.jsp?tickler_no=<%=Encode.forJavaScript(String.valueOf(t.getId()))%>')"><fmt:setBundle basename="oscarResources"/><fmt:message key="tickler.ticklerMain.editTickler"/></a>
                                 <% } %>
                             </TD>
                             <TD ROWSPAN="1" class="<%=Encode.forHtmlAttribute(String.valueOf(cellColour))%>"><a

--- a/src/main/webapp/tickler/ticklerDemoMain.jsp
+++ b/src/main/webapp/tickler/ticklerDemoMain.jsp
@@ -78,8 +78,6 @@
 <%@ page import="ca.openosp.openo.commn.model.TicklerComment" %>
 <%@ page import="ca.openosp.openo.commn.model.TicklerUpdate" %>
 <%@ page import="ca.openosp.openo.managers.TicklerManager" %>
-<%@ page import="ca.openosp.openo.commn.model.TicklerLink" %>
-<%@ page import="ca.openosp.openo.commn.dao.TicklerLinkDao" %>
 <%@ page import="ca.openosp.openo.lab.ca.on.*" %>
 <%@ page import="ca.openosp.openo.lab.ca.on.LabResultData" %>
 <%@ page import="org.owasp.encoder.Encode" %>
@@ -90,7 +88,8 @@
     OscarAppointmentDao appointmentDao = SpringUtils.getBean(OscarAppointmentDao.class);
     DemographicDao demographicDao = SpringUtils.getBean(DemographicDao.class);
 
-    TicklerLinkDao ticklerLinkDao = (TicklerLinkDao) SpringUtils.getBean(TicklerLinkDao.class);
+    ca.openosp.openo.commn.dao.TicklerDocsDao ticklerDocsDao = SpringUtils.getBean(ca.openosp.openo.commn.dao.TicklerDocsDao.class);
+    ca.openosp.openo.commn.dao.PatientLabRoutingDao patientLabRoutingDao = SpringUtils.getBean(ca.openosp.openo.commn.dao.PatientLabRoutingDao.class);
 %>
 
 
@@ -937,39 +936,53 @@
                             <TD ROWSPAN="1" class="<%=Encode.forHtmlAttribute(String.valueOf(cellColour))%>"><%=Encode.forHtml(String.valueOf(t.getMessage()))%>
 
                                 <%
-                                    List<TicklerLink> linkList = ticklerLinkDao.getLinkByTickler(t.getId().intValue());
-                                    if (linkList != null) {
-                                        for (TicklerLink tl : linkList) {
-                                            String type = tl.getTableName();
+                                    // Render the tickler's attachments from the modern attachment store (ticklerdocs).
+                                    // Lab sub-type is recovered from patient_lab_routing to pick the correct viewer.
+                                    List<ca.openosp.openo.commn.model.TicklerDocs> ticklerDocsList =
+                                            ticklerDocsDao.findByTicklerId(t.getId());
+                                    for (ca.openosp.openo.commn.model.TicklerDocs td : ticklerDocsList) {
+                                        String dtype = td.getDocType();
+                                        String docNoStr = String.valueOf(td.getDocumentNo());
+                                        String href;
+                                        if (ca.openosp.openo.commn.model.TicklerDocs.DOCTYPE_DOC.equals(dtype)) {
+                                            href = request.getContextPath() + "/documentManager/ManageDocument.do?method=display&doc_no="
+                                                    + Encode.forUriComponent(docNoStr) + "&providerNo=" + Encode.forUriComponent(String.valueOf(user_no))
+                                                    + "&searchProviderNo=" + Encode.forUriComponent(String.valueOf(user_no)) + "&status=";
+                                        } else if (ca.openosp.openo.commn.model.TicklerDocs.DOCTYPE_HRM.equals(dtype)) {
+                                            href = request.getContextPath() + "/hospitalReportManager/Display.do?id=" + Encode.forUriComponent(docNoStr);
+                                        } else if (ca.openosp.openo.commn.model.TicklerDocs.DOCTYPE_EFORM.equals(dtype)) {
+                                            href = request.getContextPath() + "/eform/efmshowform_data.jsp?fdid=" + Encode.forUriComponent(docNoStr);
+                                        } else if (ca.openosp.openo.commn.model.TicklerDocs.DOCTYPE_FORM.equals(dtype)) {
+                                            href = null;
+                                        } else {
+                                            ca.openosp.openo.commn.model.PatientLabRouting plr =
+                                                    patientLabRoutingDao.findByLabNo(td.getDocumentNo());
+                                            String labType = (plr != null) ? plr.getLabType() : null;
+                                            if (LabResultData.MDS.equals(labType)) {
+                                                href = "SegmentDisplay.jsp?segmentID=" + Encode.forUriComponent(docNoStr)
+                                                        + "&providerNo=" + Encode.forUriComponent(String.valueOf(user_no))
+                                                        + "&searchProviderNo=" + Encode.forUriComponent(String.valueOf(user_no)) + "&status=";
+                                            } else if (LabResultData.CML.equals(labType)) {
+                                                href = request.getContextPath() + "/lab/CA/ON/CMLDisplay.jsp?segmentID=" + Encode.forUriComponent(docNoStr)
+                                                        + "&providerNo=" + Encode.forUriComponent(String.valueOf(user_no))
+                                                        + "&searchProviderNo=" + Encode.forUriComponent(String.valueOf(user_no)) + "&status=";
+                                            } else if (LabResultData.HL7TEXT.equals(labType)) {
+                                                href = request.getContextPath() + "/lab/CA/ALL/labDisplay.jsp?segmentID=" + Encode.forUriComponent(docNoStr)
+                                                        + "&providerNo=" + Encode.forUriComponent(String.valueOf(user_no))
+                                                        + "&searchProviderNo=" + Encode.forUriComponent(String.valueOf(user_no)) + "&status=";
+                                            } else {
+                                                href = request.getContextPath() + "/lab/CA/BC/labDisplay.jsp?segmentID=" + Encode.forUriComponent(docNoStr)
+                                                        + "&providerNo=" + Encode.forUriComponent(String.valueOf(user_no))
+                                                        + "&searchProviderNo=" + Encode.forUriComponent(String.valueOf(user_no)) + "&status=";
+                                            }
+                                        }
+                                        if (href != null) {
                                 %>
-
+                                <a href="javascript:reportWindow('<%=Encode.forJavaScript(href)%>')">ATT</a>
                                 <%
-                                    if (LabResultData.isMDS(type)) {
+                                        } else {
                                 %>
-                                <a href="javascript:reportWindow('SegmentDisplay.jsp?segmentID=<%=Encode.forUriComponent(String.valueOf(tl.getTableId()))%>&providerNo=<%=Encode.forUriComponent(String.valueOf(user_no))%>&searchProviderNo=<%=Encode.forUriComponent(String.valueOf(user_no))%>&status=')">ATT</a>
-                                <%
-                                } else if (LabResultData.isCML(type)) {
-                                %>
-                                <a href="javascript:reportWindow('<%= request.getContextPath() %>/lab/CA/ON/CMLDisplay.jsp?segmentID=<%=Encode.forUriComponent(String.valueOf(tl.getTableId()))%>&providerNo=<%=Encode.forUriComponent(String.valueOf(user_no))%>&searchProviderNo=<%=Encode.forUriComponent(String.valueOf(user_no))%>&status=')">ATT</a>
-                                <%
-                                } else if (LabResultData.isHL7TEXT(type)) {
-                                %>
-                                <a href="javascript:reportWindow('<%= request.getContextPath() %>/lab/CA/ALL/labDisplay.jsp?segmentID=<%=Encode.forUriComponent(String.valueOf(tl.getTableId()))%>&providerNo=<%=Encode.forUriComponent(String.valueOf(user_no))%>&searchProviderNo=<%=Encode.forUriComponent(String.valueOf(user_no))%>&status=')">ATT</a>
-                                <%
-                                } else if (LabResultData.isDocument(type)) {
-                                %>
-                                <a href="javascript:reportWindow('<%=request.getContextPath()%>/documentManager/ManageDocument.do?method=display&doc_no=<%=Encode.forUriComponent(String.valueOf(tl.getTableId()))%>&providerNo=<%=Encode.forUriComponent(String.valueOf(user_no))%>&searchProviderNo=<%=Encode.forUriComponent(String.valueOf(user_no))%>&status=')">ATT</a>
-                                <%
-                                } else if (LabResultData.isHRM(type)) {
-                                %>
-                                <a href="javascript:reportWindow('<%=request.getContextPath()%>/hospitalReportManager/Display.do?id=<%=Encode.forUriComponent(String.valueOf(tl.getTableId()))%>')">ATT</a>
-                                <%
-                                } else {
-                                %>
-                                <a href="javascript:reportWindow('<%= request.getContextPath() %>/lab/CA/BC/labDisplay.jsp?segmentID=<%=Encode.forUriComponent(String.valueOf(tl.getTableId()))%>&providerNo=<%=Encode.forUriComponent(String.valueOf(user_no))%>&searchProviderNo=<%=Encode.forUriComponent(String.valueOf(user_no))%>&status=')">ATT</a>
-                                <%
-                                    }
-                                %>
+                                <span title="Attached form">ATT</span>
                                 <%
                                         }
                                     }

--- a/src/main/webapp/tickler/ticklerDemoMain.jsp
+++ b/src/main/webapp/tickler/ticklerDemoMain.jsp
@@ -90,6 +90,10 @@
 
     ca.openosp.openo.commn.dao.TicklerDocsDao ticklerDocsDao = SpringUtils.getBean(ca.openosp.openo.commn.dao.TicklerDocsDao.class);
     ca.openosp.openo.commn.dao.PatientLabRoutingDao patientLabRoutingDao = SpringUtils.getBean(ca.openosp.openo.commn.dao.PatientLabRoutingDao.class);
+    ca.openosp.openo.documentManager.DocumentAttachmentManager documentAttachmentManager = SpringUtils.getBean(ca.openosp.openo.documentManager.DocumentAttachmentManager.class);
+
+    // Encounter form names, resolved lazily per patient the first time a form attachment is seen.
+    java.util.Map<Integer, java.util.Map<String, String>> formNamesByDemographic = new java.util.HashMap<Integer, java.util.Map<String, String>>();
 %>
 
 
@@ -953,7 +957,23 @@
                                         } else if (ca.openosp.openo.commn.model.TicklerDocs.DOCTYPE_EFORM.equals(dtype)) {
                                             href = request.getContextPath() + "/eform/efmshowform_data.jsp?fdid=" + Encode.forUriComponent(docNoStr);
                                         } else if (ca.openosp.openo.commn.model.TicklerDocs.DOCTYPE_FORM.equals(dtype)) {
-                                            href = null;
+                                            // Encounter forms span many tables, so the id alone cannot address one.
+                                            // Recover the name from the patient's forms to build a URL
+                                            // When it no longer resolves, fall through to the unlinked marker.
+                                            Integer formDemographicNo = t.getDemographicNo();
+                                            if (!formNamesByDemographic.containsKey(formDemographicNo)) {
+                                                formNamesByDemographic.put(formDemographicNo,
+                                                        documentAttachmentManager.getFormNamesByFormId(loggedInInfo, formDemographicNo));
+                                            }
+                                            String formName = formNamesByDemographic.get(formDemographicNo).get(docNoStr);
+                                            if (formName == null) {
+                                                href = null;
+                                            } else {
+                                                href = request.getContextPath() + "/form/forwardshortcutname.do?formname="
+                                                        + Encode.forUriComponent(formName)
+                                                        + "&demographic_no=" + Encode.forUriComponent(String.valueOf(formDemographicNo))
+                                                        + "&formId=" + Encode.forUriComponent(docNoStr);
+                                            }
                                         } else {
                                             ca.openosp.openo.commn.model.PatientLabRouting plr =
                                                     patientLabRoutingDao.findByLabNo(td.getDocumentNo());

--- a/src/main/webapp/tickler/ticklerDemoMain.jsp
+++ b/src/main/webapp/tickler/ticklerDemoMain.jsp
@@ -900,7 +900,7 @@
                             <TD ROWSPAN="1" class="<%=Encode.forHtmlAttribute(String.valueOf(cellColour))%>">
                                 <%if (Boolean.parseBoolean(OscarProperties.getInstance().getProperty("tickler_edit_enabled"))) {%>
                                 <a href=#
-                                   onClick="popupPage(600,960, '<%= request.getContextPath() %>/tickler/ticklerEdit.jsp?tickler_no=<%=Encode.forJavaScript(String.valueOf(t.getId()))%>')"><fmt:setBundle basename="oscarResources"/><fmt:message key="tickler.ticklerMain.editTickler"/></a>
+                                   onClick="popupPage(600,960, '<%= request.getContextPath() %>/tickler/ticklerEdit.jsp?tickler_no=<%=Encode.forUriComponent(String.valueOf(t.getId()))%>')"><fmt:setBundle basename="oscarResources"/><fmt:message key="tickler.ticklerMain.editTickler"/></a>
                                 <% } %>
                             </TD>
                             <TD ROWSPAN="1" class="<%=Encode.forHtmlAttribute(String.valueOf(cellColour))%>"><a

--- a/src/main/webapp/tickler/ticklerEdit.jsp
+++ b/src/main/webapp/tickler/ticklerEdit.jsp
@@ -130,6 +130,27 @@
               font-size: 12px !important;
             }
 
+            /* Give the edit popup a little more room so the attachment count badge
+               stays beside the "Manage Attachments" button instead of wrapping under it. */
+            .container {
+                width: auto;
+                max-width: 940px;
+            }
+
+            /* Keep the "Manage Attachments" button and its count badge on one line. */
+            .attachments-cell {
+                white-space: nowrap;
+            }
+
+            /* jQuery UI renders the dialog close control as a fixed ~20px square, which
+               crushes the "Save and Close" label onto multiple overflowing lines. Let it
+               grow to fit the text (matches the Consult/eForm attachment dialog). */
+            .save-and-close-button {
+                width: auto !important;
+                white-space: nowrap;
+                padding: 0 8px !important;
+            }
+
             /*.grid {*/
             /*    display: grid;*/
             /*    grid-template-columns: repeat(10, 1fr);*/
@@ -544,7 +565,7 @@
                 %>
                 <tr>
                     <th colspan="2" style="background-color: #666699;color:white;">Attachments</th>
-                    <td colspan="2">
+                    <td colspan="2" class="attachments-cell">
                         <button type="button" class="btn" id="manageAttachmentsBtn"
                                 title="Manage Attachments"
                                 data-poload="${pageContext.request.contextPath}/previewDocs.do?method=fetchTicklerDocuments&amp;demographicNo=<%=Encode.forHtmlAttribute(String.valueOf(d.getDemographicNo()))%>&amp;ticklerId=<%=Encode.forHtmlAttribute(String.valueOf(ticklerNo))%>">

--- a/src/main/webapp/tickler/ticklerEdit.jsp
+++ b/src/main/webapp/tickler/ticklerEdit.jsp
@@ -45,6 +45,7 @@
 <%@page import="ca.openosp.openo.managers.TicklerManager" %>
 <%@page import="ca.openosp.openo.managers.DemographicManager" %>
 <%@page import="ca.openosp.openo.documentManager.DocumentAttachmentManager" %>
+<%@page import="ca.openosp.openo.documentManager.data.TicklerAttachmentData" %>
 <%@page import="ca.openosp.openo.commn.model.enumerator.DocumentType" %>
 <%@page import="ca.openosp.OscarProperties" %>
 <%
@@ -125,7 +126,8 @@
                 background-color: white;
             }
 
-            *:not(h2):not(.btn) {
+            /* Don't compress the attachment picker dialog — it styles itself. */
+            *:not(h2):not(.btn):not(.ui-dialog):not(.ui-dialog *) {
               line-height: 1 !important;
               font-size: 12px !important;
             }
@@ -140,6 +142,27 @@
             /* Keep the "Manage Attachments" button and its count badge on one line. */
             .attachments-cell {
                 white-space: nowrap;
+            }
+
+            /* Visible list of attachment names below the "Manage Attachments" button. */
+            #attachmentNames {
+                white-space: normal;
+                margin-top: 6px;
+            }
+
+            #attachmentNames .attachment-group-heading {
+                font-weight: bold;
+                margin-top: 4px;
+            }
+
+            #attachmentNames ul {
+                list-style: none;
+                margin: 2px 0 4px;
+                padding-left: 1.5em;
+            }
+
+            #attachmentNames li {
+                padding: 2px 0;
             }
 
             /* jQuery UI renders the dialog close control as a fixed ~20px square, which
@@ -446,7 +469,7 @@
                 </tr>
 
                 <tr>
-                    <td colspan="2" rowspan="7" style="border: none;">
+                    <td colspan="2" rowspan="6" style="border: none;">
                         <textarea class="form-control" rows="23" style="width:100%;" id="newMessage"
                                   name="newMessage"></textarea>
                         <input type="button" class="btn" name="pasteMessage" onclick="pasteMessageText()"
@@ -539,39 +562,60 @@
                     </td>
                 </tr>
                 <%
-                    // Build the hidden "delegate" inputs representing the tickler's current attachments.
-                    // These mirror the attachment picker's checkbox names (docNo/labNo/eFormNo/hrmNo/formNo)
-                    // so the dialog can pre-check them and EditTickler2Action can re-read the full selection.
-                    java.util.LinkedHashMap<DocumentType, String> ticklerAttachTypes = new java.util.LinkedHashMap<DocumentType, String>();
-                    ticklerAttachTypes.put(DocumentType.DOC, "docNo");
-                    ticklerAttachTypes.put(DocumentType.LAB, "labNo");
-                    ticklerAttachTypes.put(DocumentType.EFORM, "eFormNo");
-                    ticklerAttachTypes.put(DocumentType.HRM, "hrmNo");
-                    ticklerAttachTypes.put(DocumentType.FORM, "formNo");
+                    // Ids build hidden "delegate" inputs mirroring the picker's checkbox names so the
+                    // dialog can pre-check them; names build the visible attachment list.
+                    java.util.LinkedHashMap<DocumentType, String[]> ticklerAttachTypes = new java.util.LinkedHashMap<DocumentType, String[]>();
+                    ticklerAttachTypes.put(DocumentType.EFORM, new String[]{"eFormNo", "eForms"});
+                    ticklerAttachTypes.put(DocumentType.DOC, new String[]{"docNo", "Documents"});
+                    ticklerAttachTypes.put(DocumentType.LAB, new String[]{"labNo", "Labs"});
+                    ticklerAttachTypes.put(DocumentType.HRM, new String[]{"hrmNo", "HRM"});
+                    ticklerAttachTypes.put(DocumentType.FORM, new String[]{"formNo", "Forms"});
+
+                    List<TicklerAttachmentData> ticklerAttachments = documentAttachmentManager.getTicklerAttachmentDetails(loggedInInfo, ticklerNo, t.getDemographicNo());
 
                     StringBuilder delegateInputs = new StringBuilder();
-                    int attachmentCount = 0;
-                    for (java.util.Map.Entry<DocumentType, String> attachEntry : ticklerAttachTypes.entrySet()) {
-                        String paramName = attachEntry.getValue();
-                        for (String docId : documentAttachmentManager.getTicklerAttachments(loggedInInfo, ticklerNo, attachEntry.getKey(), t.getDemographicNo())) {
-                            attachmentCount++;
-                            delegateInputs.append("<input type=\"hidden\" class=\"delegateAttachment\" name=\"")
-                                    .append(paramName)
-                                    .append("\" value=\"").append(Encode.forHtmlAttribute(docId))
-                                    .append("\" id=\"delegate_").append(Encode.forHtmlAttribute(paramName + docId))
-                                    .append("\">");
-                        }
+                    for (TicklerAttachmentData ticklerAttachment : ticklerAttachments) {
+                        String paramName = ticklerAttachTypes.get(ticklerAttachment.getDocumentType())[0];
+                        delegateInputs.append("<input type=\"hidden\" class=\"delegateAttachment\" name=\"")
+                                .append(paramName)
+                                .append("\" value=\"").append(Encode.forHtmlAttribute(ticklerAttachment.getDocumentId()))
+                                .append("\" id=\"delegate_").append(Encode.forHtmlAttribute(paramName + ticklerAttachment.getDocumentId()))
+                                .append("\">");
                     }
+                    int attachmentCount = ticklerAttachments.size();
                 %>
                 <tr>
-                    <th colspan="2" style="background-color: #666699;color:white;">Attachments</th>
-                    <td colspan="2" class="attachments-cell">
-                        <button type="button" class="btn" id="manageAttachmentsBtn"
-                                title="Manage Attachments"
-                                data-poload="${pageContext.request.contextPath}/previewDocs.do?method=fetchTicklerDocuments&amp;demographicNo=<%=Encode.forHtmlAttribute(String.valueOf(d.getDemographicNo()))%>&amp;ticklerId=<%=Encode.forHtmlAttribute(String.valueOf(ticklerNo))%>">
-                            <i class="glyphicon glyphicon-paperclip"></i> Manage Attachments
-                        </button>
-                        <span id="attachmentCount" class="badge"><%=attachmentCount%></span>
+                    <th colspan="4" style="background-color: #666699;color:white;">Attachments</th>
+                </tr>
+                <tr>
+                    <td colspan="4">
+                        <span class="attachments-cell">
+                            <button type="button" class="btn" id="manageAttachmentsBtn"
+                                    title="Manage Attachments"
+                                    data-poload="${pageContext.request.contextPath}/previewDocs.do?method=fetchTicklerDocuments&amp;demographicNo=<%=Encode.forHtmlAttribute(String.valueOf(d.getDemographicNo()))%>&amp;ticklerId=<%=Encode.forHtmlAttribute(String.valueOf(ticklerNo))%>">
+                                <i class="glyphicon glyphicon-paperclip"></i> Manage Attachments
+                            </button>
+                            <span id="attachmentCount" class="badge"><%=attachmentCount%></span>
+                        </span>
+                        <div id="attachmentNames">
+                            <%
+                                for (java.util.Map.Entry<DocumentType, String[]> attachEntry : ticklerAttachTypes.entrySet()) {
+                                    String paramName = attachEntry.getValue()[0];
+                                    String groupLabel = attachEntry.getValue()[1];
+                                    StringBuilder groupItems = new StringBuilder();
+                                    for (TicklerAttachmentData ticklerAttachment : ticklerAttachments) {
+                                        if (ticklerAttachment.getDocumentType() != attachEntry.getKey()) {
+                                            continue;
+                                        }
+                                        groupItems.append("<li>").append(Encode.forHtmlContent(ticklerAttachment.getDisplayName())).append("</li>");
+                                    }
+                            %>
+                            <div class="attachment-group" id="attachmentGroup_<%=paramName%>" <%=groupItems.length() == 0 ? "style=\"display:none;\"" : ""%>>
+                                <div class="attachment-group-heading"><%=groupLabel%></div>
+                                <ul id="attachmentNames_<%=paramName%>"><%=groupItems.toString()%></ul>
+                            </div>
+                            <% } %>
+                        </div>
                         <%=delegateInputs.toString()%>
                     </td>
                 </tr>
@@ -637,6 +681,7 @@
                     // attachToTickler() diffs this against the stored set, so submitting the full
                     // current selection per type is sufficient for both adds and removals.
                     $form.find(".delegateAttachment").remove();
+                    jQuery('#attachmentNames ul').empty();
                     jQuery('#attachDocumentsForm')
                         .find(".document_check:checked, .lab_check:checked, .form_check:checked, .eForm_check:checked, .hrm_check:checked")
                         .each(function () {
@@ -648,7 +693,11 @@
                                 id: "delegate_" + element.attr('name') + element.val(),
                                 "class": 'delegateAttachment'
                             }).appendTo($form);
+                            jQuery("<li>").text(element.attr('title')).appendTo('#attachmentNames_' + element.attr('name'));
                         });
+                    jQuery('#attachmentNames .attachment-group').each(function () {
+                        jQuery(this).toggle(jQuery(this).find('li').length > 0);
+                    });
                     jQuery('#attachmentCount').text($form.find(".delegateAttachment").length);
                 }
             });

--- a/src/main/webapp/tickler/ticklerEdit.jsp
+++ b/src/main/webapp/tickler/ticklerEdit.jsp
@@ -44,10 +44,13 @@
 <%@page import="ca.openosp.openo.utility.LoggedInInfo" %>
 <%@page import="ca.openosp.openo.managers.TicklerManager" %>
 <%@page import="ca.openosp.openo.managers.DemographicManager" %>
+<%@page import="ca.openosp.openo.documentManager.DocumentAttachmentManager" %>
+<%@page import="ca.openosp.openo.commn.model.enumerator.DocumentType" %>
 <%@page import="ca.openosp.OscarProperties" %>
 <%
     TicklerManager ticklerManager = SpringUtils.getBean(TicklerManager.class);
     DemographicManager demographicManager = SpringUtils.getBean(DemographicManager.class);
+    DocumentAttachmentManager documentAttachmentManager = SpringUtils.getBean(DocumentAttachmentManager.class);
     LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
 %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
@@ -294,11 +297,17 @@
         <link href="<%= request.getContextPath() %>/library/bootstrap/3.0.0/css/bootstrap.css" rel="stylesheet"
               type="text/css">
 
+        <script type="text/javascript" src="<%=request.getContextPath()%>/library/jquery/jquery-3.6.4.min.js"></script>
+        <script type="text/javascript" src="<%=request.getContextPath()%>/library/jquery/jquery-ui-1.12.1.min.js"></script>
+        <script type="text/javascript" src="<%=request.getContextPath()%>/js/jquery_oscar_defaults.js"></script>
+        <link href="<%=request.getContextPath() %>/library/jquery/jquery-ui-1.12.1.min.css" rel="stylesheet"
+              type="text/css">
+
     </head>
 
     <body>
     <div class="container">
-        <form name="serviceform" action="${pageContext.request.contextPath}/tickler/EditTickler.do" method="post">
+        <form id="ticklerEditForm" name="serviceform" action="${pageContext.request.contextPath}/tickler/EditTickler.do" method="post">
             <input type="hidden" name="method" value="editTickler"/>
             <input type="hidden" name="ticklerNo" value="<%=Encode.forHtmlAttribute(String.valueOf(ticklerNo))%>"/>
             <input type="hidden" name="parentAjaxId" value="<e:forHtml value='${param.parentAjaxId}' />"/>
@@ -508,6 +517,43 @@
                         </div>
                     </td>
                 </tr>
+                <%
+                    // Build the hidden "delegate" inputs representing the tickler's current attachments.
+                    // These mirror the attachment picker's checkbox names (docNo/labNo/eFormNo/hrmNo/formNo)
+                    // so the dialog can pre-check them and EditTickler2Action can re-read the full selection.
+                    java.util.LinkedHashMap<DocumentType, String> ticklerAttachTypes = new java.util.LinkedHashMap<DocumentType, String>();
+                    ticklerAttachTypes.put(DocumentType.DOC, "docNo");
+                    ticklerAttachTypes.put(DocumentType.LAB, "labNo");
+                    ticklerAttachTypes.put(DocumentType.EFORM, "eFormNo");
+                    ticklerAttachTypes.put(DocumentType.HRM, "hrmNo");
+                    ticklerAttachTypes.put(DocumentType.FORM, "formNo");
+
+                    StringBuilder delegateInputs = new StringBuilder();
+                    int attachmentCount = 0;
+                    for (java.util.Map.Entry<DocumentType, String> attachEntry : ticklerAttachTypes.entrySet()) {
+                        String paramName = attachEntry.getValue();
+                        for (String docId : documentAttachmentManager.getTicklerAttachments(loggedInInfo, ticklerNo, attachEntry.getKey(), t.getDemographicNo())) {
+                            attachmentCount++;
+                            delegateInputs.append("<input type=\"hidden\" class=\"delegateAttachment\" name=\"")
+                                    .append(paramName)
+                                    .append("\" value=\"").append(Encode.forHtmlAttribute(docId))
+                                    .append("\" id=\"delegate_").append(Encode.forHtmlAttribute(paramName + docId))
+                                    .append("\">");
+                        }
+                    }
+                %>
+                <tr>
+                    <th colspan="2" style="background-color: #666699;color:white;">Attachments</th>
+                    <td colspan="2">
+                        <button type="button" class="btn" id="manageAttachmentsBtn"
+                                title="Manage Attachments"
+                                data-poload="${pageContext.request.contextPath}/previewDocs.do?method=fetchTicklerDocuments&amp;demographicNo=<%=Encode.forHtmlAttribute(String.valueOf(d.getDemographicNo()))%>&amp;ticklerId=<%=Encode.forHtmlAttribute(String.valueOf(ticklerNo))%>">
+                            <i class="glyphicon glyphicon-paperclip"></i> Manage Attachments
+                        </button>
+                        <span id="attachmentCount" class="badge"><%=attachmentCount%></span>
+                        <%=delegateInputs.toString()%>
+                    </td>
+                </tr>
                 <tr>
                     <td colspan="2" style="vertical-align: bottom;text-align:right; padding-top:15px; border:none;">
                         <oscar:oscarPropertiesCheck property="tickler_email_enabled" value="true">
@@ -522,8 +568,71 @@
                     </td>
                 </tr>
             </table>
+            <div id="attachDocumentDisplay" style="display:none;"></div>
         </form>
     </div>
+
+    <jsp:include page="/images/spinner.jsp" flush="true"/>
+
+    <script type="text/javascript">
+        /**
+         * Tickler document attachment dialog.
+         *
+         * Loads the shared attachment picker (attachDocument.jsp) into a jQuery UI dialog. Existing
+         * attachments are pre-checked from the hidden ".delegateAttachment" inputs rendered in the
+         * tickler form. On "Save and Close" the full set of checked items is written back as
+         * ".delegateAttachment" hidden inputs, which EditTickler2Action reads to synchronise the
+         * tickler's attachments (the manager soft-deletes any that were removed).
+         */
+        jQuery(document).on('click', '#manageAttachmentsBtn', function () {
+            var $form = jQuery('#ticklerEditForm');
+            var trigger = jQuery(this);
+            var title = trigger.attr("title");
+
+            jQuery("#attachDocumentDisplay").load(trigger.data('poload'), function (response, status, xhr) {
+                if (status === "success") {
+                    // Pre-check the picker boxes for attachments already on this tickler.
+                    $form.find(".delegateAttachment").each(function () {
+                        var checkboxId = this.name + this.value;
+                        jQuery('#attachDocumentsForm').find('#' + jQuery.escapeSelector(checkboxId)).prop('checked', true);
+                    });
+                }
+            }).dialog({
+                title: title,
+                modal: true,
+                closeText: "Save and Close",
+                height: 'auto',
+                width: 'auto',
+                resizable: true,
+                open: function (event, ui) {
+                    jQuery(this).parent().css({top: 0, left: 0});
+                    var closeBtn = jQuery(this).parent().find(".ui-dialog-titlebar-close");
+                    closeBtn.removeClass("ui-button-icon-only");
+                    closeBtn.addClass("save-and-close-button");
+                    closeBtn.html("Save and Close");
+                },
+                beforeClose: function (event, ui) {
+                    // Rebuild the tickler form's attachment set from the picker's checked boxes.
+                    // attachToTickler() diffs this against the stored set, so submitting the full
+                    // current selection per type is sufficient for both adds and removals.
+                    $form.find(".delegateAttachment").remove();
+                    jQuery('#attachDocumentsForm')
+                        .find(".document_check:checked, .lab_check:checked, .form_check:checked, .eForm_check:checked, .hrm_check:checked")
+                        .each(function () {
+                            var element = jQuery(this);
+                            jQuery("<input />", {
+                                type: 'hidden',
+                                name: element.attr('name'),
+                                value: element.val(),
+                                id: "delegate_" + element.attr('name') + element.val(),
+                                "class": 'delegateAttachment'
+                            }).appendTo($form);
+                        });
+                    jQuery('#attachmentCount').text($form.find(".delegateAttachment").length);
+                }
+            });
+        });
+    </script>
 
     </body>
 </html>

--- a/src/main/webapp/tickler/ticklerEdit.jsp
+++ b/src/main/webapp/tickler/ticklerEdit.jsp
@@ -132,11 +132,14 @@
               font-size: 12px !important;
             }
 
-            /* Give the edit popup a little more room so the attachment count badge
-               stays beside the "Manage Attachments" button instead of wrapping under it. */
-            .container {
-                width: auto;
-                max-width: 940px;
+            /* Shrink the quick-pick date grid so all 10 columns fit the edit window's width. */
+            #quickPickDateOptions {
+                grid-gap: 1px;
+                width: 400px;
+            }
+            #quickPickDateOptions a {
+                padding: 2px 4px;
+                min-width: 0;
             }
 
             /* Keep the "Manage Attachments" button and its count badge on one line. */

--- a/src/main/webapp/tickler/ticklerEdit.jsp
+++ b/src/main/webapp/tickler/ticklerEdit.jsp
@@ -472,7 +472,7 @@
                 </tr>
 
                 <tr>
-                    <td colspan="2" rowspan="6" style="border: none;">
+                    <td colspan="2" rowspan="8" style="border: none;">
                         <textarea class="form-control" rows="23" style="width:100%;" id="newMessage"
                                   name="newMessage"></textarea>
                         <input type="button" class="btn" name="pasteMessage" onclick="pasteMessageText()"
@@ -588,10 +588,10 @@
                     int attachmentCount = ticklerAttachments.size();
                 %>
                 <tr>
-                    <th colspan="4" style="background-color: #666699;color:white;">Attachments</th>
+                    <th colspan="2" style="background-color: #666699;color:white;">Attachments</th>
                 </tr>
                 <tr>
-                    <td colspan="4">
+                    <td colspan="2">
                         <span class="attachments-cell">
                             <button type="button" class="btn" id="manageAttachmentsBtn"
                                     title="Manage Attachments"

--- a/src/main/webapp/tickler/ticklerMain.jsp
+++ b/src/main/webapp/tickler/ticklerMain.jsp
@@ -228,7 +228,7 @@
             function renderEditIcon(data, type, row) {
                 return '<a href="javascript:void(0)" title="Edit Tickler" ' +
                     'onClick="window.open(\'' + ctx + '/tickler/ticklerEdit.jsp?tickler_no=' + row.id +
-                    '\', \'edit_tickler\', \'width=800, height=650\')">' +
+                    '\', \'edit_tickler\', \'width=960, height=650\')">' +
                     '<span class="glyphicon glyphicon-pencil"></span></a>';
             }
 

--- a/src/main/webapp/tickler/ticklerMain.jsp
+++ b/src/main/webapp/tickler/ticklerMain.jsp
@@ -281,6 +281,10 @@
                 } else if (type === 'HRM') {
                     href = "javascript:reportWindow('" + ctx + "/hospitalReportManager/Display.do?id=" + safeTableId +
                         "&segmentID=" + safeTableId + "')";
+                } else if (type === 'EFORM') {
+                    href = ctx + "/eform/efmshowform_data.jsp?fdid=" + safeTableId;
+                } else if (type === 'FORM') {
+                    return ' <i class="glyphicon glyphicon-paperclip" title="Attached form"></i>';
                 } else {
                     href = "javascript:reportWindow('" + ctx + "/lab/CA/BC/labDisplay.jsp?segmentID=" + safeTableId +
                         "&providerNo=" + uNo + "&searchProviderNo=" + uNo + "&status=')";

--- a/src/main/webapp/tickler/ticklerMain.jsp
+++ b/src/main/webapp/tickler/ticklerMain.jsp
@@ -282,7 +282,7 @@
                     href = "javascript:reportWindow('" + ctx + "/hospitalReportManager/Display.do?id=" + safeTableId +
                         "&segmentID=" + safeTableId + "')";
                 } else if (type === 'EFORM') {
-                    href = ctx + "/eform/efmshowform_data.jsp?fdid=" + safeTableId;
+                    href = "javascript:reportWindow('" + ctx + "/eform/efmshowform_data.jsp?fdid=" + safeTableId + "')";
                 } else if (type === 'FORM') {
                     return ' <i class="glyphicon glyphicon-paperclip" title="Attached form"></i>';
                 } else {

--- a/src/main/webapp/tickler/ticklerMain.jsp
+++ b/src/main/webapp/tickler/ticklerMain.jsp
@@ -35,6 +35,12 @@
 <%@ page import="ca.openosp.OscarProperties" %>
 <%@ page import="ca.openosp.openo.commn.model.Site" %>
 <%@ page import="ca.openosp.openo.commn.dao.SiteDao" %>
+<%@ page import="ca.openosp.openo.commn.model.CustomFilter" %>
+<%@ page import="ca.openosp.openo.managers.TicklerManager" %>
+<%@ page import="ca.openosp.openo.tickler.dto.TicklerListDTO" %>
+<%@ page import="ca.openosp.openo.tickler.dto.TicklerCommentDTO" %>
+<%@ page import="java.text.DateFormat" %>
+<%@ page import="java.text.SimpleDateFormat" %>
 <%@ page import="java.util.*" %>
 <%@ page import="org.owasp.encoder.Encode" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>

--- a/src/main/webapp/tickler/ticklerMain.jsp
+++ b/src/main/webapp/tickler/ticklerMain.jsp
@@ -249,7 +249,7 @@
                 var html = '<span style="white-space:pre-wrap">' + escapeHtml(row.message) + '</span>';
                 if (row.links) {
                     for (var i = 0; i < row.links.length; i++) {
-                        html += buildAttachmentLink(row.links[i].tableName, row.links[i].tableId);
+                        html += buildAttachmentLink(row.links[i], row);
                     }
                 }
                 return html;
@@ -262,9 +262,16 @@
                     '<span class="glyphicon glyphicon-comment"></span></a>';
             }
 
-            function buildAttachmentLink(type, tableId) {
+            // encodeURIComponent leaves "'" as-is, which would close the JS string inside the
+            // javascript: hrefs below. %27 is its equivalent percent-encoding.
+            function encodeUrlParam(value) {
+                return encodeURIComponent(value).replace(/'/g, "%27");
+            }
+
+            function buildAttachmentLink(link, row) {
+                var type = link.tableName;
                 var uNo = encodeURIComponent(userNo);
-                var safeTableId = encodeURIComponent(tableId);
+                var safeTableId = encodeURIComponent(link.tableId);
                 var href;
                 if (type === 'MDS') {
                     href = "javascript:reportWindow('" + ctx + "/oscarMDS/SegmentDisplay.jsp?segmentID=" + safeTableId +
@@ -284,7 +291,14 @@
                 } else if (type === 'EFORM') {
                     href = "javascript:reportWindow('" + ctx + "/eform/efmshowform_data.jsp?fdid=" + safeTableId + "')";
                 } else if (type === 'FORM') {
-                    return ' <i class="glyphicon glyphicon-paperclip" title="Attached form"></i>';
+                    // Encounter forms are spread across many tables, so the id alone cannot address
+                    // one. Without the name resolved server-side there is no URL to build.
+                    if (!link.formName) {
+                        return ' <i class="glyphicon glyphicon-paperclip" title="Attached form"></i>';
+                    }
+                    href = "javascript:reportWindow('" + ctx + "/form/forwardshortcutname.do?formname=" +
+                        encodeUrlParam(link.formName) + "&demographic_no=" + encodeUrlParam(row.demoNo) +
+                        "&formId=" + safeTableId + "')";
                 } else {
                     href = "javascript:reportWindow('" + ctx + "/lab/CA/BC/labDisplay.jsp?segmentID=" + safeTableId +
                         "&providerNo=" + uNo + "&searchProviderNo=" + uNo + "&status=')";

--- a/src/test-modern/java/ca/openosp/openo/documentManager/DocumentAttachmentManagerUnitTest.java
+++ b/src/test-modern/java/ca/openosp/openo/documentManager/DocumentAttachmentManagerUnitTest.java
@@ -1,0 +1,285 @@
+/**
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ * <p>
+ * This software was written for
+ * Magenta Health
+ * Toronto, Ontario, Canada
+ */
+package ca.openosp.openo.documentManager;
+
+import ca.openosp.openo.commn.dao.DocumentDao;
+import ca.openosp.openo.commn.dao.EFormDataDao;
+import ca.openosp.openo.commn.dao.TicklerDocsDao;
+import ca.openosp.openo.commn.model.Document;
+import ca.openosp.openo.commn.model.EFormData;
+import ca.openosp.openo.commn.model.TicklerDocs;
+import ca.openosp.openo.commn.model.enumerator.DocumentType;
+import ca.openosp.openo.documentManager.data.TicklerAttachmentData;
+import ca.openosp.openo.encounter.data.EctFormData;
+import ca.openosp.openo.hospitalReportManager.HRMUtil;
+import ca.openosp.openo.managers.FormsManager;
+import ca.openosp.openo.managers.SecurityInfoManager;
+import ca.openosp.openo.test.unit.OpenOUnitTestBase;
+import ca.openosp.openo.utility.LoggedInInfo;
+
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for {@link DocumentAttachmentManagerImpl#getTicklerAttachmentDetails}.
+ *
+ * <p>The LAB branch is not covered: it depends on lab infrastructure
+ * ({@code CommonLabResultData}) that cannot be mocked meaningfully here.</p>
+ *
+ * @since 2026-07-19
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("DocumentAttachmentManager Tickler Attachment Details Unit Tests")
+@Tag("unit")
+@Tag("fast")
+@Tag("manager")
+@Tag("tickler")
+public class DocumentAttachmentManagerUnitTest extends OpenOUnitTestBase {
+
+    private static final Integer TICKLER_ID = 42;
+    private static final Integer DEMOGRAPHIC_NO = 12345;
+    private static final String PROVIDER_NO = "999990";
+
+    @Mock
+    private TicklerDocsDao mockTicklerDocsDao;
+
+    @Mock
+    private DocumentDao mockDocumentDao;
+
+    @Mock
+    private EFormDataDao mockEFormDataDao;
+
+    @Mock
+    private FormsManager mockFormsManager;
+
+    @Mock
+    private SecurityInfoManager mockSecurityInfoManager;
+
+    @Mock
+    private LoggedInInfo mockLoggedInInfo;
+
+    private DocumentAttachmentManagerImpl manager;
+
+    @BeforeEach
+    void setUp() {
+        // HRMUtil's static initializer fetches these beans; register them before mockStatic(HRMUtil)
+        registerMock(SecurityInfoManager.class, mockSecurityInfoManager);
+        createAndRegisterMock(ca.openosp.openo.hospitalReportManager.dao.HRMDocumentDao.class);
+        createAndRegisterMock(ca.openosp.openo.hospitalReportManager.dao.HRMDocumentToDemographicDao.class);
+        createAndRegisterMock(ca.openosp.openo.hospitalReportManager.dao.HRMDocumentToProviderDao.class);
+        createAndRegisterMock(ca.openosp.openo.hospitalReportManager.dao.HRMSubClassDao.class);
+        createAndRegisterMock(ca.openosp.openo.hospitalReportManager.dao.HRMDocumentSubClassDao.class);
+        createAndRegisterMock(ca.openosp.openo.hospitalReportManager.dao.HRMCategoryDao.class);
+        createAndRegisterMock(ca.openosp.openo.commn.dao.IncomingLabRulesDao.class);
+        createAndRegisterMock(ca.openosp.openo.managers.NioFileManager.class);
+
+        // Security manager grants the "_tickler" read privilege by default
+        lenient().when(mockSecurityInfoManager.hasPrivilege(any(), anyString(), anyString(), anyInt()))
+                .thenReturn(true);
+
+        manager = new DocumentAttachmentManagerImpl();
+
+        injectDependency(manager, "ticklerDocsDao", mockTicklerDocsDao);
+        injectDependency(manager, "documentDao", mockDocumentDao);
+        injectDependency(manager, "eFormDataDao", mockEFormDataDao);
+        injectDependency(manager, "formsManager", mockFormsManager);
+        injectDependency(manager, "securityInfoManager", mockSecurityInfoManager);
+    }
+
+    @Nested
+    @DisplayName("Security")
+    class Security {
+
+        @Test
+        @DisplayName("should throw exception when user lacks tickler read privilege")
+        void shouldThrowException_whenUserLacksTicklerReadPrivilege() {
+            // Given
+            when(mockSecurityInfoManager.hasPrivilege(any(), anyString(), anyString(), anyInt()))
+                    .thenReturn(false);
+
+            // When / Then
+            assertThatThrownBy(() -> manager.getTicklerAttachmentDetails(mockLoggedInInfo, TICKLER_ID, DEMOGRAPHIC_NO))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessageContaining("_tickler");
+            verifyNoInteractions(mockTicklerDocsDao);
+        }
+    }
+
+    @Nested
+    @DisplayName("Display Name Resolution")
+    class DisplayNameResolution {
+
+        @Test
+        @DisplayName("should return empty list when tickler has no attachments")
+        void shouldReturnEmptyList_whenTicklerHasNoAttachments() {
+            // Given
+            when(mockTicklerDocsDao.findByTicklerId(TICKLER_ID)).thenReturn(Collections.emptyList());
+
+            // When
+            List<TicklerAttachmentData> details = manager.getTicklerAttachmentDetails(mockLoggedInInfo, TICKLER_ID, DEMOGRAPHIC_NO);
+
+            // Then
+            assertThat(details).isEmpty();
+        }
+
+        @Test
+        @DisplayName("should resolve document description when a document is attached")
+        void shouldResolveDocumentDescription_whenDocAttached() {
+            // Given
+            when(mockTicklerDocsDao.findByTicklerId(TICKLER_ID)).thenReturn(Collections.singletonList(
+                    new TicklerDocs(TICKLER_ID, 12, TicklerDocs.DOCTYPE_DOC, PROVIDER_NO)));
+            Document document = new Document();
+            document.setDocdesc("Discharge Summary");
+            when(mockDocumentDao.getDocument("12")).thenReturn(document);
+
+            // When
+            List<TicklerAttachmentData> details = manager.getTicklerAttachmentDetails(mockLoggedInInfo, TICKLER_ID, DEMOGRAPHIC_NO);
+
+            // Then
+            assertThat(details).hasSize(1);
+            assertThat(details.get(0).getDocumentType()).isEqualTo(DocumentType.DOC);
+            assertThat(details.get(0).getDocumentId()).isEqualTo("12");
+            assertThat(details.get(0).getDisplayName()).isEqualTo("Discharge Summary");
+        }
+
+        @Test
+        @DisplayName("should resolve eForm name when an eForm is attached")
+        void shouldResolveEFormName_whenEFormAttached() {
+            // Given
+            when(mockTicklerDocsDao.findByTicklerId(TICKLER_ID)).thenReturn(Collections.singletonList(
+                    new TicklerDocs(TICKLER_ID, 33, TicklerDocs.DOCTYPE_EFORM, PROVIDER_NO)));
+            EFormData eForm = new EFormData();
+            eForm.setFormName("Diabetes Care Plan");
+            when(mockEFormDataDao.find(33)).thenReturn(eForm);
+
+            // When
+            List<TicklerAttachmentData> details = manager.getTicklerAttachmentDetails(mockLoggedInInfo, TICKLER_ID, DEMOGRAPHIC_NO);
+
+            // Then
+            assertThat(details).hasSize(1);
+            assertThat(details.get(0).getDocumentType()).isEqualTo(DocumentType.EFORM);
+            assertThat(details.get(0).getDisplayName()).isEqualTo("Diabetes Care Plan");
+        }
+
+        @Test
+        @DisplayName("should resolve encounter form name when a form is attached")
+        void shouldResolveFormName_whenEncounterFormAttached() {
+            // Given
+            when(mockTicklerDocsDao.findByTicklerId(TICKLER_ID)).thenReturn(Collections.singletonList(
+                    new TicklerDocs(TICKLER_ID, 55, TicklerDocs.DOCTYPE_FORM, PROVIDER_NO)));
+            EctFormData.PatientForm patientForm = mock(EctFormData.PatientForm.class);
+            when(patientForm.getFormId()).thenReturn("55");
+            when(patientForm.getFormName()).thenReturn("Rourke Baby Record");
+            when(mockFormsManager.getEncounterFormsbyDemographicNumber(mockLoggedInInfo, DEMOGRAPHIC_NO, false, true))
+                    .thenReturn(Collections.singletonList(patientForm));
+
+            // When
+            List<TicklerAttachmentData> details = manager.getTicklerAttachmentDetails(mockLoggedInInfo, TICKLER_ID, DEMOGRAPHIC_NO);
+
+            // Then
+            assertThat(details).hasSize(1);
+            assertThat(details.get(0).getDocumentType()).isEqualTo(DocumentType.FORM);
+            assertThat(details.get(0).getDisplayName()).isEqualTo("Rourke Baby Record");
+        }
+
+        @Test
+        @DisplayName("should resolve HRM report name when an HRM document is attached")
+        void shouldResolveHrmName_whenHrmAttached() {
+            // Given
+            when(mockTicklerDocsDao.findByTicklerId(TICKLER_ID)).thenReturn(Collections.singletonList(
+                    new TicklerDocs(TICKLER_ID, 7, TicklerDocs.DOCTYPE_HRM, PROVIDER_NO)));
+            HashMap<String, Object> hrmDocument = new HashMap<>();
+            hrmDocument.put("id", 7);
+            hrmDocument.put("name", "Cardiology Consult Report");
+            ArrayList<HashMap<String, ? extends Object>> allHrmDocuments = new ArrayList<>();
+            allHrmDocuments.add(hrmDocument);
+
+            try (MockedStatic<HRMUtil> hrmUtilMock = mockStatic(HRMUtil.class)) {
+                hrmUtilMock.when(() -> HRMUtil.listHRMDocuments(any(), anyString(), anyBoolean(), anyString(), anyBoolean()))
+                        .thenReturn(allHrmDocuments);
+
+                // When
+                List<TicklerAttachmentData> details = manager.getTicklerAttachmentDetails(mockLoggedInInfo, TICKLER_ID, DEMOGRAPHIC_NO);
+
+                // Then
+                assertThat(details).hasSize(1);
+                assertThat(details.get(0).getDocumentType()).isEqualTo(DocumentType.HRM);
+                assertThat(details.get(0).getDisplayName()).isEqualTo("Cardiology Consult Report");
+            }
+        }
+
+        @Test
+        @DisplayName("should fall back to type and id when the referenced document is missing")
+        void shouldFallBackToTypeAndId_whenDocumentMissing() {
+            // Given
+            when(mockTicklerDocsDao.findByTicklerId(TICKLER_ID)).thenReturn(Collections.singletonList(
+                    new TicklerDocs(TICKLER_ID, 12, TicklerDocs.DOCTYPE_DOC, PROVIDER_NO)));
+            when(mockDocumentDao.getDocument("12")).thenReturn(null);
+
+            // When
+            List<TicklerAttachmentData> details = manager.getTicklerAttachmentDetails(mockLoggedInInfo, TICKLER_ID, DEMOGRAPHIC_NO);
+
+            // Then
+            assertThat(details).hasSize(1);
+            assertThat(details.get(0).getDisplayName()).isEqualTo("doc #12");
+        }
+
+        @Test
+        @DisplayName("should skip attachments with an unknown doctype")
+        void shouldSkipAttachment_whenDocTypeUnknown() {
+            // Given
+            when(mockTicklerDocsDao.findByTicklerId(TICKLER_ID)).thenReturn(Collections.singletonList(
+                    new TicklerDocs(TICKLER_ID, 99, "X", PROVIDER_NO)));
+
+            // When
+            List<TicklerAttachmentData> details = manager.getTicklerAttachmentDetails(mockLoggedInInfo, TICKLER_ID, DEMOGRAPHIC_NO);
+
+            // Then
+            assertThat(details).isEmpty();
+        }
+    }
+
+    /**
+     * Helper method to inject dependencies into the manager using reflection.
+     */
+    private void injectDependency(Object target, String fieldName, Object dependency) {
+        try {
+            java.lang.reflect.Field field = target.getClass().getDeclaredField(fieldName);
+            field.setAccessible(true);
+            field.set(target, dependency);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to inject " + fieldName, e);
+        }
+    }
+}

--- a/src/test-modern/java/ca/openosp/openo/documentManager/DocumentAttachmentManagerUnitTest.java
+++ b/src/test-modern/java/ca/openosp/openo/documentManager/DocumentAttachmentManagerUnitTest.java
@@ -205,8 +205,8 @@ public class DocumentAttachmentManagerUnitTest extends OpenOUnitTestBase {
             EctFormData.PatientForm patientForm = mock(EctFormData.PatientForm.class);
             when(patientForm.getFormId()).thenReturn("55");
             when(patientForm.getFormName()).thenReturn("Rourke Baby Record");
-            when(mockFormsManager.getEncounterFormsbyDemographicNumber(mockLoggedInInfo, DEMOGRAPHIC_NO, true, true))
-                    .thenReturn(Collections.singletonList(patientForm));
+            when(mockFormsManager.getEncounterFormsByDemographicNumbers(eq(mockLoggedInInfo), anyCollection(), eq(true), eq(true)))
+                    .thenReturn(Map.of(DEMOGRAPHIC_NO, Collections.singletonList(patientForm)));
 
             // When
             List<TicklerAttachmentData> details = manager.getTicklerAttachmentDetails(mockLoggedInInfo, TICKLER_ID, DEMOGRAPHIC_NO);
@@ -288,8 +288,8 @@ public class DocumentAttachmentManagerUnitTest extends OpenOUnitTestBase {
             // Given
             List<EctFormData.PatientForm> forms =
                     List.of(patientForm("7", "Annual"), patientForm("9", "Rourke2020"));
-            when(mockFormsManager.getEncounterFormsbyDemographicNumber(mockLoggedInInfo, DEMOGRAPHIC_NO, true, true))
-                    .thenReturn(forms);
+            when(mockFormsManager.getEncounterFormsByDemographicNumbers(eq(mockLoggedInInfo), anyCollection(), eq(true), eq(true)))
+                    .thenReturn(Map.of(DEMOGRAPHIC_NO, forms));
 
             // When
             Map<String, String> formNames = manager.getFormNamesByFormId(mockLoggedInInfo, DEMOGRAPHIC_NO);
@@ -303,15 +303,32 @@ public class DocumentAttachmentManagerUnitTest extends OpenOUnitTestBase {
         @DisplayName("should request every version so a superseded form still resolves")
         void shouldRequestAllVersions_whenResolvingFormNames() {
             // Given
-            when(mockFormsManager.getEncounterFormsbyDemographicNumber(any(), anyInt(), anyBoolean(), anyBoolean()))
-                    .thenReturn(Collections.emptyList());
+            when(mockFormsManager.getEncounterFormsByDemographicNumbers(any(), anyCollection(), anyBoolean(), anyBoolean()))
+                    .thenReturn(Collections.emptyMap());
 
             // When
             manager.getFormNamesByFormId(mockLoggedInInfo, DEMOGRAPHIC_NO);
 
             // Then
-            verify(mockFormsManager).getEncounterFormsbyDemographicNumber(
-                    mockLoggedInInfo, DEMOGRAPHIC_NO, true, true);
+            verify(mockFormsManager).getEncounterFormsByDemographicNumbers(
+                    eq(mockLoggedInInfo), anyCollection(), eq(true), eq(true));
+        }
+
+        @Test
+        @DisplayName("should omit a form id shared by two form types rather than guess")
+        void shouldOmitFormId_whenTwoFormTypesShareIt() {
+            // Given
+            List<EctFormData.PatientForm> forms =
+                    List.of(patientForm("7", "Annual"), patientForm("7", "Rourke2020"),
+                            patientForm("9", "Annual"));
+            when(mockFormsManager.getEncounterFormsByDemographicNumbers(eq(mockLoggedInInfo), anyCollection(), eq(true), eq(true)))
+                    .thenReturn(Map.of(DEMOGRAPHIC_NO, forms));
+
+            // When
+            Map<String, String> formNames = manager.getFormNamesByFormId(mockLoggedInInfo, DEMOGRAPHIC_NO);
+
+            // Then
+            assertThat(formNames).containsExactlyInAnyOrderEntriesOf(Map.of("9", "Annual"));
         }
 
         @Test

--- a/src/test-modern/java/ca/openosp/openo/documentManager/DocumentAttachmentManagerUnitTest.java
+++ b/src/test-modern/java/ca/openosp/openo/documentManager/DocumentAttachmentManagerUnitTest.java
@@ -46,6 +46,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -106,6 +107,9 @@ public class DocumentAttachmentManagerUnitTest extends OpenOUnitTestBase {
 
         // Security manager grants the "_tickler" read privilege by default
         lenient().when(mockSecurityInfoManager.hasPrivilege(any(), anyString(), anyString(), anyInt()))
+                .thenReturn(true);
+        // The "_form" check passes a null demographic, so stub the String overload as well
+        lenient().when(mockSecurityInfoManager.hasPrivilege(any(), anyString(), anyString(), nullable(String.class)))
                 .thenReturn(true);
 
         manager = new DocumentAttachmentManagerImpl();
@@ -201,7 +205,7 @@ public class DocumentAttachmentManagerUnitTest extends OpenOUnitTestBase {
             EctFormData.PatientForm patientForm = mock(EctFormData.PatientForm.class);
             when(patientForm.getFormId()).thenReturn("55");
             when(patientForm.getFormName()).thenReturn("Rourke Baby Record");
-            when(mockFormsManager.getEncounterFormsbyDemographicNumber(mockLoggedInInfo, DEMOGRAPHIC_NO, false, true))
+            when(mockFormsManager.getEncounterFormsbyDemographicNumber(mockLoggedInInfo, DEMOGRAPHIC_NO, true, true))
                     .thenReturn(Collections.singletonList(patientForm));
 
             // When
@@ -267,6 +271,80 @@ public class DocumentAttachmentManagerUnitTest extends OpenOUnitTestBase {
 
             // Then
             assertThat(details).isEmpty();
+        }
+    }
+
+    /**
+     * Covers the shared form-name recovery that makes attached encounter forms addressable.
+     * Attachment tables store only {@code (document_no, doctype)}, which cannot identify a form.
+     */
+    @Nested
+    @DisplayName("Form Name Recovery")
+    class FormNameRecovery {
+
+        @Test
+        @DisplayName("should map form ids to form names for the patient")
+        void shouldMapFormIdsToNames_whenPatientHasForms() {
+            // Given
+            List<EctFormData.PatientForm> forms =
+                    List.of(patientForm("7", "Annual"), patientForm("9", "Rourke2020"));
+            when(mockFormsManager.getEncounterFormsbyDemographicNumber(mockLoggedInInfo, DEMOGRAPHIC_NO, true, true))
+                    .thenReturn(forms);
+
+            // When
+            Map<String, String> formNames = manager.getFormNamesByFormId(mockLoggedInInfo, DEMOGRAPHIC_NO);
+
+            // Then
+            assertThat(formNames).containsExactlyInAnyOrderEntriesOf(
+                    Map.of("7", "Annual", "9", "Rourke2020"));
+        }
+
+        @Test
+        @DisplayName("should request every version so a superseded form still resolves")
+        void shouldRequestAllVersions_whenResolvingFormNames() {
+            // Given
+            when(mockFormsManager.getEncounterFormsbyDemographicNumber(any(), anyInt(), anyBoolean(), anyBoolean()))
+                    .thenReturn(Collections.emptyList());
+
+            // When
+            manager.getFormNamesByFormId(mockLoggedInInfo, DEMOGRAPHIC_NO);
+
+            // Then
+            verify(mockFormsManager).getEncounterFormsbyDemographicNumber(
+                    mockLoggedInInfo, DEMOGRAPHIC_NO, true, true);
+        }
+
+        @Test
+        @DisplayName("should return empty map when user lacks form read privilege")
+        void shouldReturnEmptyMap_whenFormPrivilegeDenied() {
+            // Given
+            when(mockSecurityInfoManager.hasPrivilege(any(), eq("_form"), anyString(), nullable(String.class)))
+                    .thenReturn(false);
+
+            // When
+            Map<String, String> formNames = manager.getFormNamesByFormId(mockLoggedInInfo, DEMOGRAPHIC_NO);
+
+            // Then
+            assertThat(formNames).isEmpty();
+            verifyNoInteractions(mockFormsManager);
+        }
+
+        @Test
+        @DisplayName("should return empty map when demographic is null")
+        void shouldReturnEmptyMap_whenDemographicIsNull() {
+            // When
+            Map<String, String> formNames = manager.getFormNamesByFormId(mockLoggedInInfo, null);
+
+            // Then
+            assertThat(formNames).isEmpty();
+            verifyNoInteractions(mockFormsManager);
+        }
+
+        private EctFormData.PatientForm patientForm(String formId, String formName) {
+            EctFormData.PatientForm form = mock(EctFormData.PatientForm.class);
+            when(form.getFormId()).thenReturn(formId);
+            when(form.getFormName()).thenReturn(formName);
+            return form;
         }
     }
 

--- a/src/test-modern/java/ca/openosp/openo/tickler/dao/TicklerDocsDaoIntegrationTest.java
+++ b/src/test-modern/java/ca/openosp/openo/tickler/dao/TicklerDocsDaoIntegrationTest.java
@@ -1,0 +1,142 @@
+/**
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ * <p>
+ * This software was written for
+ * Magenta Health
+ * Toronto, Ontario, Canada
+ */
+package ca.openosp.openo.tickler.dao;
+
+import ca.openosp.openo.commn.dao.TicklerDocsDao;
+import ca.openosp.openo.commn.model.TicklerDocs;
+import ca.openosp.openo.test.base.OpenOTestBase;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link TicklerDocsDao}, the data access layer behind the modern
+ * Tickler document attachment component (issue #2476).
+ *
+ * <p>Verifies the three finders and confirms that soft-deleted rows ({@code deleted = 'Y'})
+ * are excluded from query results.</p>
+ *
+ * @since 2026-06-12
+ * @see TicklerDocsDao
+ * @see TicklerDocs
+ */
+@Tag("integration")
+@Tag("database")
+@Tag("slow")
+@Tag("dao")
+@Tag("tickler")
+@Transactional
+class TicklerDocsDaoIntegrationTest extends OpenOTestBase {
+
+    @Autowired
+    private TicklerDocsDao ticklerDocsDao;
+
+    @PersistenceContext(unitName = "entityManagerFactory")
+    private EntityManager entityManager;
+
+    private static final int TICKLER_ID = 5000;
+    private static final String PROVIDER_NO = "999998";
+
+    private TicklerDocs persistAttachment(int ticklerId, int documentNo, String docType) {
+        TicklerDocs ticklerDocs = new TicklerDocs(ticklerId, documentNo, docType, PROVIDER_NO);
+        ticklerDocsDao.persist(ticklerDocs);
+        entityManager.flush();
+        return ticklerDocs;
+    }
+
+    @Test
+    @DisplayName("should persist and find tickler attachment by id")
+    void shouldPersistAndFindAttachment_whenAttachmentSaved() {
+        TicklerDocs saved = persistAttachment(TICKLER_ID, 11, TicklerDocs.DOCTYPE_DOC);
+
+        TicklerDocs found = ticklerDocsDao.find(saved.getId());
+
+        assertThat(found).isNotNull();
+        assertThat(found.getTicklerId()).isEqualTo(TICKLER_ID);
+        assertThat(found.getDocumentNo()).isEqualTo(11);
+        assertThat(found.getDocType()).isEqualTo(TicklerDocs.DOCTYPE_DOC);
+    }
+
+    @Test
+    @DisplayName("should return all non-deleted attachments for a tickler")
+    @Tag("read")
+    void shouldReturnAllAttachments_whenFindingByTicklerId() {
+        persistAttachment(TICKLER_ID, 11, TicklerDocs.DOCTYPE_DOC);
+        persistAttachment(TICKLER_ID, 22, TicklerDocs.DOCTYPE_LAB);
+        persistAttachment(TICKLER_ID + 1, 33, TicklerDocs.DOCTYPE_DOC);
+
+        List<TicklerDocs> results = ticklerDocsDao.findByTicklerId(TICKLER_ID);
+
+        assertThat(results).hasSize(2);
+        assertThat(results).extracting(TicklerDocs::getDocumentNo).containsExactlyInAnyOrder(11, 22);
+    }
+
+    @Test
+    @DisplayName("should filter attachments by document type")
+    @Tag("read")
+    @Tag("filter")
+    void shouldFilterByDocType_whenFindingByTicklerIdDocType() {
+        persistAttachment(TICKLER_ID, 11, TicklerDocs.DOCTYPE_DOC);
+        persistAttachment(TICKLER_ID, 22, TicklerDocs.DOCTYPE_LAB);
+
+        List<TicklerDocs> docs = ticklerDocsDao.findByTicklerIdDocType(TICKLER_ID, TicklerDocs.DOCTYPE_DOC);
+
+        assertThat(docs).hasSize(1);
+        assertThat(docs.get(0).getDocumentNo()).isEqualTo(11);
+    }
+
+    @Test
+    @DisplayName("should find a specific attachment by tickler id, document number and type")
+    @Tag("read")
+    void shouldFindSpecificAttachment_whenFindingByTicklerIdDocNoDocType() {
+        persistAttachment(TICKLER_ID, 11, TicklerDocs.DOCTYPE_DOC);
+
+        List<TicklerDocs> results = ticklerDocsDao.findByTicklerIdDocNoDocType(TICKLER_ID, 11, TicklerDocs.DOCTYPE_DOC);
+
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0).getDocType()).isEqualTo(TicklerDocs.DOCTYPE_DOC);
+    }
+
+    @Test
+    @DisplayName("should exclude soft-deleted attachments from finder results")
+    @Tag("read")
+    @Tag("delete")
+    void shouldExcludeSoftDeleted_whenAttachmentMarkedDeleted() {
+        TicklerDocs attachment = persistAttachment(TICKLER_ID, 11, TicklerDocs.DOCTYPE_DOC);
+
+        attachment.setDeleted(TicklerDocs.DELETED);
+        ticklerDocsDao.merge(attachment);
+        entityManager.flush();
+
+        assertThat(ticklerDocsDao.findByTicklerId(TICKLER_ID)).isEmpty();
+        assertThat(ticklerDocsDao.findByTicklerIdDocType(TICKLER_ID, TicklerDocs.DOCTYPE_DOC)).isEmpty();
+        assertThat(ticklerDocsDao.findByTicklerIdDocNoDocType(TICKLER_ID, 11, TicklerDocs.DOCTYPE_DOC)).isEmpty();
+    }
+}

--- a/src/test-modern/java/ca/openosp/openo/tickler/dao/TicklerDocsDaoIntegrationTest.java
+++ b/src/test-modern/java/ca/openosp/openo/tickler/dao/TicklerDocsDaoIntegrationTest.java
@@ -40,8 +40,9 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Integration tests for {@link TicklerDocsDao}, the data access layer behind the modern
  * Tickler document attachment component (issue #2476).
  *
- * <p>Verifies the three finders and confirms that soft-deleted rows ({@code deleted = 'Y'})
- * are excluded from query results.</p>
+ * <p>Verifies the finders, including the batched {@code findByTicklerIds} used to render the
+ * tickler list, and confirms that soft-deleted rows ({@code deleted = 'Y'}) are excluded from
+ * query results.</p>
  *
  * @since 2026-06-12
  * @see TicklerDocsDao
@@ -124,6 +125,55 @@ class TicklerDocsDaoIntegrationTest extends OpenOTestBase {
 
         assertThat(results).hasSize(1);
         assertThat(results.get(0).getDocType()).isEqualTo(TicklerDocs.DOCTYPE_DOC);
+    }
+
+    @Test
+    @DisplayName("should return attachments for every requested tickler in one query")
+    @Tag("read")
+    @Tag("query")
+    void shouldReturnAttachmentsForEveryTickler_whenFindingByTicklerIds() {
+        persistAttachment(TICKLER_ID, 11, TicklerDocs.DOCTYPE_DOC);
+        persistAttachment(TICKLER_ID, 22, TicklerDocs.DOCTYPE_LAB);
+        persistAttachment(TICKLER_ID + 1, 33, TicklerDocs.DOCTYPE_DOC);
+        // Not requested below, so it must not leak into the results
+        persistAttachment(TICKLER_ID + 2, 44, TicklerDocs.DOCTYPE_DOC);
+
+        List<TicklerDocs> results = ticklerDocsDao.findByTicklerIds(List.of(TICKLER_ID, TICKLER_ID + 1));
+
+        assertThat(results).hasSize(3);
+        assertThat(results).extracting(TicklerDocs::getDocumentNo).containsExactlyInAnyOrder(11, 22, 33);
+        // Callers group by tickler id, so each row must carry the tickler it belongs to
+        assertThat(results).extracting(TicklerDocs::getTicklerId)
+                .containsExactlyInAnyOrder(TICKLER_ID, TICKLER_ID, TICKLER_ID + 1);
+    }
+
+    @Test
+    @DisplayName("should exclude soft-deleted attachments when finding by tickler ids")
+    @Tag("read")
+    @Tag("delete")
+    void shouldExcludeSoftDeleted_whenFindingByTicklerIds() {
+        TicklerDocs attachment = persistAttachment(TICKLER_ID, 11, TicklerDocs.DOCTYPE_DOC);
+        persistAttachment(TICKLER_ID + 1, 33, TicklerDocs.DOCTYPE_DOC);
+
+        attachment.setDeleted(TicklerDocs.DELETED);
+        ticklerDocsDao.merge(attachment);
+        entityManager.flush();
+
+        List<TicklerDocs> results = ticklerDocsDao.findByTicklerIds(List.of(TICKLER_ID, TICKLER_ID + 1));
+
+        assertThat(results).extracting(TicklerDocs::getDocumentNo).containsExactly(33);
+    }
+
+    @Test
+    @DisplayName("should return an empty list when no tickler ids are requested")
+    @Tag("read")
+    void shouldReturnEmptyList_whenTicklerIdsAreEmptyOrNull() {
+        persistAttachment(TICKLER_ID, 11, TicklerDocs.DOCTYPE_DOC);
+
+        // A page with no ticklers reaches this finder with an empty list; an unguarded
+        // "in ()" would not be valid SQL
+        assertThat(ticklerDocsDao.findByTicklerIds(List.of())).isEmpty();
+        assertThat(ticklerDocsDao.findByTicklerIds(null)).isEmpty();
     }
 
     @Test

--- a/src/test-modern/java/ca/openosp/openo/tickler/dao/TicklerDocsDaoIntegrationTest.java
+++ b/src/test-modern/java/ca/openosp/openo/tickler/dao/TicklerDocsDaoIntegrationTest.java
@@ -73,6 +73,8 @@ class TicklerDocsDaoIntegrationTest extends OpenOTestBase {
 
     @Test
     @DisplayName("should persist and find tickler attachment by id")
+    @Tag("create")
+    @Tag("read")
     void shouldPersistAndFindAttachment_whenAttachmentSaved() {
         TicklerDocs saved = persistAttachment(TICKLER_ID, 11, TicklerDocs.DOCTYPE_DOC);
 

--- a/src/test-modern/java/ca/openosp/openo/tickler/web/TicklerList2ActionTest.java
+++ b/src/test-modern/java/ca/openosp/openo/tickler/web/TicklerList2ActionTest.java
@@ -250,8 +250,8 @@ class TicklerList2ActionTest extends OpenOWebTestBase {
 
         stubPaginatedResults(1, List.of(createTestTickler(5, "Form attached")));
         stubAttachments(ticklerDoc(5, 7, TicklerDocs.DOCTYPE_FORM));
-        when(mockDocumentAttachmentManager.getFormNamesByFormId(any(LoggedInInfo.class), eq(1001)))
-                .thenReturn(Map.of("7", "Annual"));
+        when(mockDocumentAttachmentManager.getFormNamesByDemographic(any(LoggedInInfo.class), anyCollection()))
+                .thenReturn(Map.of(1001, Map.of("7", "Annual")));
 
         executeAction(action);
 
@@ -267,8 +267,8 @@ class TicklerList2ActionTest extends OpenOWebTestBase {
 
         stubPaginatedResults(1, List.of(createTestTickler(5, "Deleted form attached")));
         stubAttachments(ticklerDoc(5, 7, TicklerDocs.DOCTYPE_FORM));
-        when(mockDocumentAttachmentManager.getFormNamesByFormId(any(LoggedInInfo.class), anyInt()))
-                .thenReturn(Map.of("42", "Annual"));
+        when(mockDocumentAttachmentManager.getFormNamesByDemographic(any(LoggedInInfo.class), anyCollection()))
+                .thenReturn(Map.of(1001, Map.of("42", "Annual")));
 
         executeAction(action);
 
@@ -286,7 +286,7 @@ class TicklerList2ActionTest extends OpenOWebTestBase {
         stubPaginatedResults(1, List.of(createTestTickler(5, "Form attached")));
         stubAttachments(ticklerDoc(5, 7, TicklerDocs.DOCTYPE_FORM));
         // Missing "_form" read makes the lookup return nothing rather than throwing
-        when(mockDocumentAttachmentManager.getFormNamesByFormId(any(LoggedInInfo.class), anyInt()))
+        when(mockDocumentAttachmentManager.getFormNamesByDemographic(any(LoggedInInfo.class), anyCollection()))
                 .thenReturn(Collections.emptyMap());
 
         executeAction(action);
@@ -315,10 +315,10 @@ class TicklerList2ActionTest extends OpenOWebTestBase {
                 ticklerDoc(1, 7, TicklerDocs.DOCTYPE_FORM),
                 ticklerDoc(2, 7, TicklerDocs.DOCTYPE_FORM));
 
-        when(mockDocumentAttachmentManager.getFormNamesByFormId(any(LoggedInInfo.class), eq(1001)))
-                .thenReturn(Map.of("7", "Annual"));
-        when(mockDocumentAttachmentManager.getFormNamesByFormId(any(LoggedInInfo.class), eq(2002)))
-                .thenReturn(Map.of("7", "Rourke2020"));
+        when(mockDocumentAttachmentManager.getFormNamesByDemographic(any(LoggedInInfo.class), anyCollection()))
+                .thenReturn(Map.of(
+                        1001, Map.of("7", "Annual"),
+                        2002, Map.of("7", "Rourke2020")));
 
         executeAction(action);
 
@@ -338,27 +338,35 @@ class TicklerList2ActionTest extends OpenOWebTestBase {
         executeAction(action);
 
         verify(mockDocumentAttachmentManager, never())
-                .getFormNamesByFormId(any(LoggedInInfo.class), anyInt());
+                .getFormNamesByDemographic(any(LoggedInInfo.class), anyCollection());
     }
 
     @Test
-    @DisplayName("Should look up form names once per patient regardless of tickler count")
-    void shouldLookUpFormNamesOncePerPatient_whenPatientHasSeveralTicklers() throws Exception {
+    @DisplayName("Should resolve every patient on the page in a single batched call")
+    void shouldLookUpFormNamesInOneCall_whenPageSpansPatients() throws Exception {
         allowPrivilege("_tickler", "r");
 
-        stubPaginatedResults(2, List.of(
-                createTestTickler(1, "First"),
-                createTestTickler(2, "Second")));
+        TicklerListDTO other = new TicklerListDTO(
+                2, "Second", new Date(), new Date(),
+                Tickler.STATUS.A, Tickler.PRIORITY.Normal,
+                2002, "Jones", "Mary",
+                "Doctor", "Jane",
+                "Nurse", "Bob");
+        stubPaginatedResults(2, List.of(createTestTickler(1, "First"), other));
         stubAttachments(
                 ticklerDoc(1, 7, TicklerDocs.DOCTYPE_FORM),
                 ticklerDoc(2, 8, TicklerDocs.DOCTYPE_FORM));
-        when(mockDocumentAttachmentManager.getFormNamesByFormId(any(LoggedInInfo.class), anyInt()))
-                .thenReturn(Map.of("7", "Annual", "8", "Annual"));
+        when(mockDocumentAttachmentManager.getFormNamesByDemographic(any(LoggedInInfo.class), anyCollection()))
+                .thenReturn(Map.of(1001, Map.of("7", "Annual"), 2002, Map.of("8", "Annual")));
 
         executeAction(action);
 
+        // One call for the whole page, carrying both patients: reading the form config per patient
+        // is what made this path slow.
+        ArgumentCaptor<java.util.Collection<Integer>> captor = ArgumentCaptor.forClass(java.util.Collection.class);
         verify(mockDocumentAttachmentManager, times(1))
-                .getFormNamesByFormId(any(LoggedInInfo.class), eq(1001));
+                .getFormNamesByDemographic(any(LoggedInInfo.class), captor.capture());
+        assertThat(captor.getValue()).containsExactlyInAnyOrder(1001, 2002);
     }
 
     // ── Paging Parameters ──────────────────────────────────────────────

--- a/src/test-modern/java/ca/openosp/openo/tickler/web/TicklerList2ActionTest.java
+++ b/src/test-modern/java/ca/openosp/openo/tickler/web/TicklerList2ActionTest.java
@@ -241,6 +241,26 @@ class TicklerList2ActionTest extends OpenOWebTestBase {
         assertThat(links.get(0).get("tableId").asLong()).isEqualTo(999L);
     }
 
+    @Test
+    @DisplayName("Should not repeat a lab number when the same lab is attached to several ticklers")
+    void shouldDeduplicateLabNumbers_whenLabAttachedToSeveralTicklers() throws Exception {
+        allowPrivilege("_tickler", "r");
+
+        stubPaginatedResults(2, List.of(
+                createTestTickler(1, "First"),
+                createTestTickler(2, "Second")));
+        stubAttachments(
+                ticklerDoc(1, 999, TicklerDocs.DOCTYPE_LAB),
+                ticklerDoc(2, 999, TicklerDocs.DOCTYPE_LAB));
+
+        executeAction(action);
+
+        // The same lab on two ticklers would otherwise pad the IN (:labNos) list
+        ArgumentCaptor<List<Integer>> captor = ArgumentCaptor.forClass(List.class);
+        verify(mockPatientLabRoutingDao).findByLabNos(captor.capture());
+        assertThat(captor.getValue()).containsExactly(999);
+    }
+
     // ── Form Attachments ───────────────────────────────────────────────
 
     @Test

--- a/src/test-modern/java/ca/openosp/openo/tickler/web/TicklerList2ActionTest.java
+++ b/src/test-modern/java/ca/openosp/openo/tickler/web/TicklerList2ActionTest.java
@@ -1,12 +1,15 @@
 package ca.openosp.openo.tickler.web;
 
+import ca.openosp.openo.commn.dao.PatientLabRoutingDao;
+import ca.openosp.openo.commn.dao.TicklerDocsDao;
 import ca.openosp.openo.commn.model.CustomFilter;
 import ca.openosp.openo.commn.model.Tickler;
+import ca.openosp.openo.commn.model.TicklerDocs;
+import ca.openosp.openo.documentManager.DocumentAttachmentManager;
 import ca.openosp.openo.managers.SecurityInfoManager;
 import ca.openosp.openo.managers.TicklerManager;
 import ca.openosp.openo.test.base.OpenOWebTestBase;
 import ca.openosp.openo.tickler.dto.TicklerCommentDTO;
-import ca.openosp.openo.tickler.dto.TicklerLinkDTO;
 import ca.openosp.openo.tickler.dto.TicklerListDTO;
 import ca.openosp.openo.tickler.pageUtil.TicklerList2Action;
 import ca.openosp.openo.utility.LoggedInInfo;
@@ -28,6 +31,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Web layer tests for {@link TicklerList2Action}.
@@ -43,6 +47,15 @@ class TicklerList2ActionTest extends OpenOWebTestBase {
 
     @Mock
     private TicklerManager mockTicklerManager;
+
+    @Mock
+    private TicklerDocsDao mockTicklerDocsDao;
+
+    @Mock
+    private PatientLabRoutingDao mockPatientLabRoutingDao;
+
+    @Mock
+    private DocumentAttachmentManager mockDocumentAttachmentManager;
 
     private TicklerList2Action action;
 
@@ -69,9 +82,16 @@ class TicklerList2ActionTest extends OpenOWebTestBase {
         when(mockTicklerManager.getTicklerDTOs(any(LoggedInInfo.class), any(CustomFilter.class)))
                 .thenReturn(Collections.emptyList());
 
+        // Default: no attachments, so link-unrelated tests do not need to stub the attachment path
+        when(mockTicklerDocsDao.findByTicklerIds(anyList())).thenReturn(Collections.emptyList());
+        when(mockPatientLabRoutingDao.findByLabNos(anyList())).thenReturn(Collections.emptyList());
+
         action = new TicklerList2Action();
         injectField("ticklerManager", mockTicklerManager);
         injectField("securityInfoManager", mockSecurityInfoManager);
+        injectField("ticklerDocsDao", mockTicklerDocsDao);
+        injectField("patientLabRoutingDao", mockPatientLabRoutingDao);
+        injectField("documentAttachmentManager", mockDocumentAttachmentManager);
     }
 
     // ── Privilege Enforcement ──────────────────────────────────────────
@@ -206,19 +226,139 @@ class TicklerList2ActionTest extends OpenOWebTestBase {
 
     @Test
     @DisplayName("Should include links array in data rows")
-    void shouldIncludeLinks_whenTicklerHasLinks() throws Exception {
+    void shouldIncludeLinks_whenTicklerHasAttachments() throws Exception {
         allowPrivilege("_tickler", "r");
 
-        TicklerListDTO dto = createTestTickler(5, "Lab attached");
-        dto.setLinks(List.of(new TicklerLinkDTO(1, 5, "HL7", 999L)));
+        TicklerListDTO dto = createTestTickler(5, "Document attached");
         stubPaginatedResults(1, List.of(dto));
+        stubAttachments(ticklerDoc(5, 999, TicklerDocs.DOCTYPE_DOC));
 
         executeAction(action);
 
         JsonNode links = parseResponse().get("data").get(0).get("links");
         assertThat(links.size()).isEqualTo(1);
-        assertThat(links.get(0).get("tableName").asText()).isEqualTo("HL7");
+        assertThat(links.get(0).get("tableName").asText()).isEqualTo("DOC");
         assertThat(links.get(0).get("tableId").asLong()).isEqualTo(999L);
+    }
+
+    // ── Form Attachments ───────────────────────────────────────────────
+
+    @Test
+    @DisplayName("Should include formName when a form attachment resolves to a name")
+    void shouldIncludeFormName_whenFormAttachmentResolves() throws Exception {
+        allowPrivilege("_tickler", "r");
+
+        stubPaginatedResults(1, List.of(createTestTickler(5, "Form attached")));
+        stubAttachments(ticklerDoc(5, 7, TicklerDocs.DOCTYPE_FORM));
+        when(mockDocumentAttachmentManager.getFormNamesByFormId(any(LoggedInInfo.class), eq(1001)))
+                .thenReturn(Map.of("7", "Annual"));
+
+        executeAction(action);
+
+        JsonNode link = parseResponse().get("data").get(0).get("links").get(0);
+        assertThat(link.get("tableName").asText()).isEqualTo("FORM");
+        assertThat(link.get("formName").asText()).isEqualTo("Annual");
+    }
+
+    @Test
+    @DisplayName("Should omit formName when the form id no longer resolves")
+    void shouldOmitFormName_whenFormIdDoesNotResolve() throws Exception {
+        allowPrivilege("_tickler", "r");
+
+        stubPaginatedResults(1, List.of(createTestTickler(5, "Deleted form attached")));
+        stubAttachments(ticklerDoc(5, 7, TicklerDocs.DOCTYPE_FORM));
+        when(mockDocumentAttachmentManager.getFormNamesByFormId(any(LoggedInInfo.class), anyInt()))
+                .thenReturn(Map.of("42", "Annual"));
+
+        executeAction(action);
+
+        // Absent rather than empty, so the client falls back to an unlinked icon
+        JsonNode link = parseResponse().get("data").get(0).get("links").get(0);
+        assertThat(link.get("tableName").asText()).isEqualTo("FORM");
+        assertThat(link.has("formName")).isFalse();
+    }
+
+    @Test
+    @DisplayName("Should still render the list when form names cannot be read")
+    void shouldOmitFormName_whenFormPrivilegeDenied() throws Exception {
+        allowPrivilege("_tickler", "r");
+
+        stubPaginatedResults(1, List.of(createTestTickler(5, "Form attached")));
+        stubAttachments(ticklerDoc(5, 7, TicklerDocs.DOCTYPE_FORM));
+        // Missing "_form" read makes the lookup return nothing rather than throwing
+        when(mockDocumentAttachmentManager.getFormNamesByFormId(any(LoggedInInfo.class), anyInt()))
+                .thenReturn(Collections.emptyMap());
+
+        executeAction(action);
+
+        JsonNode json = parseResponse();
+        assertThat(json.get("data").size()).isEqualTo(1);
+        assertThat(json.get("data").get(0).get("links").get(0).has("formName")).isFalse();
+    }
+
+    @Test
+    @DisplayName("Should resolve each form name against its own patient when a page spans patients")
+    void shouldResolveFormNamesPerDemographic_whenPageSpansPatients() throws Exception {
+        allowPrivilege("_tickler", "r");
+
+        // Same formId for two patients: form ids are only unique within one form's table, so a
+        // lookup keyed by document number alone would cross-label these two rows.
+        TicklerListDTO first = createTestTickler(1, "Patient A form");
+        TicklerListDTO second = new TicklerListDTO(
+                2, "Patient B form", new Date(), new Date(),
+                Tickler.STATUS.A, Tickler.PRIORITY.Normal,
+                2002, "Jones", "Mary",
+                "Doctor", "Jane",
+                "Nurse", "Bob");
+        stubPaginatedResults(2, List.of(first, second));
+        stubAttachments(
+                ticklerDoc(1, 7, TicklerDocs.DOCTYPE_FORM),
+                ticklerDoc(2, 7, TicklerDocs.DOCTYPE_FORM));
+
+        when(mockDocumentAttachmentManager.getFormNamesByFormId(any(LoggedInInfo.class), eq(1001)))
+                .thenReturn(Map.of("7", "Annual"));
+        when(mockDocumentAttachmentManager.getFormNamesByFormId(any(LoggedInInfo.class), eq(2002)))
+                .thenReturn(Map.of("7", "Rourke2020"));
+
+        executeAction(action);
+
+        JsonNode data = parseResponse().get("data");
+        assertThat(data.get(0).get("links").get(0).get("formName").asText()).isEqualTo("Annual");
+        assertThat(data.get(1).get("links").get(0).get("formName").asText()).isEqualTo("Rourke2020");
+    }
+
+    @Test
+    @DisplayName("Should not look up form names when no form is attached")
+    void shouldNotLookUpFormNames_whenNoFormAttachments() throws Exception {
+        allowPrivilege("_tickler", "r");
+
+        stubPaginatedResults(1, List.of(createTestTickler(5, "Document attached")));
+        stubAttachments(ticklerDoc(5, 999, TicklerDocs.DOCTYPE_DOC));
+
+        executeAction(action);
+
+        verify(mockDocumentAttachmentManager, never())
+                .getFormNamesByFormId(any(LoggedInInfo.class), anyInt());
+    }
+
+    @Test
+    @DisplayName("Should look up form names once per patient regardless of tickler count")
+    void shouldLookUpFormNamesOncePerPatient_whenPatientHasSeveralTicklers() throws Exception {
+        allowPrivilege("_tickler", "r");
+
+        stubPaginatedResults(2, List.of(
+                createTestTickler(1, "First"),
+                createTestTickler(2, "Second")));
+        stubAttachments(
+                ticklerDoc(1, 7, TicklerDocs.DOCTYPE_FORM),
+                ticklerDoc(2, 8, TicklerDocs.DOCTYPE_FORM));
+        when(mockDocumentAttachmentManager.getFormNamesByFormId(any(LoggedInInfo.class), anyInt()))
+                .thenReturn(Map.of("7", "Annual", "8", "Annual"));
+
+        executeAction(action);
+
+        verify(mockDocumentAttachmentManager, times(1))
+                .getFormNamesByFormId(any(LoggedInInfo.class), eq(1001));
     }
 
     // ── Paging Parameters ──────────────────────────────────────────────
@@ -275,7 +415,7 @@ class TicklerList2ActionTest extends OpenOWebTestBase {
     }
 
     @Test
-    @DisplayName("Should use paginated overload with totalRecords as limit when length is -1")
+    @DisplayName("Should fetch without a limit when length is -1")
     void shouldShowAll_whenLengthIsNegative() throws Exception {
         allowPrivilege("_tickler", "r");
 
@@ -285,8 +425,10 @@ class TicklerList2ActionTest extends OpenOWebTestBase {
 
         executeAction(action);
 
+        // limit 0 means unbounded (TicklerDaoImpl only applies a limit when it is > 0), so DataTables
+        // "All" returns every row rather than being truncated at MAX_PAGE_SIZE
         verify(mockTicklerManager).getTicklerDTOs(
-                any(LoggedInInfo.class), any(CustomFilter.class), eq(0), eq(150));
+                any(LoggedInInfo.class), any(CustomFilter.class), eq(0), eq(0));
     }
 
     @Test
@@ -460,6 +602,14 @@ class TicklerList2ActionTest extends OpenOWebTestBase {
                 1001, "Smith", "John",
                 "Doctor", "Jane",
                 "Nurse", "Bob");
+    }
+
+    private TicklerDocs ticklerDoc(int ticklerId, int documentNo, String docType) {
+        return new TicklerDocs(ticklerId, documentNo, docType, TEST_PROVIDER);
+    }
+
+    private void stubAttachments(TicklerDocs... ticklerDocs) {
+        when(mockTicklerDocsDao.findByTicklerIds(anyList())).thenReturn(List.of(ticklerDocs));
     }
 
     private void stubPaginatedResults(int total, List<TicklerListDTO> ticklers) {

--- a/src/test-modern/resources/META-INF/persistence.xml
+++ b/src/test-modern/resources/META-INF/persistence.xml
@@ -22,6 +22,7 @@
         <class>ca.openosp.openo.commn.model.TicklerCategory</class>
         <class>ca.openosp.openo.commn.model.TicklerComment</class>
         <class>ca.openosp.openo.commn.model.TicklerLink</class>
+        <class>ca.openosp.openo.commn.model.TicklerDocs</class>
         <class>ca.openosp.openo.commn.model.CustomFilter</class>
         <class>ca.openosp.openo.commn.model.Admission</class>
         <class>ca.openosp.openo.commn.model.OscarLog</class>

--- a/src/test-modern/resources/test-context-full.xml
+++ b/src/test-modern/resources/test-context-full.xml
@@ -185,6 +185,7 @@
     <bean id="ticklerDao" class="ca.openosp.openo.commn.dao.TicklerDaoImpl" autowire="byName" />
     <bean id="ticklerCommentDao" class="ca.openosp.openo.commn.dao.TicklerCommentDaoImpl" autowire="byName" />
     <bean id="ticklerLinkDao" class="ca.openosp.openo.commn.dao.TicklerLinkDaoImpl" autowire="byName" />
+    <bean id="ticklerDocsDao" class="ca.openosp.openo.commn.dao.TicklerDocsDaoImpl" autowire="byName" />
     <bean id="ticklerUpdateDao" class="ca.openosp.openo.commn.dao.TicklerUpdateDaoImpl" autowire="byName" />
     <bean id="ticklerTextSuggestDao" class="ca.openosp.openo.commn.dao.TicklerTextSuggestDaoImpl" autowire="byName" />
     <bean id="ticklerCategoryDao" class="ca.openosp.openo.commn.dao.TicklerCategoryDaoImpl" autowire="byName" />

--- a/src/test-modern/resources/test-context-full.xml
+++ b/src/test-modern/resources/test-context-full.xml
@@ -204,6 +204,21 @@
     <bean id="providerExtDao" class="ca.openosp.openo.commn.dao.ProviderExtDaoImpl" autowire="byName" />
     <bean id="hashAuditDao" class="ca.openosp.openo.commn.dao.HashAuditDaoImpl" autowire="byName" />
 
+    <!--
+      Resolved by TicklerList2Action's field initialisers via SpringUtils.getBean(), so the context
+      has to supply them before the action can be constructed. Mocked rather than real, since
+      DocumentAttachmentManagerImpl declares a dozen required @Autowired collaborators.
+
+      type="java.lang.Class" is required: Mockito 5 also exposes a reified mock(T...), and without
+      an explicit type Spring binds to that overload and the mock fails to build.
+    -->
+    <bean id="patientLabRoutingDao" class="org.mockito.Mockito" factory-method="mock">
+        <constructor-arg type="java.lang.Class" value="ca.openosp.openo.commn.dao.PatientLabRoutingDao" />
+    </bean>
+    <bean id="documentAttachmentManager" class="org.mockito.Mockito" factory-method="mock">
+        <constructor-arg type="java.lang.Class" value="ca.openosp.openo.documentManager.DocumentAttachmentManager" />
+    </bean>
+
     <!-- Manually define managers -->
     <bean id="ticklerManager" class="ca.openosp.openo.managers.TicklerManagerImpl" autowire="byName" />
     <!-- Use mock SecurityInfoManager that always grants access for tests -->


### PR DESCRIPTION
## Summary by Sourcery

Migrate Tickler attachments to the shared document attachment system backed by a new ticklerdocs store, and update UI, services, and data access to support managing and displaying these attachments with soft-delete and security enforcement.

New Features:
- Add a shared attachment picker dialog to Tickler add and edit screens for managing document, lab, eForm, HRM, and form attachments.
- Introduce ticklerdocs persistence model, DAO, and schema as the unified store for Tickler document attachments with soft-delete semantics.
- Expose new DocumentAttachmentManager APIs to read and write Tickler attachments with _tickler-based access control.
- Provide a new DocumentPreview2Action endpoint to load attachment options for Ticklers into the shared picker.

Bug Fixes:
- Ensure attachment links in Tickler views use consistent URL encoding and lab-type resolution via PatientLabRouting to open the correct viewer.
- Allow Tickler edits that only change attachments to be persisted by processing attachment updates independently of other field changes.

Enhancements:
- Update Tickler list, demo, and macro flows to read and write attachments via ticklerdocs instead of the legacy tickler_link table.
- Improve Tickler add/edit popup layouts and attachment controls for better usability, including wider dialogs and non-wrapping buttons and badges.
- Extend client-side Tickler link rendering to support eForm navigation and indicate attached encounter forms with an icon.

Tests:
- Add integration tests for TicklerDocsDao to verify persistence, filtering by type, and exclusion of soft-deleted attachments.

Chores:
- Add ticklerdocs entity and DAO wiring to the test persistence configuration and Spring test context.
- Provide a MySQL migration script to create ticklerdocs and backfill it from existing tickler_link data for existing installations.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates Tickler attachments from legacy `tickler_link` to the shared attachment component backed by `ticklerdocs`. Add/edit now use the picker, lists read from `ticklerdocs`, and attachments are recorded under the authenticated provider; remaining `tickler_link` readers continue to work until migrated (Linear #2476).

- **Review Notes**
  - Storage is `ticklerdocs` with soft-delete via `TicklerDocsDao`; `EDocUtil`, REST conversion, and some lab lookups still read `tickler_link` (TODOs in code).
  - `DocumentAttachmentManager` adds tickler read/write APIs with `_tickler` checks and writes attachments under the authenticated `provider_no`.
  - List rendering batches lab routing (`PatientLabRoutingDao.findByLabNos`) and encounter form names (`FormsManager.getEncounterFormsByDemographicNumbers`), omitting ambiguous form ids; `DocumentPreview2Action` adds `fetchTicklerDocuments` and uses the updated `populateCommonDocs` signature.
  - UI: “Manage Attachments” in add/edit shows inline names, consistent picker styling, wider dialogs, EForm links open in a new window, and the edit page prevents date picker overflow.

- **Migration**
  - New installs: `database/mysql/oscarinit.sql` creates `ticklerdocs` and index.
  - Existing installs: run `database/mysql/updates/update-2026-06-12-tickler-docs.sql` to create and backfill from `tickler_link`; the backfill is re-runnable.
  - Action: Legacy `TicklerManager.addTicklerLink` is removed; ensure `_tickler` privileges allow attachment read/write.

<sup>Written for commit e10aeab06c0b95c7fb4d90e9fdc0360592d00538. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openo-beta/Open-O/pull/2491?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tickler document attachments end-to-end for DOC, LAB, eForms, HRM, and forms, including add/edit/list/preview support and a shared attachment picker with live selection counts.
* **Bug Fixes**
  * Improved attachment-only updates by reliably detaching removed items and attaching newly selected ones.
* **Database / Migrations**
  * Added new `ticklerdocs` storage and backfilled existing attachment links into it.
* **Chores / Tests**
  * Added/updated DAO and service tests (unit + integration), updated test persistence wiring, and improved Docker build ignore rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->