### PR TITLE
Fix: separate health card fields on the consultation request screen

### DIFF
--- a/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequest2Form.java
+++ b/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequest2Form.java
@@ -450,6 +450,34 @@ public final class EctConsultationFormRequest2Form {
         this.patientHealthCardType = patientHealthCardType;
     }
 
+    /**
+     * Formats the health card for display as "number version (card type)", omitting whichever
+     * optional parts are not on file. The version code and the card type are both two characters
+     * drawn from the same alphabet, so the parentheses are what stop a version code such as AB
+     * from reading as a second province code.
+     * <p>
+     * The value is returned as raw text. Callers are responsible for encoding it at the output
+     * boundary; encoding here would double-encode.
+     *
+     * @return String the formatted health card, or an empty string when nothing is on file
+     */
+    public String getFormattedHealthCard() {
+        // Delegate to the getters rather than the fields: the fields are populated straight from
+        // the demographic and may be null, while the getters normalise null to an empty string.
+        String number = getPatientHealthNum();
+        String versionCode = getPatientHealthCardVersionCode();
+        String cardType = getPatientHealthCardType();
+
+        StringBuilder formatted = new StringBuilder(number);
+        if (!versionCode.isEmpty()) {
+            formatted.append(' ').append(versionCode);
+        }
+        if (!cardType.isEmpty()) {
+            formatted.append(" (").append(cardType).append(')');
+        }
+        return formatted.toString().trim();
+    }
+
     public Integer getHl7TextMessageId() {
         return hl7TextMessageId;
     }

