### PR TITLE
Feature: include the pharmacy's phone number in the Rx chart note

### DIFF
--- a/src/main/java/ca/openosp/openo/prescript/data/RxPharmacyData.java
+++ b/src/main/java/ca/openosp/openo/prescript/data/RxPharmacyData.java
@@ -250,6 +250,7 @@ public class RxPharmacyData {
      *
      * @param pharmacy PharmacyInfo the pharmacy, may be null
      * @return String the joined phone numbers, or "" if none are on file
+     * @since 2026-08-13
      */
     public static String composePharmacyPhone(PharmacyInfo pharmacy) {
         if (pharmacy == null) {

--- a/src/main/java/ca/openosp/openo/prescript/data/RxPharmacyData.java
+++ b/src/main/java/ca/openosp/openo/prescript/data/RxPharmacyData.java
@@ -42,6 +42,7 @@ import ca.openosp.openo.utility.SpringUtils;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.StringJoiner;
 
 /**
  * @author Jay Gallagher
@@ -235,5 +236,35 @@ public class RxPharmacyData {
 
     public Long getTotalDemographicsPreferedToPharmacyByPharmacyId(String pharmacyId) {
         return demographicPharmacyDao.getTotalDemographicsPreferedToPharmacyByPharmacyId(Integer.parseInt(pharmacyId));
+    }
+
+    /**
+     * Composes a pharmacy's telephone numbers into the single value used wherever a pharmacy is
+     * shown to a provider -- the printed Rx address block and the "Rx faxed to" chart note. Joins
+     * phone1 and phone2 with a single space, skipping whichever is absent so there is never a stray
+     * separator or a literal "null".
+     *
+     * <p>Numbers are returned verbatim apart from trimming and newline collapsing. Stored pharmacy
+     * phone numbers are unvalidated free text in mixed formats, so callers must not normalise
+     * them.</p>
+     *
+     * @param pharmacy PharmacyInfo the pharmacy, may be null
+     * @return String the joined phone numbers, or "" if none are on file
+     */
+    public static String composePharmacyPhone(PharmacyInfo pharmacy) {
+        if (pharmacy == null) {
+            return "";
+        }
+        StringJoiner phones = new StringJoiner(" ");
+        for (String phone : new String[]{pharmacy.getPhone1(), pharmacy.getPhone2()}) {
+            if (phone != null) {
+                // Collapse embedded newlines so the chart note stays on one line once encoded.
+                String cleaned = phone.replaceAll("[\\r\\n]+", " ").trim();
+                if (!cleaned.isEmpty()) {
+                    phones.add(cleaned);
+                }
+            }
+        }
+        return phones.toString();
     }
 }

--- a/src/main/java/ca/openosp/openo/rx/RxPrintPreview2Action.java
+++ b/src/main/java/ca/openosp/openo/rx/RxPrintPreview2Action.java
@@ -557,11 +557,10 @@ public class RxPrintPreview2Action extends ActionSupport {
         addressJoiner.add(pharmacy.getName());
         addressJoiner.add(pharmacy.getAddress());
         addressJoiner.add(pharmacy.getCity() + ", " + pharmacy.getProvince() + " " + pharmacy.getPostalCode());
-        String tel = "Tel: " + pharmacy.getPhone1();
-        if (pharmacy.getPhone2() != null && !pharmacy.getPhone2().isEmpty()) {
-            tel += " " + pharmacy.getPhone2();
+        String tel = RxPharmacyData.composePharmacyPhone(pharmacy);
+        if (!tel.isEmpty()) {
+            addressJoiner.add("Tel: " + tel);
         }
-        addressJoiner.add(tel);
         addressJoiner.add("Fax: " + pharmacy.getFax());
         if (pharmacy.getEmail() != null && !pharmacy.getEmail().isEmpty()) {
             addressJoiner.add("Email: " + pharmacy.getEmail());
@@ -655,6 +654,7 @@ public class RxPrintPreview2Action extends ActionSupport {
         request.setAttribute("pharmacyName", pharmacyName);
         String pharmacyFax = (pharmacy != null && pharmacy.getFax() != null) ? pharmacy.getFax() : "";
         request.setAttribute("pharmacyFax", pharmacyFax);
+        request.setAttribute("pharmacyPhone", RxPharmacyData.composePharmacyPhone(pharmacy));
     }
 
     /**

--- a/src/main/webapp/oscarRx/ViewScript2.jsp
+++ b/src/main/webapp/oscarRx/ViewScript2.jsp
@@ -220,6 +220,9 @@
                 }
             }
 
+            String pharmacyPhone = RxPharmacyData.composePharmacyPhone(pharmacy);
+            String pharmacyPhoneSegment = pharmacyPhone.isEmpty() ? "" : " Tel: " + pharmacyPhone;
+
             String userAgent = request.getHeader("User-Agent");
             String browserType = "";
             if (userAgent != null) {
@@ -351,6 +354,7 @@
                         <% String timeStamp = new SimpleDateFormat("dd-MMM-yyyy hh:mm a").format(Calendar.getInstance().getTime()); %>
                         // %>
                         text = "[Rx faxed to " + '<%= pharmacy!=null?Encode.forJavaScript(pharmacy.getName()):""%>' + " Fax#: " + '<%=Encode.forJavaScript(String.valueOf(pharmacy!=null?pharmacy.getFax():""))%>';
+                        text += '<%=Encode.forJavaScript(pharmacyPhoneSegment)%>';
 
                         <%--    	 <% if (rxPreferencesMap.getOrDefault("rx_paste_provider_to_echart", false)) { %>--%>
                         text += " prescribed by <%= Encode.forJavaScript(loggedInInfo.getLoggedInProvider().getFormattedName())%>";

--- a/src/main/webapp/oscarRx/printRx/PrintPreview.js
+++ b/src/main/webapp/oscarRx/printRx/PrintPreview.js
@@ -381,19 +381,19 @@ function sendFax(scriptId, signatureRequestId, useSC, scAddress, ctx) {
 }
 
 function printPasteToParent(ctx, rxPasteAsterisk, prefPharmacy, demographicNo, providerName, providerNo, pharmacyName,
-                            pharmacyFax, prescribedBy) {
+                            pharmacyFax, prescribedBy, pharmacyPhone = "") {
     return printPaste2Parent(ctx, true, false, true, rxPasteAsterisk, prefPharmacy, demographicNo, providerName,
-        providerNo, pharmacyName, pharmacyFax, prescribedBy)
+        providerNo, pharmacyName, pharmacyFax, prescribedBy, pharmacyPhone)
 }
 
 function faxPasteToParent(ctx, rxPasteAsterisk, prefPharmacy, demographicNo, providerName, providerNo, pharmacyName,
-                            pharmacyFax, prescribedBy) {
+                            pharmacyFax, prescribedBy, pharmacyPhone = "") {
     return printPaste2Parent(ctx, false, true, true, rxPasteAsterisk, prefPharmacy, demographicNo, providerName,
-        providerNo, pharmacyName, pharmacyFax, prescribedBy)
+        providerNo, pharmacyName, pharmacyFax, prescribedBy, pharmacyPhone)
 }
 
 function printPaste2Parent(ctx, print, fax, pasteRx, rxPasteAsterisk, prefPharmacy, demographicNo, providerName,
-                           providerNo, pharmacyName, pharmacyFax, prescribedBy) {
+                           providerNo, pharmacyName, pharmacyFax, prescribedBy, pharmacyPhone = "") {
     try {
         let text = "";
         const timeStamp = new Date().toLocaleString('en-US', {
@@ -413,6 +413,10 @@ function printPaste2Parent(ctx, print, fax, pasteRx, rxPasteAsterisk, prefPharma
 
         } else if (fax) {
             text = "[Rx faxed to " + pharmacyName.replace(/\\n/g, '\n') + " Fax#: " + pharmacyFax;
+
+            if (pharmacyPhone && pharmacyPhone.trim() !== "") {
+                text += " Tel: " + pharmacyPhone.trim();
+            }
 
             text += " prescribed by " + prescribedBy;
 

--- a/src/main/webapp/oscarRx/printRx/PrintPreview.js
+++ b/src/main/webapp/oscarRx/printRx/PrintPreview.js
@@ -420,7 +420,7 @@ function printPaste2Parent(ctx, print, fax, pasteRx, rxPasteAsterisk, prefPharma
 
             text += " prescribed by " + prescribedBy;
 
-            text += "," + timeStamp + "]\n";
+            text += ", " + timeStamp + "]\n";
         }
 
         if (pasteRx) {

--- a/src/main/webapp/oscarRx/printRx/PrintPreview.jsp
+++ b/src/main/webapp/oscarRx/printRx/PrintPreview.jsp
@@ -164,7 +164,8 @@
                                                 '${requestScope.providerNo}',
                                                 '${e:forJavaScript(requestScope.pharmacyName)}',
                                                 '${e:forJavaScript(requestScope.pharmacyFax)}',
-                                                '${requestScope.prescribedBy}');">
+                                                '${requestScope.prescribedBy}',
+                                                '${e:forJavaScript(requestScope.pharmacyPhone)}');">
                                     Print &amp; Add to encounter note
                                 </button>
 
@@ -207,7 +208,8 @@
                                                     '${requestScope.providerNo}',
                                                     '${e:forJavaScript(requestScope.pharmacyName)}',
                                                     '${e:forJavaScript(requestScope.pharmacyFax)}',
-                                                    '${requestScope.prescribedBy}').then(function() {
+                                                    '${requestScope.prescribedBy}',
+                                                    '${e:forJavaScript(requestScope.pharmacyPhone)}').then(function() {
                                                         sendFax('${e:forJavaScript(param.scriptId)}',
                                                     '${requestScope.signatureRequestId}',
                                                     ${requestScope.useSC != null ? requestScope.useSC : false},

--- a/src/test-modern/java/ca/openosp/openo/test/prescript/RxPharmacyDataPhoneTest.java
+++ b/src/test-modern/java/ca/openosp/openo/test/prescript/RxPharmacyDataPhoneTest.java
@@ -1,0 +1,102 @@
+package ca.openosp.openo.test.prescript;
+
+import ca.openosp.openo.commn.model.PharmacyInfo;
+import ca.openosp.openo.prescript.data.RxPharmacyData;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link RxPharmacyData#composePharmacyPhone(PharmacyInfo)}, the helper
+ * shared by the printed Rx pharmacy address block and the "Rx faxed to" chart note.
+ *
+ * <p>The helper must join phone1 and phone2 with a single space while skipping whichever is
+ * absent, so that neither output ever shows a stray separator, a literal "null", or a dangling
+ * "Tel:" label. Stored phone formats are mixed free text and must be returned verbatim.</p>
+ *
+ * <p>The helper is static and {@link RxPharmacyData}'s Spring lookups are instance fields, so no
+ * container is needed and the class is never instantiated here.</p>
+ *
+ * @since 2026-08-13
+ */
+@Tag("unit")
+@Tag("rx")
+@DisplayName("RxPharmacyData.composePharmacyPhone")
+class RxPharmacyDataPhoneTest {
+
+    /**
+     * Builds a pharmacy carrying only the two phone fields under test.
+     *
+     * @param phone1 String the primary phone number, may be null
+     * @param phone2 String the secondary phone number, may be null
+     * @return PharmacyInfo a pharmacy with the given phone numbers
+     */
+    private PharmacyInfo pharmacyWithPhones(String phone1, String phone2) {
+        PharmacyInfo pharmacy = new PharmacyInfo();
+        pharmacy.setPhone1(phone1);
+        pharmacy.setPhone2(phone2);
+        return pharmacy;
+    }
+
+    @Test
+    @DisplayName("should join both numbers with a single space when both are present")
+    void shouldJoinBothNumbers_whenBothPresent() {
+        String phone = RxPharmacyData.composePharmacyPhone(
+                pharmacyWithPhones("(416) 269-4820", "416-555-0000"));
+
+        assertThat(phone).isEqualTo("(416) 269-4820 416-555-0000");
+    }
+
+    @Test
+    @DisplayName("should return phone1 alone when phone2 is absent")
+    void shouldReturnPhone1Alone_whenPhone2Absent() {
+        assertThat(RxPharmacyData.composePharmacyPhone(pharmacyWithPhones("(416) 269-4820", null)))
+                .isEqualTo("(416) 269-4820");
+        assertThat(RxPharmacyData.composePharmacyPhone(pharmacyWithPhones("(416) 269-4820", "")))
+                .isEqualTo("(416) 269-4820");
+    }
+
+    @Test
+    @DisplayName("should return phone2 alone without a leading separator when phone1 is absent")
+    void shouldReturnPhone2Alone_whenPhone1Absent() {
+        String phone = RxPharmacyData.composePharmacyPhone(pharmacyWithPhones(null, "416-555-0000"));
+
+        assertThat(phone).isEqualTo("416-555-0000");
+        assertThat(phone).doesNotStartWith(" ").doesNotContain("null");
+    }
+
+    @Test
+    @DisplayName("should return empty when no phone numbers are on file")
+    void shouldReturnEmpty_whenNoPhoneNumbersOnFile() {
+        assertThat(RxPharmacyData.composePharmacyPhone(pharmacyWithPhones(null, null))).isEmpty();
+        assertThat(RxPharmacyData.composePharmacyPhone(pharmacyWithPhones("", ""))).isEmpty();
+        assertThat(RxPharmacyData.composePharmacyPhone(pharmacyWithPhones("   ", "  "))).isEmpty();
+    }
+
+    @Test
+    @DisplayName("should return empty when the pharmacy is null")
+    void shouldReturnEmpty_whenPharmacyIsNull() {
+        assertThat(RxPharmacyData.composePharmacyPhone(null)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("should preserve stored formatting verbatim")
+    void shouldPreserveStoredFormatting_verbatim() {
+        assertThat(RxPharmacyData.composePharmacyPhone(pharmacyWithPhones("(604) 707-5989", null)))
+                .isEqualTo("(604) 707-5989");
+        assertThat(RxPharmacyData.composePharmacyPhone(pharmacyWithPhones("14162694819", null)))
+                .isEqualTo("14162694819");
+    }
+
+    @Test
+    @DisplayName("should collapse embedded newlines so the note stays on one line")
+    void shouldCollapseEmbeddedNewlines_soNoteStaysOnOneLine() {
+        String phone = RxPharmacyData.composePharmacyPhone(
+                pharmacyWithPhones("416-555-0000\r\next 123", null));
+
+        assertThat(phone).isEqualTo("416-555-0000 ext 123");
+        assertThat(phone).doesNotContain("\n").doesNotContain("\r");
+    }
+}

--- a/src/test-modern/java/ca/openosp/openo/test/prescript/RxPharmacyDataPhoneTest.java
+++ b/src/test-modern/java/ca/openosp/openo/test/prescript/RxPharmacyDataPhoneTest.java
@@ -50,6 +50,15 @@ class RxPharmacyDataPhoneTest {
     }
 
     @Test
+    @DisplayName("should trim both numbers and still join them with a single space")
+    void shouldTrimBothNumbers_whenBothArePadded() {
+        String phone = RxPharmacyData.composePharmacyPhone(
+                pharmacyWithPhones("  (416) 269-4820  ", "  416-555-0000  "));
+
+        assertThat(phone).isEqualTo("(416) 269-4820 416-555-0000");
+    }
+
+    @Test
     @DisplayName("should return phone1 alone when phone2 is absent")
     void shouldReturnPhone1Alone_whenPhone2Absent() {
         assertThat(RxPharmacyData.composePharmacyPhone(pharmacyWithPhones("(416) 269-4820", null)))


### PR DESCRIPTION
# Summary

When a prescription is faxed, the note posted to the patient's chart now includes the pharmacy's
phone number alongside the fax number:

```
[Rx faxed to Example Pharmacy Fax#: 5555550100 Tel: 5555550199 prescribed by Testerson, Testy, Jan 01, 2026, 09:00 AM]
```

The `Tel:` label and the phone1/phone2 composition deliberately match the pharmacy address block
already printed on the prescription, so the note shows the same numbers the pharmacy was sent.

Full write-up, screenshots and test evidence: **[Pharmacy Phone Number in Rx Chart Note Feature](https://docs.google.com/document/d/1cu7i9flHbsyYsXdLhYhJ-Hdbo8Ek0cx0o6SXn31fEBk/edit?usp=sharing)**

Fixes: [Include pharmacy's phone # in rx chart note](https://trello.com/c/STmlofNK/50-include-pharmacys-phone-in-rx-chart-note)

## Problem

Requested by a Magenta MD:

> May I possibly suggest a tinkering to the way prescriptions are posted to the chart? Currently
> it'll show the fax number, but is it possible to also post the phone number? […] Sometimes I find
> I need to call the pharmacy, to clarify things, and it would be so much easier if the phone number
> were just there when the faxed prescription is posted.

The chart note recorded the fax number only. A prescriber needing to call the pharmacy — to clarify a
dose, a substitution, a rejected claim — had to leave the chart, open the pharmacy picker and look the
number up. The one number on screen was the one number they couldn't dial.

## Solution

- **`RxPharmacyData.composePharmacyPhone(PharmacyInfo)`** — a single shared helper that joins `phone1`
  and `phone2` with one space, skipping whichever is absent. It lives on `RxPharmacyData` because that
  is the pharmacy class both call sites already import and instantiate.
- **`RxPrintPreview2Action`** uses it for the printed address block and exposes the result as the
  `pharmacyPhone` request attribute.
- **`PrintPreview.js` / `PrintPreview.jsp`** thread that attribute through and emit the `Tel:` segment.
- **`ViewScript2.jsp`** — the legacy Rx preview holds a second copy of this note string. It is
  unreachable today, but leaving one of two copies behind is how formats silently diverge.

**Behaviour**

| Case | Note segment |
| :---- | :---- |
| `phone1` + `phone2` | `Fax#: … Tel: (416) 269-4820 4165550000` |
| `phone1` only | `Fax#: … Tel: (416) 269-4820` |
| `phone2` only | `Fax#: … Tel: 4165550000` |
| Neither | `Fax#: …` — no `Tel:` segment, exactly as today |

Numbers are rendered **verbatim** — leading/trailing whitespace is trimmed and embedded newlines
collapse to a space, but nothing is reformatted. Stored pharmacy phone numbers are unvalidated free
text in mixed

The change is **self-suppressing**: a pharmacy with no phone on file gets no `Tel:` segment at all, so
there is no property flag. (The separate space-restoring commit does change that line by one
character — see the notes for reviewers below.)

**UI Before:**
<img width="625" height="74" alt="image" src="https://github.com/user-attachments/assets/87c0436a-ac2f-4120-b5f0-d74c8da6b9a9" />

**UI After:**
<img width="722" height="66" alt="image" src="https://github.com/user-attachments/assets/4d46a9fd-9210-4eb0-89c3-7f8b9ebcfd2b" />

## Validation

- **Manual UI testing** across five pharmacies covering every branch: `phone1` only, both numbers in
  mixed formats, `phone2` only, no phones with an apostrophe in the name, and embedded double quotes
  in the phone field. Screenshots in the linked doc.
- **8 unit tests** — `RxPharmacyDataPhoneTest` covers all four composition cases plus null pharmacy,
  whitespace-only input, newline collapsing and verbatim passthrough. Verified they actually execute
  under the modern surefire include patterns, not just that the build is green.
- **Both changed JSPs precompiled with Jasper** to `.class`. This matters for `ViewScript2.jsp`: it is
  dead code, so a scriptlet error there would never surface at runtime.
- **Backport rehearsed** — all five commits cherry-picked onto `release/2026-03-17` in a scratch
  worktree. Four apply clean; the legacy-JSP commit takes a one-line conflict resolution, documented
  in the linked doc.

## Additional notes for reviewers

- **Fixes a latent bug on the printed Rx.** `setupPharmacyAddress` had an unguarded `getPhone1()`, so a
  pharmacy with no `phone1` printed `Tel: null`, and one with only `phone2` printed
  `Tel: null 4165550000`. Routing both through the shared helper removes those. This changes the
  *prescription*, not just the note — called out deliberately rather than slipped in.
- **One commit is not part of the feature.** The last commit restores a missing space before the
  timestamp (`… prescribed by Name,Jan 01 …` → `… prescribed by Name, Jan 01 …`). `ViewScript2.jsp`,
  which this path was ported from, has the space — it was dropped in the port. Isolated so it can be
  reverted independently if wanted.
- **The timestamp *format* is deliberately untouched.** `PrintPreview.js` builds its own timestamp via
  `toLocaleString` and ignores the server-computed `timeStamp` attribute, which has zero consumers.
  Do not "fix" this by switching to the server value:
  [MagentaHealth#152](https://github.com/MagentaHealth/Open-O/pull/152) removed `timeZone: 'UTC'` from
  exactly these lines so the note renders in local time, and moving to `SimpleDateFormat` would hand
  the timestamp back to the server's timezone. The real follow-up is to delete the dead attribute.
- **Quote handling.** Quotes in pharmacy fields have broken this note before (#2483, and
  MagentaHealth#144). `pharmacyPhone` is a new value flowing into the same JS string literal, so it is
  encoded at the output point (`${e:forJavaScript(...)}` / `Encode.forJavaScript`) and explicitly
  tested with embedded quotes.

## Security

- OWASP encoding at every JS output point; the value is stored raw and encoded per context, matching
  the existing `pharmacyName` / `pharmacyFax` convention.
- No SQL — reuses `RxPharmacyData.getPharmacy()`.
- Privilege checks unchanged; `RxWriteToEncounter2Action` still enforces `_rx` write.
- No new logging.

---

## Summary by Sourcery

Include composed pharmacy phone numbers in faxed prescription chart notes and printed Rx address blocks while correcting chart note timestamp spacing.

New Features:
- Add pharmacy phone number to the "Rx faxed to" chart note when available.

Bug Fixes:
- Prevent printed prescriptions from showing "Tel: null" or stray separators when pharmacy phone fields are missing.

Enhancements:
- Introduce a shared helper to compose pharmacy phone1/phone2 into a single display value used across Rx views.
- Extend both modern and legacy Rx print preview flows to pass and safely encode pharmacy phone data in JavaScript-driven notes.

Tests:
- Add unit test coverage for pharmacy phone composition across null, empty, whitespace, newline, and mixed-format cases.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Include the pharmacy phone number in the “Rx faxed to …” chart note so providers can call without leaving the chart. Previously the note showed only the fax; now it appends “Tel: <phone1> <phone2>” verbatim and skips the segment when no phone exists; printed Rxs no longer show “Tel: null,” and the note restores a missing space before the timestamp.

- Adds `RxPharmacyData.composePharmacyPhone(PharmacyInfo)` to join `phone1`/`phone2`, trim, and collapse newlines; returns "" when both are blank; documents with `@since`.
- Uses the helper in `RxPrintPreview2Action` to render the printed address block and exposes `pharmacyPhone` to `PrintPreview.jsp`/`PrintPreview.js`; updates `ViewScript2.jsp` for parity.
- JS appends the “ Tel: …” segment and fixes “, <timestamp>” spacing; the new parameter is optional for rolling deploys with cached assets.
- Tests cover both numbers, each alone, all blank, null pharmacy, verbatim formatting, newline collapsing, and trimming when both numbers are padded.

<sup>Written for commit aeeb83844cc7993f202a0aa88ad78996ba978047. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openo-beta/Open-O/pull/2494?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Include composed pharmacy phone numbers in faxed prescription chart notes and printed Rx address blocks, while correcting spacing before the chart note timestamp.

New Features:
- Add pharmacy phone number to the "Rx faxed to" chart note when a faxed prescription is posted, using phone1/phone2 when available.

Bug Fixes:
- Prevent printed prescriptions from showing "Tel: null" or stray separators when pharmacy phone fields are missing.

Enhancements:
- Introduce a shared helper to compose pharmacy phone1/phone2 into a single display value reused across Rx views and notes.

Tests:
- Add unit tests covering pharmacy phone composition for null pharmacies, empty/whitespace values, newline collapsing, and mixed-format numbers.