--- a/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequest2Form.java
+++ b/src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequest2Form.java
@@ -31,7 +31,9 @@ import org.apache.commons.lang3.StringUtils;
 import ca.openosp.openo.utility.WebUtils;
 
 import javax.servlet.http.HttpServletRequest;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 
 public final class EctConsultationFormRequest2Form {
 
@@ -468,14 +470,19 @@ public final class EctConsultationFormRequest2Form {
         String versionCode = getPatientHealthCardVersionCode();
         String cardType = getPatientHealthCardType();
 
-        StringBuilder formatted = new StringBuilder(number);
+        // Collect only the parts that are on file, then join. Each part stands on its own, so no
+        // combination can produce a stray separator or an empty pair of parentheses.
+        List<String> parts = new ArrayList<String>();
+        if (!number.isEmpty()) {
+            parts.add(number);
+        }
         if (!versionCode.isEmpty()) {
-            formatted.append(' ').append(versionCode);
+            parts.add(versionCode);
         }
         if (!cardType.isEmpty()) {
-            formatted.append(" (").append(cardType).append(')');
+            parts.add("(" + cardType + ")");
         }
-        return formatted.toString().trim();
+        return String.join(" ", parts);
     }
 
     public Integer getHl7TextMessageId() {

--- a/src/main/webapp/oscarEncounter/oscarConsultationRequest/ConsultationFormRequest.jsp
+++ b/src/main/webapp/oscarEncounter/oscarConsultationRequest/ConsultationFormRequest.jsp
@@ -2470,7 +2470,18 @@ if (userAgent != null) {
                                     <tr>
                                         <td class="tite4"><fmt:setBundle basename="oscarResources"/><fmt:message key="oscarEncounter.oscarConsultationRequest.ConsultationFormRequest.msgHealthCard"/>
                                         </td>
-                                        <td class="tite1"><%=Encode.forHtml(String.valueOf(thisForm.getPatientHealthNum()))%><%=Encode.forHtml(String.valueOf(thisForm.getPatientHealthCardVersionCode()))%><%=Encode.forHtml(String.valueOf(thisForm.getPatientHealthCardType()))%>
+                                        <%
+                                            // Health card renders as "number version (card type)"; the version code
+                                            // and the card type are both two characters, so without the parentheses
+                                            // a version code such as AB is indistinguishable from a province code.
+                                            String hcNum = thisForm.getPatientHealthNum();
+                                            String hcVer = thisForm.getPatientHealthCardVersionCode();
+                                            String hcType = thisForm.getPatientHealthCardType();
+                                            StringBuilder healthCard = new StringBuilder(hcNum);
+                                            if (!hcVer.isEmpty()) healthCard.append(' ').append(hcVer);
+                                            if (!hcType.isEmpty()) healthCard.append(" (").append(hcType).append(')');
+                                        %>
+                                        <td class="tite1"><%=Encode.forHtml(healthCard.toString().trim())%>
                                         </td>
                                     </tr>
                                     <tr id="conReqSendTo">

--- a/src/main/webapp/oscarEncounter/oscarConsultationRequest/ConsultationFormRequest.jsp
+++ b/src/main/webapp/oscarEncounter/oscarConsultationRequest/ConsultationFormRequest.jsp
@@ -2470,18 +2470,7 @@ if (userAgent != null) {
                                     <tr>
                                         <td class="tite4"><fmt:setBundle basename="oscarResources"/><fmt:message key="oscarEncounter.oscarConsultationRequest.ConsultationFormRequest.msgHealthCard"/>
                                         </td>
-                                        <%
-                                            // Health card renders as "number version (card type)"; the version code
-                                            // and the card type are both two characters, so without the parentheses
-                                            // a version code such as AB is indistinguishable from a province code.
-                                            String hcNum = thisForm.getPatientHealthNum();
-                                            String hcVer = thisForm.getPatientHealthCardVersionCode();
-                                            String hcType = thisForm.getPatientHealthCardType();
-                                            StringBuilder healthCard = new StringBuilder(hcNum);
-                                            if (!hcVer.isEmpty()) healthCard.append(' ').append(hcVer);
-                                            if (!hcType.isEmpty()) healthCard.append(" (").append(hcType).append(')');
-                                        %>
-                                        <td class="tite1"><%=Encode.forHtml(healthCard.toString().trim())%>
+                                        <td class="tite1"><%=Encode.forHtml(thisForm.getFormattedHealthCard())%>
                                         </td>
                                     </tr>
                                     <tr id="conReqSendTo">

--- a/src/test-modern/java/ca/openosp/openo/encounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequest2FormHealthCardTest.java
+++ b/src/test-modern/java/ca/openosp/openo/encounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequest2FormHealthCardTest.java
@@ -93,6 +93,31 @@ public class EctConsultationFormRequest2FormHealthCardTest {
         }
 
         @Test
+        @DisplayName("should render the version code and card type when the number is absent")
+        void shouldRenderVersionAndType_whenNumberAbsent() {
+            // Each part is rendered on its own merits, mirroring the demographic master file where
+            // HC Type occupies its own row regardless of whether a health number is on file.
+            assertThat(formWith(null, VERSION_CODE, CARD_TYPE).getFormattedHealthCard())
+                    .isEqualTo("AB (ON)");
+        }
+
+        @Test
+        @DisplayName("should render the card type alone when number and version code are absent")
+        void shouldRenderTypeOnly_whenNumberAndVersionAbsent() {
+            // Reachable in practice: the card type defaults to a province on new demographics,
+            // so it is commonly set before any health number has been entered.
+            assertThat(formWith(null, null, CARD_TYPE).getFormattedHealthCard())
+                    .isEqualTo("(ON)");
+        }
+
+        @Test
+        @DisplayName("should render the version code alone when number and card type are absent")
+        void shouldRenderVersionOnly_whenNumberAndTypeAbsent() {
+            assertThat(formWith("", VERSION_CODE, "").getFormattedHealthCard())
+                    .isEqualTo("AB");
+        }
+
+        @Test
         @DisplayName("should treat blank and whitespace-only parts as absent")
         void shouldTreatBlankAsAbsent_whenPartsAreEmptyOrWhitespace() {
             assertThat(formWith(NUMBER, "", "").getFormattedHealthCard()).isEqualTo("1234567890");

--- a/src/test-modern/java/ca/openosp/openo/encounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequest2FormHealthCardTest.java
+++ b/src/test-modern/java/ca/openosp/openo/encounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequest2FormHealthCardTest.java
@@ -1,0 +1,148 @@
+package ca.openosp.openo.encounter.oscarConsultationRequest.pageUtil;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link EctConsultationFormRequest2Form#getFormattedHealthCard()}.
+ *
+ * <p>The health card is displayed as "number version (card type)". The version code and the
+ * card type are both two characters drawn from the same alphabet, so a purely space-separated
+ * rendering leaves a version code such as AB looking like a second province code; the
+ * parentheses are what disambiguate them.</p>
+ *
+ * <p>The optional parts are frequently absent - {@code demographic.ver} and
+ * {@code demographic.hc_type} are both nullable - so the cases below pin down that a missing
+ * part is dropped entirely rather than leaving a stray gap or an empty pair of parentheses.</p>
+ *
+ * @since 2026-08-20
+ */
+@DisplayName("EctConsultationFormRequest2Form - Health Card Formatting")
+@Tag("unit")
+@Tag("fast")
+@Tag("encounter")
+public class EctConsultationFormRequest2FormHealthCardTest {
+
+    /** Fails the Ontario health-number check digit, so it cannot match a real card. */
+    private static final String NUMBER = "1234567890";
+    private static final String VERSION_CODE = "AB";
+    private static final String CARD_TYPE = "ON";
+
+    private static EctConsultationFormRequest2Form formWith(String number, String versionCode, String cardType) {
+        EctConsultationFormRequest2Form form = new EctConsultationFormRequest2Form();
+        form.setPatientHealthNum(number);
+        form.setPatientHealthCardVersionCode(versionCode);
+        form.setPatientHealthCardType(cardType);
+        return form;
+    }
+
+    @Nested
+    @DisplayName("all parts present")
+    class AllPartsPresent {
+
+        @Test
+        @DisplayName("should render number, version code and parenthesised card type")
+        void shouldRenderAllParts_whenAllPresent() {
+            assertThat(formWith(NUMBER, VERSION_CODE, CARD_TYPE).getFormattedHealthCard())
+                    .isEqualTo("1234567890 AB (ON)");
+        }
+
+        @Test
+        @DisplayName("should separate the version code from the card type")
+        void shouldDisambiguateVersionCodeFromCardType_whenBothLookLikeProvinceCodes() {
+            // A version code of ON on a BC card is the worst case: spacing alone would render
+            // "1234567890 ON BC", which reads as two jurisdictions.
+            assertThat(formWith(NUMBER, "ON", "BC").getFormattedHealthCard())
+                    .isEqualTo("1234567890 ON (BC)");
+        }
+    }
+
+    @Nested
+    @DisplayName("optional parts absent")
+    class OptionalPartsAbsent {
+
+        @Test
+        @DisplayName("should omit the version code when it is not on file")
+        void shouldOmitVersionCode_whenNull() {
+            assertThat(formWith(NUMBER, null, CARD_TYPE).getFormattedHealthCard())
+                    .isEqualTo("1234567890 (ON)");
+        }
+
+        @Test
+        @DisplayName("should omit the card type when it is not on file")
+        void shouldOmitCardType_whenNull() {
+            assertThat(formWith(NUMBER, VERSION_CODE, null).getFormattedHealthCard())
+                    .isEqualTo("1234567890 AB");
+        }
+
+        @Test
+        @DisplayName("should render the number alone when both optional parts are absent")
+        void shouldRenderNumberOnly_whenBothOptionalPartsNull() {
+            assertThat(formWith(NUMBER, null, null).getFormattedHealthCard())
+                    .isEqualTo("1234567890");
+        }
+
+        @Test
+        @DisplayName("should return an empty string when nothing is on file")
+        void shouldReturnEmpty_whenNothingOnFile() {
+            assertThat(formWith(null, null, null).getFormattedHealthCard()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("should treat blank and whitespace-only parts as absent")
+        void shouldTreatBlankAsAbsent_whenPartsAreEmptyOrWhitespace() {
+            assertThat(formWith(NUMBER, "", "").getFormattedHealthCard()).isEqualTo("1234567890");
+            assertThat(formWith(NUMBER, "   ", "\t").getFormattedHealthCard()).isEqualTo("1234567890");
+        }
+    }
+
+    @Nested
+    @DisplayName("output hygiene")
+    class OutputHygiene {
+
+        @Test
+        @DisplayName("should never emit empty parentheses")
+        void shouldNeverEmitEmptyParentheses_whenCardTypeAbsent() {
+            for (String cardType : new String[]{null, "", "  "}) {
+                assertThat(formWith(NUMBER, VERSION_CODE, cardType).getFormattedHealthCard())
+                        .doesNotContain("(")
+                        .doesNotContain(")");
+            }
+        }
+
+        @Test
+        @DisplayName("should never emit a doubled or trailing space")
+        void shouldNeverEmitStraySpacing_whenPartsAreAbsent() {
+            String[][] cases = {
+                    {NUMBER, null, CARD_TYPE},
+                    {NUMBER, "", CARD_TYPE},
+                    {NUMBER, VERSION_CODE, null},
+                    {NUMBER, null, null},
+                    {null, VERSION_CODE, CARD_TYPE},
+            };
+            for (String[] c : cases) {
+                String formatted = formWith(c[0], c[1], c[2]).getFormattedHealthCard();
+                assertThat(formatted).doesNotContain("  ");
+                assertThat(formatted).isEqualTo(formatted.trim());
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("encoding boundary")
+    class EncodingBoundary {
+
+        @Test
+        @DisplayName("should return raw text so the caller can encode without double-encoding")
+        void shouldReturnRawText_whenPartsContainHtmlSpecialCharacters() {
+            // Encoding belongs at the JSP output boundary (Encode.forHtml). If this method were
+            // to encode as well, the rendered value would be double-encoded.
+            assertThat(formWith("<&'\"", VERSION_CODE, CARD_TYPE).getFormattedHealthCard())
+                    .isEqualTo("<&'\" AB (ON)");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

The **Health Card No.** row on the consultation request screen rendered the health
number, version code and card type jammed together with no separator, so a card
displayed as `HINVCON`. This adds separators and parenthesises the card type, so it
now reads `HIN VC (CT)`.

**UI Before:**

<img width="419" height="364" alt="ui-before" src="https://github.com/user-attachments/assets/f9f9029b-77f3-41d4-8a94-5da6ebfba5c8" />

**UI After:**

<img width="417" height="364" alt="ui-after" src="https://github.com/user-attachments/assets/59e187fc-e3fa-4868-98b6-5f43fba6f123" />


Display-only. No submitted values, stored data, or outgoing referral documents are
affected. The formatting lives in a new method on the consult form bean, so the JSP
row itself is a one-line change.

## Problem

`ConsultationFormRequest.jsp` emitted the three fields as three directly adjacent
scriptlets with zero characters between them:

```jsp
<td class="tite1"><%=Encode.forHtml(String.valueOf(thisForm.getPatientHealthNum()))%><%=Encode.forHtml(String.valueOf(thisForm.getPatientHealthCardVersionCode()))%><%=Encode.forHtml(String.valueOf(thisForm.getPatientHealthCardType()))%>
```

This produced two distinct problems:

**1. The reported case: the run-on is visible but ambiguous.** A card with all three
fields populated rendered as `HINVCON`.

**2. The quieter case: the run-on is invisible.** `demographic.ver` is nullable
(`oscarinit.sql:557`), and the form getters are `StringUtils.trimToEmpty(...)`
(`EctConsultationFormRequest2Form.java:431-450`), so a missing version code silently
collapsed to `HINCT`. No `null`, no gap, just a longer run of characters that reads
as a single valid identifier with nothing to signal where the number ends and the
province begins.

## Solution

A new `getFormattedHealthCard()` on `EctConsultationFormRequest2Form`
(`EctConsultationFormRequest2Form.java:466`) collects the parts that are on file and
joins them:

```java
List<String> parts = new ArrayList<String>();
if (!number.isEmpty())      parts.add(number);
if (!versionCode.isEmpty()) parts.add(versionCode);
if (!cardType.isEmpty())    parts.add("(" + cardType + ")");
return String.join(" ", parts);
```

The separator sits between parts rather than being glued to the front of one, so no
combination can emit a stray separator or an empty pair of parentheses, and no trailing
`trim()` is needed as a backstop.

The JSP row (`ConsultationFormRequest.jsp:2473`) becomes a single expression:

```jsp
<td class="tite1"><%=Encode.forHtml(thisForm.getFormattedHealthCard())%>
```

Measured against `develop` that is a one-line swap, three encoded getter calls became
one, so the view carries less Java than before this branch.

Three things about the method are deliberate:

- **It delegates to the `trimToEmpty` getters, not the raw fields.** `fillFormValues`
  populates those fields straight from the demographic, where `ver` and `hc_type` are
  nullable, so reading the fields directly would throw on the common
  missing-version-code case.
- **It returns raw text.** Encoding stays at the JSP output boundary. Encoding inside
  the getter as well would double-encode. `getOruR01UrlString()` on the same class does
  escape internally, so this is an easy pattern to copy by mistake; a unit test pins the
  contract.
- **No existing getter was modified.** The bean is a plain DTO, absent from `struts.xml`
  and `struts-config.xml` with nothing reflecting over it, so a read-only getter cannot
  affect parameter binding. The two consult PDF generators run on
  `EctConsultationFormRequestUtil`, a different class, and are untouched.

### Why parentheses rather than just spaces

Spacing alone would give `HIN VC CT`. Version codes are two alphanumerics and card
types come from a province dropdown (`demographicaddarecordhtm.jsp:1629-1652`:
`AB`, `BC`, `MB`, `NB`, `NL`, `NT`, `NS`, `NU`, `ON`, `PE`, `QC`, `SK`, `YT`, plus
`OT` and `US`/`US-XX`). The two fields are drawn from the same alphabet and are the
same width, so a spaced rendering leaves the version code looking like a second
province code. The parentheses mark which token is the jurisdiction.

This matches the existing on-screen convention rather than inventing one:

| Site | Rendering |
|---|---|
| eChart header: `Demographic.getStandardIdentificationHTML` (`Demographic.java:1515`, used at `casemgmt/newEncounterHeader.jsp:68`) | `hin (CT)` label, `HIN VC` value |
| Encounter worksheet: (`form/patientEncounterWorksheet.jsp:218`) | `HIN (CT)` |

The card type is placed in the value rather than the label because the consult row's
label comes from the localized `msgHealthCard` key; injecting the province there
would mean editing five resource bundles for an identical visual result.

### Behaviour

| `hin` / `ver` / `hc_type` | Before | After |
|---|---|---|
| all three present | `HINVCON` | `HIN VC (CT)` |
| no version code | `HINCT` | `HIN (CT)` |
| no card type | `HINVC` | `HIN VC` |
| number only | `HIN` | `HIN` |
| no number, version and card type | `VCCT` | `VC (CT)` |
| card type only | `CT` | `(CT)` |
| nothing on file | *(blank)* | *(blank)* |

Blank fields are dropped rather than leaving a stray gap or an empty `()`.

The last two rows are worth calling out. Each part is rendered on its own merits, which
mirrors the demographic master file where HC Type occupies its own row regardless of
whether a health number is on file. The card-type-only case is reachable in practice:
`hc_type` defaults to a province on new demographics, so it is commonly set before any
health number has been entered. That state previously rendered as a bare `CT`, which
read as a fragment of a number.

## Files changed

- `src/main/java/ca/openosp/openo/encounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequest2Form.java`
  one new method, nothing existing modified
- `src/main/webapp/oscarEncounter/oscarConsultationRequest/ConsultationFormRequest.jsp`
  one line
- `src/test-modern/java/ca/openosp/openo/encounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequest2FormHealthCardTest.java`
  new

Net against `develop`: 3 files, +209 / -1.

## Verification

Checked before and after the change:

- **Only occurrence.** A case-insensitive sweep for `patientHealthNum|patientHealthCard`
  across the consults module returns this one line. The consult list views and the fax
  cover sheet do not display the health number at all.
- **Display only.** No hidden input or form field carries the concatenated value, so
  nothing submitted changes.
- **Null-safety.** All three getters are `StringUtils.trimToEmpty(...)`, so they never
  return null and `.isEmpty()` is safe. The formatter delegates to them rather than to
  the fields, which can be null. The now-removed `String.valueOf()` wrappers were no-ops
  on values that were already non-null Strings.
- **Encoding unchanged.** Still a single `Encode.forHtml()` over the assembled string.
- **Population paths.** All four paths that fill the form (`requestId`, `segmentId`,
  new-request, and validation-error redisplay) populate the same `thisForm` instance
  that the row reads, so moving the composition onto that object cannot diverge from
  what the page previously rendered.
- **Not a regression from the encoder sweep.** `git show ada4c9a73f6^` confirms the
  fields were already concatenated before that commit touched the line.

### Automated tests

`EctConsultationFormRequest2FormHealthCardTest`, 13 tests, `@Tag("unit")`, no Spring
context required now that the logic is out of the JSP.

Covers every combination of present, absent, blank and whitespace-only optional fields;
asserts that empty parentheses and stray or doubled spacing can never be emitted; and
pins that the formatter returns raw text so the `Encode.forHtml` at the JSP boundary
cannot double-encode. Includes the worst-case ambiguity this PR exists to fix, a version
code of `ON` on a `BC` card, which plain spacing would render as two jurisdictions.

## Testing steps

All steps below were executed against a local deployment; the UI screenshots above come
from steps 3 and 4.

Requires a demographic with a health number, a version code, **and** a card type set,
with the version code blank the old rendering does not look obviously wrong.

1. `make clean && make install`, then `server start`
2. Open a patient meeting the criteria above
3. eChart → **Consultations** in the left nav → open any existing consult (or start a
   new consultation request);
4. In the patient info table at the upper right, confirm the **Health Card No.** row
   reads `HIN VC (CT)`
5. Edit the demographic to clear the version code, reload the consult → confirm
   `HIN (CT)` with no double space and no empty parentheses
6. Set the card type to a blank/`Other` value → confirm `HIN VC` with no trailing `()`
7. Confirm the row is correct both when **creating a new** request and when **viewing an
   existing** one (the row is not inside a conditional, so both paths render it)
8. Regression check: **Submit & Print Preview** the consult and confirm the generated
   PDF is unchanged

Other entry points to the same screen, all worth a spot check:
`DisplayDemographicConsultationRequests.jsp:314` (patient chart → Consultations tab),
`ViewConsultationRequests.jsp:554-591` (incoming consults list), and the Inbox for a
REF_I12 document (`oscarMDSIndex.js:1297`).

## Risk

Low. One table row, display only. The new method has a single caller and the bean it
sits on is used by this one screen, so the blast radius is that row. No data, billing,
or outgoing document path is touched, and no existing method was modified. Worst case is
a cosmetic regression on a single row of one screen.

## Out of scope

Deliberately not addressed here, noted since issues cannot be filed on this repo:

- **The two consult PDF generators disagree with each other.** `ConsultationPDFCreator.java:582`
  emits `(CT) HIN VC` while `EctConsultationFormRequestPrintPdf.java:230` emits
  `CT HIN VC`. Both already space the fields, so neither has the bug being fixed here,
  and they produce documents that go out to the specialist, changing referral output
  deserves its own PR and its own review.
- **No shared formatter exists.** Roughly a dozen sites across the project hand-roll
  this concatenation, which is why they have drifted into three different formats
  (type-in-parens on screens, type-first in PDF headers, three separate labelled fields
  in the demographic master). A single `formatHealthCard(hin, ver, hcType)` helper would
  fix that, but it would touch prevention, DHDR, DHIR, billing labels and referral PDFs
  at once, far more blast radius than a one-row display bug justifies.
- **`oscarPrevention/PreventionReporting.jsp:641,658`** renders `HIN` + `VC` run-on in a
  report column. Two fields rather than three, no province involved, and it is a report
  rather than a clinical screen. Left alone.
- **`Demographic.getStandardIdentificationHtml()`** (the no-arg variant,
  `Demographic.java:1723`) builds `HIN VC(CT)` with a missing space before the paren. It
  has zero callers anywhere in `src/`, so it is dead code and not worth touching.

## Summary by Sourcery

Format health-card details clearly and safely on the consultation request screen.

Bug Fixes:
- Fix the consultation request screen’s Health Card No. display so health number, version code, and card type are clearly separated and unambiguous.
- Handle missing health-card components without stray spaces or empty parentheses.

Enhancements:
- Centralize health-card display formatting in the consultation form model while preserving HTML encoding at the JSP output boundary.

Tests:
- Add unit coverage for complete, partial, blank, whitespace-only, and special-character health-card values.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Health Card No. display on the consultation request screen: previously rendered as a run-on (HINVCON); now shows HIN VC (CT) and cleanly omits missing parts.

- `EctConsultationFormRequest2Form#getFormattedHealthCard()` collects non-empty parts and joins them as "number version (type)"; returns raw text. `ConsultationFormRequest.jsp` now calls it and HTML-encodes the result.
- Treats null/blank/whitespace as absent, supports number-absent cases, and guarantees no double spaces or empty parentheses.
- Display-only change; no submitted values, stored data, or referral PDFs are affected.
- Added and expanded unit tests covering all combinations, spacing hygiene, and encoding-at-boundary expectations.
- Low risk; verify the Health Card No. row in both new and existing consults.

<sup>Written for commit 2bf2938fdaedb46aec674425e95f61f299b4d2e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openo-beta/Open-O/pull/2495?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved health card information formatting for clearer display.
  * Empty card details are now omitted, and displayed values are safely encoded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->