### PR TITLE
open-osp/Open-O:main sync

### DIFF
--- a/dependencies-lock-modern.json
+++ b/dependencies-lock-modern.json
@@ -1493,11 +1493,11 @@
   }, {
     "groupId" : "net.java.dev.jna",
     "artifactId" : "jna",
-    "version" : "5.18.1",
+    "version" : "5.19.1",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:6Fmqe/AyJdrN0EPGf5OeklDj4iPvAxoMtncXl0Ni6d8r0dnXBOe1LnQIIw8B2Ba6t+wadF2c8v6ybr2DmAJsfg=="
+    "integrity" : "sha512:DmqWCs/W+sd0htp7bRjrnZjgogW994GJVImX+29gk+cT5XDpgp7MbX3sgTJ26vXTr1bTDGJ/67OgsyT6kDXojw=="
   }, {
     "groupId" : "net.minidev",
     "artifactId" : "accessors-smart",

--- a/dependencies-lock-modern.json
+++ b/dependencies-lock-modern.json
@@ -1493,11 +1493,11 @@
   }, {
     "groupId" : "net.java.dev.jna",
     "artifactId" : "jna",
-    "version" : "5.18.1",
+    "version" : "5.19.0",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:6Fmqe/AyJdrN0EPGf5OeklDj4iPvAxoMtncXl0Ni6d8r0dnXBOe1LnQIIw8B2Ba6t+wadF2c8v6ybr2DmAJsfg=="
+    "integrity" : "sha512:39wcr9Gn/7RBOMYsO3PSpIyW71rpXFEnWplfp31kueAGhvrLltpWXdRFH95prpe+2UHhjr5YzN2bXpC6V2iKDQ=="
   }, {
     "groupId" : "net.minidev",
     "artifactId" : "accessors-smart",

--- a/dependencies-lock-modern.json
+++ b/dependencies-lock-modern.json
@@ -1493,11 +1493,11 @@
   }, {
     "groupId" : "net.java.dev.jna",
     "artifactId" : "jna",
-    "version" : "5.19.0",
+    "version" : "5.18.1",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:39wcr9Gn/7RBOMYsO3PSpIyW71rpXFEnWplfp31kueAGhvrLltpWXdRFH95prpe+2UHhjr5YzN2bXpC6V2iKDQ=="
+    "integrity" : "sha512:6Fmqe/AyJdrN0EPGf5OeklDj4iPvAxoMtncXl0Ni6d8r0dnXBOe1LnQIIw8B2Ba6t+wadF2c8v6ybr2DmAJsfg=="
   }, {
     "groupId" : "net.minidev",
     "artifactId" : "accessors-smart",

--- a/dependencies-lock.json
+++ b/dependencies-lock.json
@@ -1445,11 +1445,11 @@
   }, {
     "groupId" : "net.java.dev.jna",
     "artifactId" : "jna",
-    "version" : "5.19.0",
+    "version" : "5.18.1",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:39wcr9Gn/7RBOMYsO3PSpIyW71rpXFEnWplfp31kueAGhvrLltpWXdRFH95prpe+2UHhjr5YzN2bXpC6V2iKDQ=="
+    "integrity" : "sha512:6Fmqe/AyJdrN0EPGf5OeklDj4iPvAxoMtncXl0Ni6d8r0dnXBOe1LnQIIw8B2Ba6t+wadF2c8v6ybr2DmAJsfg=="
   }, {
     "groupId" : "net.minidev",
     "artifactId" : "accessors-smart",

--- a/dependencies-lock.json
+++ b/dependencies-lock.json
@@ -1445,11 +1445,11 @@
   }, {
     "groupId" : "net.java.dev.jna",
     "artifactId" : "jna",
-    "version" : "5.18.1",
+    "version" : "5.19.0",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:6Fmqe/AyJdrN0EPGf5OeklDj4iPvAxoMtncXl0Ni6d8r0dnXBOe1LnQIIw8B2Ba6t+wadF2c8v6ybr2DmAJsfg=="
+    "integrity" : "sha512:39wcr9Gn/7RBOMYsO3PSpIyW71rpXFEnWplfp31kueAGhvrLltpWXdRFH95prpe+2UHhjr5YzN2bXpC6V2iKDQ=="
   }, {
     "groupId" : "net.minidev",
     "artifactId" : "accessors-smart",

--- a/dependencies-lock.json
+++ b/dependencies-lock.json
@@ -41,6 +41,14 @@
     "integrity" : "sha512:P7sy4EBGDXhLcZPUsS3xCkperUfAmQV/AJpOV9VLTudj9qt42wVGzUSTSX1GqrCBtyTz+7iF4wmpCi6dXnTuhQ=="
   }, {
     "groupId" : "ca.uhn.hapi.fhir",
+    "artifactId" : "hapi-fhir-client",
+    "version" : "6.10.5",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:M5yV/2n3/xlm72Q9+h2Bdt214lkZr1ZxZVkhrm0H0NXnVb60yvzZ+tB3XCfNJTzok2fcdqAxPjvs8AbD0lUdxg=="
+  }, {
+    "groupId" : "ca.uhn.hapi.fhir",
     "artifactId" : "hapi-fhir-structures-dstu2",
     "version" : "6.10.5",
     "scope" : "compile",
@@ -57,12 +65,28 @@
     "integrity" : "sha512:TwbsA/lm8DAkBibmgATRxK3WBM/iGZsuO0SV7QI65QGXEDMWM8v4IvkjPfAybFU8NswYIYLI3DT57SGEWBBPKw=="
   }, {
     "groupId" : "ca.uhn.hapi.fhir",
+    "artifactId" : "hapi-fhir-structures-r4",
+    "version" : "6.10.5",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:4jMFxdKLeGD3L8HqkuA1ZYNce6l6ZQnGPY76/p66Il3UPgX/gv3Od3cD9QyOg5UYT4pXF7MuUFa8UNXJU3JbhA=="
+  }, {
+    "groupId" : "ca.uhn.hapi.fhir",
     "artifactId" : "org.hl7.fhir.dstu3",
     "version" : "6.4.0",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
     "integrity" : "sha512:jsXA+nxwtcREDusL853GitoYNywUJULdej+gWT0Wc7zo01zAPhblaiRS3UeBcFJ/5vWV0tD3LQhG7OTPnTIx+A=="
+  }, {
+    "groupId" : "ca.uhn.hapi.fhir",
+    "artifactId" : "org.hl7.fhir.r4",
+    "version" : "6.1.2.2",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:WfEKhiY8LyJLtM+3g62f/pHfKyk5x270MyXMroVkQZOd7nCEVdrQ+9YNta1kAA59St6p8nqp1Z8MGr0VaBvyXg=="
   }, {
     "groupId" : "ca.uhn.hapi.fhir",
     "artifactId" : "org.hl7.fhir.utilities",
@@ -74,67 +98,67 @@
   }, {
     "groupId" : "ca.uhn.hapi",
     "artifactId" : "hapi-base",
-    "version" : "1.0.1",
+    "version" : "2.3",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:52LSZKam5t5rMnXtXw8fN3i/ngUQp6vz1Wve+KNgYxHDh4nYcW9uX0lf8UeHvoZoWfGpeBGNXYeV+DP3Bj122A=="
+    "integrity" : "sha512:cV+QZUX1X/mqWSaT/AktQsvPINxz/qKSOzOBSmCwTQg2glvov64e/IT3oM8Q1ArvW54uzRIiJKK5fGRCRXFjgA=="
   }, {
     "groupId" : "ca.uhn.hapi",
     "artifactId" : "hapi-structures-v21",
-    "version" : "1.0.1",
+    "version" : "2.3",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:NCMpcJGrsvrshD64gZOzLnr029MEphePqjdIAO6PnNWjijsjnihjYw6CvstY/Vi7sAmQKTAjzH0KHIoI3SOtJA=="
+    "integrity" : "sha512:9HQfithExK8yz+vfBjHKYO+XQvj9+lb2naTowVxghVe7X8+lgGpRdd7piZKEbY4Z8ZcoXrBF5FzTr2yXU/Bk7g=="
   }, {
     "groupId" : "ca.uhn.hapi",
     "artifactId" : "hapi-structures-v22",
-    "version" : "1.0.1",
+    "version" : "2.3",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:Cu+P4/qVeaQgNzt2KPSQTgrSTTdGy1FrIC5XCJ9a2CEO8u6XPo7wesNs5IkIZ/1f5ElZlHonqkyJ0MRBypq0fQ=="
+    "integrity" : "sha512:WhyA2Q6/+ne1+s6TKF4AzuUerQGCPruj2llO7UBHyssP44HgUDA+8+BhLRdrDzzTp2ozh1B9XkCwwuCGcRwFqQ=="
   }, {
     "groupId" : "ca.uhn.hapi",
     "artifactId" : "hapi-structures-v231",
-    "version" : "1.0.1",
+    "version" : "2.3",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:dM/aJw0rVHllTkmT++OeDrl6ZyJWwqoWfBRgv0mmpk1pvD+iAdew8cOOxllbJKJ5lNYQBtt7L4AIdt6U3l/2RQ=="
+    "integrity" : "sha512:3zRsYqgkJ2KVXKSCu3sG3HfIO8Q7gbaUaKj2kVqOVHqCgQaPrvaMYLu3MIH/yn51mPq0GzJX0wXbcTwU6RlnmQ=="
   }, {
     "groupId" : "ca.uhn.hapi",
     "artifactId" : "hapi-structures-v23",
-    "version" : "1.0.1",
+    "version" : "2.3",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:ZB+6VTphE8XInCdGchvAuZaW+9r7et3pt9VUM4aIvd0HMrKUXbzS5Rbk6+8623Z/3TP3TncXz06bzF9gSQmrqg=="
+    "integrity" : "sha512:Gu4mD3FGY/Wl5Qwlc4u5TxaW+FkZGdF0A3KJG08jU8ihL2KuNDEakYTNrkcxUTsu4yiTlBl2Hrdbxlp9nDmIcg=="
   }, {
     "groupId" : "ca.uhn.hapi",
     "artifactId" : "hapi-structures-v24",
-    "version" : "1.0.1",
+    "version" : "2.3",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:MM19XuIm4Ud+yZPqJ7E/kJG1bUhOk6krph+k4wU3ha8POHO0IkaJGRKc1w+cLHxZxMTHXSSContBKpkZm/UdTg=="
+    "integrity" : "sha512:dGRV+pRbvdPhMyyh2dJ3OKYJ+FMuHjxWWK/N4P9TnBaCbuT1r8YRwVAaLJUbWZieMb+R+CSP4MCY/OPh39lxGQ=="
   }, {
     "groupId" : "ca.uhn.hapi",
     "artifactId" : "hapi-structures-v25",
-    "version" : "1.0.1",
+    "version" : "2.3",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:wh2/iX5dUp0gGonkaaR+RHIK1WLGi9qUw+yQXm0K07K+ruH85PhN3NMlZHh6IgUiYjOEyrVrkfsAEtzH+/pKXA=="
+    "integrity" : "sha512:LbVBYam6ks3jgMKffvGM9/0oHlchN6l1oizz4Jttm3OKO1ZrpBjE6fhR4bj6ovXMR5m9f3olJfUhN9fn8g20sw=="
   }, {
     "groupId" : "ca.uhn.hapi",
     "artifactId" : "hapi-structures-v26",
-    "version" : "1.0.1",
+    "version" : "2.3",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:kljShqyjhOiIw33z0nRrNniQSppzRkw8kC8SzYyjHDl1YGSpsmiSgYBc/JPOMMWw98H6j6e165uJlPa4DtHzdg=="
+    "integrity" : "sha512:ocFVzN1W8Ddy1MerUEiQXVUJ04Hklim6KG17ycRO4WoAsKN2XyWN1oO+/YoF6HwNCbzPXlGVERZfSXWAdZjsWg=="
   }, {
     "groupId" : "cds",
     "artifactId" : "cds",
@@ -192,6 +216,14 @@
     "optional" : false,
     "integrity" : "sha512:IvR7uftlGA6jAcsHjPWKqPGa8RCx7zt5DJkyItTs8cPa8j5LHIBOhyld4q0WDlvwjRxNm1Yw3DH9Kj5JDbUipQ=="
   }, {
+    "groupId" : "com.auth0",
+    "artifactId" : "java-jwt",
+    "version" : "4.5.1",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:Y9yMK4dFqpLskE3PLuLn/gVQudCdr4Q7OOJXuxnNEfreAs5VRIdex5Smx/bVs+2TPvfF47Zy9VYlndLP1xJv+Q=="
+  }, {
     "groupId" : "com.beust",
     "artifactId" : "jcommander",
     "version" : "1.82",
@@ -210,11 +242,11 @@
   }, {
     "groupId" : "com.fasterxml.jackson.core",
     "artifactId" : "jackson-core",
-    "version" : "2.21.1",
+    "version" : "2.21.0",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:9LFToKfJdGIN7D/P5KSGnCYyq5f3PCZiBBr30OsMQq1GK/7ozcq1VChCF1uWGX3x2RCohBBnZU9udjs3DBjM+g=="
+    "integrity" : "sha512:TwA1HlfOSAQoIWaRxSxZp1yoJGdNXCbvkCJQzD0BLyIELILqucpTDGMoAxtZcjkUPp47aMHHpsxtSc74y0IHdA=="
   }, {
     "groupId" : "com.fasterxml.jackson.core",
     "artifactId" : "jackson-databind",
@@ -897,14 +929,6 @@
     "optional" : false,
     "integrity" : "sha512:Q0hnBXlgG8EVHeLydBRjXE6gtLUwYdEWwJujGeLE+OkdDLBxOpZGaL1RiRBaweK2WQiBhQiAv1/yPMZAnycEIA=="
   }, {
-    "groupId" : "commons-cli",
-    "artifactId" : "commons-cli",
-    "version" : "1.0",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:zg39atifzCzWgZAGf+Lv/5F9gd1kELYIBXKV79vFJEtiPH4QAA2RPv9eDIy/FWtWoRN3MT2/rYwzO5v67q62PA=="
-  }, {
     "groupId" : "commons-codec",
     "artifactId" : "commons-codec",
     "version" : "1.18.0",
@@ -992,6 +1016,30 @@
     "type" : "jar",
     "optional" : false,
     "integrity" : "sha512:TSXsVUMPPIBP0lpkm4GwlaH3QqmLmWsjEM14Vn7zBZZDzE04U24FyezojodAnXbFcEctPBfGrM4bvSInnVlyDw=="
+  }, {
+    "groupId" : "io.jsonwebtoken",
+    "artifactId" : "jjwt-api",
+    "version" : "0.13.0",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:t25kO6tdoBFkhLtjbl8TnVPjxYCqB/qf+e+59VKxnxSgkCER68plCUZH9vLZukWAXjGF0Unw2dE7joTl9XXITg=="
+  }, {
+    "groupId" : "io.jsonwebtoken",
+    "artifactId" : "jjwt-impl",
+    "version" : "0.13.0",
+    "scope" : "runtime",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:cMTkPkH5OpqexH+3SxFbsqffffJeo0EyCHmYAq8rkcnmBgQqi2TPhWhJFN6snxK172X0N3cCZoqVYtvs3WXvTw=="
+  }, {
+    "groupId" : "io.jsonwebtoken",
+    "artifactId" : "jjwt-jackson",
+    "version" : "0.13.0",
+    "scope" : "runtime",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:58uHirhxjtwAz2+qETQsNxna1efhFG0gNXzW1Alu0l7+wfe6C9/IoNjrT9oK01zEfPFDgbKYZTrjWl2DJYhQsQ=="
   }, {
     "groupId" : "io.micrometer",
     "artifactId" : "micrometer-commons",
@@ -1405,11 +1453,11 @@
   }, {
     "groupId" : "joda-time",
     "artifactId" : "joda-time",
-    "version" : "2.10.6",
+    "version" : "2.1",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:Xd5dVNou6uIB8/XAVi8WOa5mSfezqD0nbih3LOLl2GsmvTUz/c7a+EHMd5gtaDWYwY+OxcW2y6TrR3SPC9QROA=="
+    "integrity" : "sha512:uvO0xAZ9+hK5zbG2ZuWrOqDj0xJKANA6PgDQfXwEZhgqLQl5sgQn0/PUlAOIMVp3c0h5MrBAsAYMRIssn6xp5w=="
   }, {
     "groupId" : "junit",
     "artifactId" : "junit",
@@ -1445,11 +1493,11 @@
   }, {
     "groupId" : "net.java.dev.jna",
     "artifactId" : "jna",
-    "version" : "5.18.1",
+    "version" : "5.19.1",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:6Fmqe/AyJdrN0EPGf5OeklDj4iPvAxoMtncXl0Ni6d8r0dnXBOe1LnQIIw8B2Ba6t+wadF2c8v6ybr2DmAJsfg=="
+    "integrity" : "sha512:DmqWCs/W+sd0htp7bRjrnZjgogW994GJVImX+29gk+cT5XDpgp7MbX3sgTJ26vXTr1bTDGJ/67OgsyT6kDXojw=="
   }, {
     "groupId" : "net.minidev",
     "artifactId" : "accessors-smart",

--- a/src/main/java/ca/openosp/openo/form/pdfservlet/FrmCustomedPDFServlet.java
+++ b/src/main/java/ca/openosp/openo/form/pdfservlet/FrmCustomedPDFServlet.java
@@ -648,6 +648,10 @@ public class FrmCustomedPDFServlet extends HttpServlet {
                 listElem += newline;
             }
         }
+        // flush the final prescription; without this the last line (e.g. Qty/Repeats) is dropped when it has no trailing boundary token
+        if (!listElem.isEmpty()) {
+            listRx.add(listElem);
+        }
 
         // A0-A10, LEGAL, LETTER, HALFLETTER, _11x17, LEDGER, NOTE, B0-B5, ARCH_A-ARCH_E, FLSA
         // and FLSE

--- a/src/main/java/ca/openosp/openo/prescript/pageUtil/RxChoosePatient2Action.java
+++ b/src/main/java/ca/openosp/openo/prescript/pageUtil/RxChoosePatient2Action.java
@@ -95,6 +95,8 @@ public final class RxChoosePatient2Action extends ActionSupport {
             bean = new RxSessionBean();
             bean.setProviderNo(user_no);
             bean.setDemographicNo(demographicNoInt);
+        } else {
+            bean.removePersistedStashItems();
         }
         RxSessionBean.saveToSession(request, bean);
 

--- a/src/main/java/ca/openosp/openo/prescript/pageUtil/RxSessionBean.java
+++ b/src/main/java/ca/openosp/openo/prescript/pageUtil/RxSessionBean.java
@@ -341,6 +341,35 @@ public class RxSessionBean implements java.io.Serializable {
         stash = new ArrayList();
     }
 
+    /**
+     * Drops stash items that have already been persisted in this session's
+     * save flow, leaving unsaved drafts in place. {@code drugId} is 0 until
+     * {@code rx.Save()} writes a Drug row and assigns the generated id, so
+     * {@code drugId > 0} reliably means "this stash item was persisted."
+     * <p>
+     * Note: {@code script_no} is not a safe signal here because
+     * {@link RxPrescriptionData#newPrescription(String, int, RxPrescriptionData.Prescription)}
+     * copies the original prescription's {@code script_no} into a freshly-staged
+     * re-prescription, which would cause unsaved ReRx drafts to be dropped.
+     * <p>
+     * Called from {@link RxChoosePatient2Action} on each Rx open so a reused
+     * per-patient bean shows a clean staging area after a completed save, while
+     * preserving in-progress drafts staged in another tab (PR #2261 invariant).
+     *
+     * @since 2026-05-27
+     */
+    public void removePersistedStashItems() {
+        RxPrescriptionData.Prescription selected =
+                (stashIndex >= 0 && stashIndex < stash.size()) ? stash.get(stashIndex) : null;
+        stash.removeIf(rx -> rx.getDrugId() > 0);
+        if (selected != null) {
+            int newIndex = stash.indexOf(selected);
+            stashIndex = (newIndex >= 0) ? newIndex : stash.size() - 1;
+        } else if (stashIndex >= stash.size()) {
+            stashIndex = stash.size() - 1;
+        }
+    }
+
     public HashMap<Integer, Long> getFavIdRandomIdMaps() {
         return favIdRandomIdMap;
     }

--- a/src/main/java/ca/openosp/openo/prescript/pageUtil/RxSessionFilter.java
+++ b/src/main/java/ca/openosp/openo/prescript/pageUtil/RxSessionFilter.java
@@ -30,6 +30,7 @@ public class RxSessionFilter implements Filter {
     private static final Logger logger = MiscUtils.getLogger();
     private static final String LEGACY_KEY = "RxSessionBean";
     private static final String PATIENT_KEY = "Patient";
+    private static final String STAGING_PAGE_PATH = "/oscarRx/SearchDrug3.jsp";
 
     /**
      * {@inheritDoc}
@@ -104,6 +105,17 @@ public class RxSessionFilter implements Filter {
                             session.setAttribute(PATIENT_KEY, patient);
                         }
                     }
+                }
+            }
+
+            // On a direct browser load/refresh of the staging page, drop drugs already
+            // persisted by a completed save (unsaved drafts, drugId == 0, are kept).
+            // Action entries (e.g. choosePatient.do) forward here and reconcile themselves;
+            // this REQUEST-scoped filter skips forwards, so there is no double-clear.
+            if (STAGING_PAGE_PATH.equals(request.getServletPath())) {
+                RxSessionBean currentBean = (RxSessionBean) session.getAttribute(LEGACY_KEY);
+                if (currentBean != null) {
+                    currentBean.removePersistedStashItems();
                 }
             }
         }

--- a/src/main/java/ca/openosp/openo/prescript/pageUtil/RxWriteScript2Action.java
+++ b/src/main/java/ca/openosp/openo/prescript/pageUtil/RxWriteScript2Action.java
@@ -75,6 +75,7 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.Enumeration;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -277,7 +278,14 @@ public final class RxWriteScript2Action extends ActionSupport {
         String action = request.getParameter("action");
         String drugId = request.getParameter("reRxDrugId");
         if (action.equals("addToReRxDrugIdList") && !reRxDrugIdList.contains(drugId)) {
-            reRxDrugIdList.add(drugId);
+            // Only store valid numeric drug ids so the archival loop in saveDrug()
+            // can never choke on a malformed entry from a crafted request (#2453).
+            try {
+                Integer.parseInt(drugId);
+                reRxDrugIdList.add(drugId);
+            } catch (NumberFormatException e) {
+                logger.warn("Ignored non-numeric reRxDrugId");
+            }
         } else if (action.equals("removeFromReRxDrugIdList") && reRxDrugIdList.contains(drugId)) {
             reRxDrugIdList.remove(drugId);
             try {
@@ -1272,7 +1280,15 @@ public final class RxWriteScript2Action extends ActionSupport {
             }
         }
         response.setContentType("application/json");
-		String savedScriptId = saveDrug(request);
+
+        // Nothing staged: do not persist an empty prescription. The UI already
+        // blocks this (see SearchDrug3.jsp), but guard server-side too so a
+        // crafted request can't create an empty script or archive a ReRx'd med
+        // without a replacement (#2453).
+        String savedScriptId = null;
+        if (bean.getStashSize() > 0) {
+            savedScriptId = saveDrug(request);
+        }
         Map<String, String> hm = new HashMap<>();
         hm.put("savedScriptId", savedScriptId);
         ObjectNode jo = objectMapper.valueToTree(hm);
@@ -1350,11 +1366,21 @@ public final class RxWriteScript2Action extends ActionSupport {
         StringBuilder auditStr = new StringBuilder();
         ArrayList<String> attrib_names = bean.getAttributeNames();
 
+        // Original drug ids that were actually re-prescribed in this save: each
+        // staged re-prescription carries the source drug's id in drugReferenceId
+        // (set by RxPrescriptionData.newPrescription(.., rePrescribe)). Only these
+        // originals should be archived below - a ReRx box ticked but never staged
+        // leaves no matching stash item and must not archive the active med (#2453).
+        Set<Integer> represcribedOriginalIds = new HashSet<>();
+
         for (int i = 0; i < bean.getStashSize(); i++) {
             try {
                 rx = bean.getStashItem(i);
                 rx.Save(scriptId);// new drug id available after this line
                 rx.setScript_no(scriptId);
+                if (rx.getDrugReferenceId() > 0) {
+                    represcribedOriginalIds.add(rx.getDrugReferenceId());
+                }
                 bean.addRandomIdDrugIdPair(rx.getRandomId(), rx.getDrugId());
                 auditStr.append(rx.getAuditString());
                 auditStr.append("\n");
@@ -1412,9 +1438,27 @@ public final class RxWriteScript2Action extends ActionSupport {
         while (i.hasNext()) {
 
             String item = i.next();
+            int originalDrugId;
+            try {
+                originalDrugId = Integer.parseInt(item);
+            } catch (NumberFormatException e) {
+                // Defensive: skip any malformed entry from a polluted session
+                // rather than failing the whole save (#2453).
+                logger.warn("Skipping non-numeric reRxDrugId");
+                continue;
+            }
+
+            // Skip ReRx entries that were checked but never staged/saved: with no
+            // matching staged drug, archiving would silently delete the active med (#2453).
+            if (!represcribedOriginalIds.contains(originalDrugId)) {
+                continue;
+            }
 
             //archive drug(s)
-            Drug drug = drugDao.find(Integer.parseInt(item));
+            Drug drug = drugDao.find(originalDrugId);
+            if (drug == null) {
+                continue;
+            }
             drug.setArchived(true);
             drug.setArchivedDate(new Date());
             drug.setArchivedReason(Drug.REPRESCRIBED);

--- a/src/main/java/ca/openosp/openo/prescript/pageUtil/RxWriteToEncounter2Action.java
+++ b/src/main/java/ca/openosp/openo/prescript/pageUtil/RxWriteToEncounter2Action.java
@@ -49,8 +49,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Locale;
 
-import org.owasp.encoder.Encode;
-
 import org.apache.struts2.ActionSupport;
 import org.apache.struts2.ServletActionContext;
 
@@ -83,7 +81,8 @@ public class RxWriteToEncounter2Action extends ActionSupport {
         CaseManagementTmpSave tmpSave = caseManagementMgr.getTmpSave(loggedInInfo.getLoggedInProviderNo(), demographicNo, programNo);
         Date today = new Date();
         if (tmpSave != null) {
-            String noteBody = generateNote(loggedInInfo, Encode.forJavaScript(request.getParameter("body")), false);
+            // Store the body raw, like the branches below; encoding it here leaked literal \n and \/ into the saved note (issue #2452).
+            String noteBody = generateNote(loggedInInfo, request.getParameter("body"), false);
 
             if (tmpSave.getNoteId() > 0) {
                 note = caseManagementMgr.getNote(String.valueOf(tmpSave.getNoteId()));

--- a/src/main/java/ca/openosp/openo/rx/RxPrintPreview2Action.java
+++ b/src/main/java/ca/openosp/openo/rx/RxPrintPreview2Action.java
@@ -371,6 +371,7 @@ public class RxPrintPreview2Action extends ActionSupport {
         request.setAttribute("sessionBean", sessionBean);
         request.setAttribute("reprint", reprint);
 
+        // Store the raw value; encoding is applied per-context at the JSP output points (issue #2451).
         request.setAttribute("providerName", ca.openosp.openo.providers.data.ProviderData.getProviderName(sessionBean.getProviderNo()));
         request.setAttribute("providerNo", sessionBean.getProviderNo());
 
@@ -528,10 +529,11 @@ public class RxPrintPreview2Action extends ActionSupport {
         if (pharmacyId != null && !"null".equalsIgnoreCase(pharmacyId)) {
             pharmacy = pharmacyData.getPharmacy(pharmacyId);
             if (pharmacy != null) {
-                prefPharmacy = pharmacy.getName().replace("'", "\\'");
-                prefPharmacyId = String.valueOf(pharmacy.getId());
-                prefPharmacy = prefPharmacy.trim();
-                prefPharmacyId = prefPharmacyId.trim();
+                // Store the raw name; encoding is applied per-context at the JSP output points (issue
+                // #2451). Guard against a null name so the attribute is never null.
+                String name = pharmacy.getName();
+                prefPharmacy = name != null ? name.trim() : "";
+                prefPharmacyId = String.valueOf(pharmacy.getId()).trim();
 
                 request.setAttribute("prefPharmacy", prefPharmacy);
                 request.setAttribute("prefPharmacyId", prefPharmacyId);
@@ -645,8 +647,14 @@ public class RxPrintPreview2Action extends ActionSupport {
         String timeStamp = new SimpleDateFormat("dd-MMM-yyyy hh:mm a").format(Calendar.getInstance().getTime());
         request.setAttribute("timeStamp", timeStamp);
 
-        request.setAttribute("pharmacyName", Encode.forJavaScript(pharmacy != null ? pharmacy.getName() : ""));
-        request.setAttribute("pharmacyFax", pharmacy != null ? pharmacy.getFax() : "");
+        // Store raw values; these attributes are consumed in two contexts -- the PrintPreview.jsp onClick
+        // (JavaScript string) and the PreviewContent.jsp hidden inputs (HTML attribute, submitted to the
+        // PDF servlet) -- so each output point applies its own context-appropriate encoding (issue #2451).
+        // Guard the null cases so the attributes are never null.
+        String pharmacyName = (pharmacy != null && pharmacy.getName() != null) ? pharmacy.getName() : "";
+        request.setAttribute("pharmacyName", pharmacyName);
+        String pharmacyFax = (pharmacy != null && pharmacy.getFax() != null) ? pharmacy.getFax() : "";
+        request.setAttribute("pharmacyFax", pharmacyFax);
     }
 
     /**

--- a/src/main/java/ca/openosp/openo/rx/RxPrintPreview2Action.java
+++ b/src/main/java/ca/openosp/openo/rx/RxPrintPreview2Action.java
@@ -338,7 +338,9 @@ public class RxPrintPreview2Action extends ActionSupport {
                     .replaceAll("\\\\n", "<br>");
         }
 
-        request.setAttribute("strRx", strRx.toString().replaceAll("\\\\n", "<br>"));
+        // Separate prescription lines with the platform line separator so the PDF servlet,
+        // which splits on System.getProperty("line.separator"), renders each on its own line.
+        request.setAttribute("strRx", strRx.toString().replace(";", System.lineSeparator()));
         request.setAttribute("strRxNoNewLines", strRxNoNewLines.toString());
         request.setAttribute("rxFullOutLines", rxFullOutLines);
     }

--- a/src/main/webapp/casemgmt/ChartNotesAjax.jsp
+++ b/src/main/webapp/casemgmt/ChartNotesAjax.jsp
@@ -1124,7 +1124,7 @@ EmailComposeManager emailComposeManager = SpringUtils.getBean(EmailComposeManage
             encounterText = "\n[" + apptDate + " .: " + reason + "]\n";
         }
 
-        encounterText = Encode.forJavaScript(encounterText);
+        // Return raw; the sole caller JS-encodes at the output point.
         return encounterText;
     }
 

--- a/src/main/webapp/demographic/demographiccontrol.jsp
+++ b/src/main/webapp/demographic/demographiccontrol.jsp
@@ -33,8 +33,6 @@
 <%@page import="ca.openosp.openo.web.DemographicSearchHelper" %>
 <%@page import="java.util.GregorianCalendar" %>
 <%@page import="ca.openosp.openo.caisi_integrator.ws.MatchingDemographicParameters" %>
-<%@ page import="java.io.UnsupportedEncodingException" %>
-<%@ page import="java.net.URLEncoder" %>
 
 
 <%@ page import="ca.openosp.OscarProperties" %>
@@ -68,19 +66,13 @@
         
         if (keyword == null) {
             keyword = ""; // Default to an empty string
-        } else {
-            // Encode the keyword to ensure any special characters (like '%') are properly encoded
-            try {
-                // If keyword contains a '%' sign, encode it as %25
-                keyword = java.net.URLEncoder.encode(keyword, "UTF-8");
-            } catch (UnsupportedEncodingException e) {
-                e.printStackTrace(); // Log the error or handle it
-                keyword = ""; // Default to empty string if error occurs
-            }
         }
-       
-        if (keyword.indexOf("*") != -1 || keyword.indexOf("%") != -1) 
-        {
+
+        // A '%' or '*' in the keyword signals a wildcard search. The keyword must be
+        // used verbatim here - it feeds the integrator match parameters and is bound as
+        // a SQL parameter downstream, so URL-encoding it would corrupt wildcards (and
+        // characters such as apostrophes in names).
+        if (keyword.indexOf("*") != -1 || keyword.indexOf("%") != -1) {
             regularexp = "like";
         }
 

--- a/src/main/webapp/demographic/zdemographicfulltitlesearch.jsp
+++ b/src/main/webapp/demographic/zdemographicfulltitlesearch.jsp
@@ -63,36 +63,61 @@
     }
     
     function formatDateInput(input) {
-        // Remove any non-digit characters
-        var value = input.value.replace(/\D/g, '');
-        
-        // Format as YYYY-MM-DD
-        if (value.length > 0) {
-            // Ensure we only take the first 8 digits
-            value = value.substring(0, Math.min(8, value.length));
-            
-            // Add hyphens
-            if (value.length > 4) {
-                value = value.substring(0, 4) + '-' + value.substring(4);
-            }
-            if (value.length > 7) {
-                value = value.substring(0, 7) + '-' + value.substring(7);
+        var old = input.value;
+        var atEnd = input.selectionStart === old.length;
+        // Keep only digits, the yyyy-mm-dd separators, and the % wildcard.
+        var out = old.replace(/[^0-9%-]/g, '');
+
+        // Auto-insert hyphens only when a plain date is typed at the end of the field.
+        // Wildcards (%) and mid-field edits are left as typed, so % survives and the
+        // caret is never yanked to the end.
+        if (atEnd && out.indexOf('%') === -1) {
+            var d = out.replace(/-/g, '').substring(0, 8);
+            if (d.length > 6) out = d.substring(0, 4) + '-' + d.substring(4, 6) + '-' + d.substring(6);
+            else if (d.length > 4) out = d.substring(0, 4) + '-' + d.substring(4);
+            else out = d;
+            // Preserve a hyphen the user just typed so 2024-07- can be built before a %.
+            var typedHyphen = old.charAt(input.selectionStart - 1) === '-';
+            if (typedHyphen && out.charAt(out.length - 1) !== '-' && (d.length === 4 || d.length === 6)) {
+                out += '-';
             }
         }
-        
-        input.value = value;
+
+        if (out === old) return;
+
+        // Restore the caret after the same number of non-hyphen characters (or at the end
+        // when appending) instead of letting it jump.
+        var keep = old.slice(0, input.selectionStart).replace(/-/g, '').length;
+        input.value = out;
+        if (atEnd) {
+            input.setSelectionRange(out.length, out.length);
+            return;
+        }
+        var pos = 0, seen = 0;
+        while (pos < out.length && seen < keep) {
+            if (out.charAt(pos) !== '-') seen++;
+            pos++;
+        }
+        input.setSelectionRange(pos, pos);
     }
-    
+
     function checkTypeIn() {
         var dob = document.titlesearch.keyword;
         if (document.titlesearch.search_mode.value == "search_dob") {
-            // Remove hyphens for validation
-            var dobValue = dob.value.replace(/-/g, '');
-            
-            // Check if we have enough digits
-            if (dobValue.length < 8) {
-                alert("Date format must be YYYY-MM-DD");
-                return false;
+            if (dob.value.indexOf('%') !== -1) {
+                // Wildcard search (e.g. everyone born in July 2024). The backend splits
+                // the value on '-' into year/month/day, so pad any missing trailing
+                // groups with '%': 2024-07% or 2024-% become 2024-07%-% / 2024-%-%.
+                var parts = dob.value.split('-');
+                while (parts.length < 3) parts.push('%');
+                dob.value = parts.slice(0, 3).join('-');
+            } else {
+                // A non-wildcard DOB search still needs a full yyyy-mm-dd date
+                var dobValue = dob.value.replace(/-/g, '');
+                if (dobValue.length < 8) {
+                    alert("Date format must be YYYY-MM-DD (use % as a wildcard, e.g. 2024-07-%)");
+                    return false;
+                }
             }
         }
         return true;

--- a/src/main/webapp/oscarPrevention/dhirSubmission.jsp
+++ b/src/main/webapp/oscarPrevention/dhirSubmission.jsp
@@ -40,7 +40,7 @@
 <%@page import="org.hl7.fhir.dstu3.model.Patient" %>
 <%@page import="org.hl7.fhir.dstu3.model.Bundle.BundleEntryComponent" %>
 <%@page import="ca.openosp.openo.utility.LoggedInInfo" %>
-<%@page import="ca.openosp.openo.integration.fhir.builder.AbstractFhirMessageBuilder" %>
+<%@page import="ca.openosp.openo.integration.fhir.dstu3.builder.AbstractFhirMessageBuilder" %>
 <%@page import="org.hl7.fhir.dstu3.model.Bundle" %>
 <%@page import="java.util.Map" %>
 <%@page import="java.io.InputStream" %>

--- a/src/main/webapp/oscarRx/ListDrugs.jsp
+++ b/src/main/webapp/oscarRx/ListDrugs.jsp
@@ -191,7 +191,7 @@
             data-is-current="<%= prescriptDrug.isCurrent() %>"
             data-is-external="<%= prescriptDrug.isExternal() %>">
 
-        <td><a id="createDate_<%=Encode.forHtmlAttribute(String.valueOf(prescriptIdInt))%>" <%=styleColor%> href="<%= request.getContextPath() %>/oscarRx/StaticScript2.jsp?regionalIdentifier=<%=Encode.forUriComponent(prescriptDrug.getRegionalIdentifier())%>&amp;cn=<%=Encode.forUriComponent(prescriptDrug.getCustomName())%>&amp;bn=<%=Encode.forUriComponent(bn)%>&amp;atc=<%=Encode.forUriComponent(prescriptDrug.getAtc())%>"><%=Encode.forHtml(String.valueOf(DateToString(prescriptDrug.getCreateDate())))%></a></td>
+        <td><a id="createDate_<%=Encode.forHtmlAttribute(String.valueOf(prescriptIdInt))%>" class="<%=Encode.forHtmlAttribute(String.valueOf(styleColor))%>" href="<%= request.getContextPath() %>/oscarRx/StaticScript2.jsp?regionalIdentifier=<%=Encode.forUriComponent(prescriptDrug.getRegionalIdentifier())%>&amp;cn=<%=Encode.forUriComponent(prescriptDrug.getCustomName())%>&amp;bn=<%=Encode.forUriComponent(bn)%>&amp;atc=<%=Encode.forUriComponent(prescriptDrug.getAtc())%>"><%=Encode.forHtml(String.valueOf(DateToString(prescriptDrug.getCreateDate())))%></a></td>
             <%-- data-order: DataTables sorts this column by the attribute value instead of the cell
                  content. When start date is unknown the cell renders empty, so we fall back to
                  createDate to maintain parity with the previous server-side sort, which used
@@ -204,7 +204,7 @@
                     String startDate = UtilDateUtilities.DateToString(prescriptDrug.getRxDate());
                     startDate = partialDateDao.getDatePartial(startDate, PartialDate.DRUGS, prescriptDrug.getId(), PartialDate.DRUGS_STARTDATE);
                 %>
-                <a id="rxDate_<%=Encode.forHtmlAttribute(String.valueOf(prescriptIdInt))%>"   <%=Encode.forHtml(String.valueOf(styleColor))%>
+                <a id="rxDate_<%=Encode.forHtmlAttribute(String.valueOf(prescriptIdInt))%>"   class="<%=Encode.forHtmlAttribute(String.valueOf(styleColor))%>"
                    href="<%= request.getContextPath() %>/oscarRx/StaticScript2.jsp?regionalIdentifier=<%=Encode.forUriComponent(prescriptDrug.getRegionalIdentifier())%>&amp;cn=<%=Encode.forUriComponent(prescriptDrug.getCustomName())%>&amp;bn=<%=Encode.forUriComponent(bn)%>"><%=Encode.forHtml(String.valueOf(startDate))%>
                 </a>
                 <% } %>
@@ -238,7 +238,7 @@
 			}
 			
 			%>
-            <td><a id="prescrip_<%=Encode.forHtmlAttribute(String.valueOf(prescriptIdInt))%>" <%=styleColor%> href="<%= request.getContextPath() %>/oscarRx/StaticScript2.jsp?regionalIdentifier=<%=Encode.forUriComponent(prescriptDrug.getRegionalIdentifier())%>&amp;cn=<%=Encode.forUriComponent(prescriptDrug.getCustomName())%>&amp;bn=<%=Encode.forUriComponent(bn)%>&amp;atc=<%=Encode.forUriComponent(prescriptDrug.getAtc())%>"   <%=tComment%>   ><%=Encode.forHtml(String.valueOf(RxPrescriptionData.getFullOutLine(prescriptDrug.getSpecial()).replaceAll(";", " ")))%></a></td>
+            <td><a id="prescrip_<%=Encode.forHtmlAttribute(String.valueOf(prescriptIdInt))%>" class="<%=Encode.forHtmlAttribute(String.valueOf(styleColor))%>" href="<%= request.getContextPath() %>/oscarRx/StaticScript2.jsp?regionalIdentifier=<%=Encode.forUriComponent(prescriptDrug.getRegionalIdentifier())%>&amp;cn=<%=Encode.forUriComponent(prescriptDrug.getCustomName())%>&amp;bn=<%=Encode.forUriComponent(bn)%>&amp;atc=<%=Encode.forUriComponent(prescriptDrug.getAtc())%>"   <%=tComment%>   ><%=Encode.forHtml(String.valueOf(RxPrescriptionData.getFullOutLine(prescriptDrug.getSpecial()).replaceAll(";", " ")))%></a></td>
 			<%            			
 	           	if(securityManager.hasWriteAccess("_rx",roleName$,true)) {            		
            	%>
@@ -266,7 +266,7 @@
             <td>
 
                 <%if (prescriptDrug.getRemoteFacilityName() == null) {%>
-                <a id="del_<%=Encode.forHtmlAttribute(String.valueOf(prescriptIdInt))%>" name="delete" <%=Encode.forHtml(String.valueOf(styleColor))%> href="javascript:void(0);"
+                <a id="del_<%=Encode.forHtmlAttribute(String.valueOf(prescriptIdInt))%>" name="delete" class="<%=Encode.forHtmlAttribute(String.valueOf(styleColor))%>" href="javascript:void(0);"
                    onclick="Delete2(this);">Del</a>
                 <%}%>
             </td>
@@ -283,7 +283,7 @@
 					if(securityManager.hasWriteAccess("_rx",roleName$,true)) {            		
 				
                 %>
-                	<a id="discont_<%=Encode.forHtmlAttribute(String.valueOf(prescriptIdInt))%>" href="javascript:void(0);" onclick="Discontinue(event,this);" <%=Encode.forHtml(String.valueOf(styleColor))%> >Discon</a>                
+                	<a id="discont_<%=Encode.forHtmlAttribute(String.valueOf(prescriptIdInt))%>" href="javascript:void(0);" onclick="Discontinue(event,this);" class="<%=Encode.forHtmlAttribute(String.valueOf(styleColor))%>" >Discon</a>                
                 <% }
                	 }
                 }else{%>
@@ -492,7 +492,12 @@
     }
 
     String getClassColour(Drug drug, long referenceTime, long durationToSoon) {
-        StringBuilder sb = new StringBuilder("class=\"");
+        // Returns only the space-separated CSS class tokens (e.g. "currentDrug expireInReference"),
+        // or "" when none apply. Callers wrap this in class="..." and OWASP-encode it as an
+        // attribute value (Encode.forHtmlAttribute). Do NOT re-add the class="..." wrapper here:
+        // emitting a full attribute fragment and then running it through Encode.forHtml() double-
+        // encodes the quotes (class=&#34;...&#34;) and breaks the drug row styling.
+        StringBuilder sb = new StringBuilder();
 
         if (!drug.isLongTerm() && (drug.isCurrent() && drug.getEndDate() != null && (drug.getEndDate().getTime() - referenceTime <= durationToSoon))) {
             sb.append("expireInReference ");
@@ -524,20 +529,12 @@
         }
 
         if (drug.getOutsideProviderName() != null && !drug.getOutsideProviderName().equals("")) {
-            sb = new StringBuilder("class=\"");
-            sb.append("external ");
+            sb = new StringBuilder("external ");
         }
         if (drug.getRemoteFacilityName() != null) {
-            sb = new StringBuilder("class=\"");
-            sb.append("external ");
+            sb = new StringBuilder("external ");
         }
-        String retval = sb.toString();
-
-        if (retval.equals("class=\"")) {
-            return "";
-        }
-
-        return retval.substring(0, retval.length()) + "\"";
+        return sb.toString().trim();
 
     }
     

--- a/src/main/webapp/oscarRx/SearchDrug3.jsp
+++ b/src/main/webapp/oscarRx/SearchDrug3.jsp
@@ -1067,6 +1067,9 @@
 
     .rightColumnAdjust {
       padding-left: 10px;
+      /* Table cells default to vertical-align: middle, so a long favourites column (left cell)
+         makes the row tall and drifts this content to the page middle (#2464). Pin it to top. */
+      vertical-align: top;
     }
   </style>
 

--- a/src/main/webapp/oscarRx/SearchDrug3.jsp
+++ b/src/main/webapp/oscarRx/SearchDrug3.jsp
@@ -3378,11 +3378,43 @@
         }
     
     
+        /**
+         * Counts the medications currently staged for this prescription.
+         *
+         * Each staged drug renders a drugName_<rand> input inside the drug form;
+         * a ReRx box that was only checked (not staged) produces no such input.
+         * This deliberately keys on the same drugName_ marker that the server
+         * uses to detect staged drugs in RxWriteScript2Action.updateSaveAllDrugs()
+         * ("ele.startsWith(\"drugName_\")"), so this gate matches exactly what the
+         * server would persist. Keep the two in sync if that marker ever changes.
+         *
+         * @returns {number} the number of staged medications
+         */
+        function countStagedMedications() {
+            const form = document.getElementById('drugForm');
+            if (!form) {
+                return 0;
+            }
+            return form.querySelectorAll('input[name^="drugName_"]').length;
+        }
+
         function updateSaveAllDrugsPrintCheckContinue() {
+            // Nothing staged: warn instead of saving an empty prescription (#2453).
+            // The ReRx selection is left intact so the user can still click
+            // Stage Medication; it is only archived once actually staged and saved
+            // (guarded in RxWriteScript2Action.saveDrug()).
+            if (countStagedMedications() === 0) {
+                alert('No medications have been added.');
+                return;
+            }
             updateSaveAllDrugsPrintContinue();
         }
-    
+
         function updateSaveAllDrugsCheckContinue() {
+            // Nothing staged: do nothing rather than save an empty prescription (#2453).
+            if (countStagedMedications() === 0) {
+                return;
+            }
             updateSaveAllDrugsContinue();
         }
     

--- a/src/main/webapp/oscarRx/SearchDrug3.jsp
+++ b/src/main/webapp/oscarRx/SearchDrug3.jsp
@@ -1023,12 +1023,17 @@
 
     #discontinueUI {
       position: absolute;
-      display: none;
       width: 500px;
       height: 200px;
       background-color: white;
       padding: 20px;
       border: 1px solid grey;
+    }
+
+    /* Bootstrap added to this page resets h1-h6 to font-weight:500,
+       which un-bolds the popup heading vs the pre-Bootstrap look. Restore bold here. */
+    #discontinueUI h3 {
+      font-weight: bold;
     }
 
     #drugProfile {
@@ -1491,7 +1496,8 @@
 
 
 <div id="dragifm"></div>
-<div id="discontinueUI">
+<%-- hidden attribute is toggled by JS (hidden = true/false) — do not move to CSS as display:none or the discontinue popup will not open (Prototype show() cannot override a stylesheet rule) --%>
+<div id="discontinueUI" hidden>
   <h3>Discontinue :<span id="disDrug"></span></h3>
   <input type="hidden" name="disDrugId" id="disDrugId"/>
   <fmt:setBundle basename="oscarResources"/><fmt:message key="oscarRx.discontinuedReason.msgReason"/>
@@ -1535,7 +1541,7 @@
   <br/>
   <fmt:setBundle basename="oscarResources"/><fmt:message key="oscarRx.discontinuedReason.msgComment"/><br/>
   <textarea id="disComment" rows="3" cols="45"></textarea><br/>
-  <input type="button" onclick="$('discontinueUI').hide();" value="Cancel"/>
+  <input type="button" onclick="document.getElementById('discontinueUI').hidden = true;" value="Cancel"/>
   <input type="button"
          onclick="Discontinue2($('disDrugId').value,$('disReason').value,$('disComment').value,$('disDrug').innerHTML);"
          value="Discontinue"/>
@@ -2112,7 +2118,7 @@
     let drugName = prescripElement ? prescripElement.textContent : '';
     $('discontinueUI').setStyle(styleStr);
     safeSetText('disDrug', drugName);
-    $('discontinueUI').show();
+    document.getElementById('discontinueUI').hidden = false;
     $('disDrugId').value = id;
   }
 
@@ -2125,7 +2131,7 @@
       onSuccess: function (transport) {
         try {
           let json = JSON.parse(transport.responseText);
-          $('discontinueUI').hide();
+          document.getElementById('discontinueUI').hidden = true;
           $('rxDate_' + json.id).style.textDecoration = 'line-through';
           $('reRx_' + json.id).style.textDecoration = 'line-through';
           $('del_' + json.id).style.textDecoration = 'line-through';
@@ -2137,7 +2143,7 @@
       },
       onFailure: function (transport) {
         console.error('Discontinue request failed with status: ' + (transport.status || 'unknown'));
-        $('discontinueUI').hide();
+        document.getElementById('discontinueUI').hidden = true;
       }
     });
   }

--- a/src/main/webapp/oscarRx/SelectPharmacy2.jsp
+++ b/src/main/webapp/oscarRx/SelectPharmacy2.jsp
@@ -201,8 +201,8 @@
                     var pharmacyNameKey = new RegExp($("#pharmacySearch").val(), "i");
                     var pharmacyCityKey = new RegExp($("#pharmacyCitySearch").val(), "i");
                     var pharmacyPostalCodeKey = new RegExp($("#pharmacyPostalCodeSearch").val(), "i");
-					var pharmacyFaxKey = new RegExp($("#pharmacyFaxSearch").val().replaceAll(" ", ""), "i");
-					var pharmacyPhoneKey = new RegExp($("#pharmacyPhoneSearch").val().replaceAll(" ", ""), "i");
+					var pharmacyFaxKey = new RegExp($("#pharmacyFaxSearch").val().replace(/\D/g, ""), "i");
+					var pharmacyPhoneKey = new RegExp($("#pharmacyPhoneSearch").val().replace(/\D/g, ""), "i");
                     var pharmacyAddressKey = new RegExp($("#pharmacyAddressSearch").val(), "i");
 
                     $("#pharmacySearch").keyup(function () {
@@ -212,7 +212,7 @@
                             if ($(value).html().toLowerCase().search(pharmacyNameKey) >= 0) {
                                 if ($(value).siblings(".city").html().search(pharmacyCityKey) >= 0) {
                                     if ($(value).siblings(".postalCode").html().search(pharmacyPostalCodeKey) >= 0) {
-                                        if ($(value).siblings(".fax").html().search(pharmacyFaxKey) >= 0) {
+                                        if ($(value).siblings(".fax").html().replace(/\D/g, "").search(pharmacyFaxKey) >= 0) {
                                             if ($(value).siblings(".fax").html().search(pharmacyAddressKey) >= 0) {
                                                 $(value).parent().show();
                                             }
@@ -230,7 +230,7 @@
                             if ($(value).html().toLowerCase().search(pharmacyCityKey) >= 0) {
                                 if ($(value).siblings(".pharmacyName").html().search(pharmacyNameKey) >= 0) {
                                     if ($(value).siblings(".postalCode").html().search(pharmacyPostalCodeKey) >= 0) {
-                                        if ($(value).siblings(".fax").html().search(pharmacyFaxKey) >= 0) {
+                                        if ($(value).siblings(".fax").html().replace(/\D/g, "").search(pharmacyFaxKey) >= 0) {
                                             if ($(value).siblings(".fax").html().search(pharmacyAddressKey) >= 0) {
                                                 $(value).parent().show();
                                             }
@@ -248,7 +248,7 @@
                             if ($(value).html().toLowerCase().search(pharmacyPostalCodeKey) >= 0) {
                                 if ($(value).siblings(".pharmacyName").html().search(pharmacyNameKey) >= 0) {
                                     if ($(value).siblings(".city").html().search(pharmacyCityKey) >= 0) {
-                                        if ($(value).siblings(".fax").html().search(pharmacyFaxKey) >= 0) {
+                                        if ($(value).siblings(".fax").html().replace(/\D/g, "").search(pharmacyFaxKey) >= 0) {
                                             $(value).parent().show();
                                         }
                                     }
@@ -261,7 +261,7 @@
                         updateSearchKeys();
                         $(".pharmacyItem").hide();
                         $.each($(".fax"), function (key, value) {
-							if ($(value).html().search(pharmacyFaxKey) >= 0 || $(value).html().replaceAll(" ", "").split(")").join("").split("-").join("").search(pharmacyFaxKey) >= 0) {
+							if ($(value).html().replace(/\D/g, "").search(pharmacyFaxKey) >= 0) {
                                 if ($(value).siblings(".pharmacyName").html().search(pharmacyNameKey) >= 0) {
                                     if ($(value).siblings(".city").html().search(pharmacyCityKey) >= 0) {
                                         if ($(value).siblings(".postalCode").html().search(pharmacyPostalCodeKey) >= 0) {
@@ -277,7 +277,7 @@
                         updateSearchKeys();
                         $(".pharmacyItem").hide();
                         $.each($(".phone"), function (key, value) {
-							if ($(value).html().search(pharmacyPhoneKey) >= 0 || $(value).html().replaceAll(" ", "").split(")").join("").split("-").join("").search(pharmacyPhoneKey) >= 0) {
+							if ($(value).html().replace(/\D/g, "").search(pharmacyPhoneKey) >= 0) {
                                 if ($(value).siblings(".pharmacyName").html().search(pharmacyNameKey) >= 0) {
                                     if ($(value).siblings(".city").html().search(pharmacyCityKey) >= 0) {
                                         if ($(value).siblings(".postalCode").html().search(pharmacyPostalCodeKey) >= 0) {
@@ -362,8 +362,8 @@
                         pharmacyNameKey = new RegExp($("#pharmacySearch").val(), "i");
                         pharmacyCityKey = new RegExp($("#pharmacyCitySearch").val(), "i");
                         pharmacyPostalCodeKey = new RegExp($("#pharmacyPostalCodeSearch").val(), "i");
-                        pharmacyFaxKey = new RegExp($("#pharmacyFaxSearch").val(), "i");
-                        pharmacyPhoneKey = new RegExp($("#pharmacyPhoneSearch").val(), "i");
+                        pharmacyFaxKey = new RegExp($("#pharmacyFaxSearch").val().replace(/\D/g, ""), "i");
+                        pharmacyPhoneKey = new RegExp($("#pharmacyPhoneSearch").val().replace(/\D/g, ""), "i");
                         pharmacyAddressKey = new RegExp($("#pharmacyAddressSearch").val(), "i");
                     }
                 })

--- a/src/main/webapp/oscarRx/printRx/PreviewContent.jsp
+++ b/src/main/webapp/oscarRx/printRx/PreviewContent.jsp
@@ -119,8 +119,8 @@
                                        value="<%= Encode.forHtml(((RxPatientData.Patient)request.getAttribute("patient")).getFirstName())+ " " +Encode.forHtml(((RxPatientData.Patient)request.getAttribute("patient")).getSurname()) %>"/>
                                 <input type="hidden" name="patientDOB"
                                        value="<%= Encode.forHtml((String)request.getAttribute("patientDOBStr")) %>"/>
-                                <input type="hidden" name="pharmaFax" value="${requestScope.pharmacyFax}"/>
-                                <input type="hidden" name="pharmaName" value="${requestScope.pharmacyName}"/>
+                                <input type="hidden" name="pharmaFax" value="<%= Encode.forHtmlAttribute(request.getAttribute("pharmacyFax") != null ? request.getAttribute("pharmacyFax").toString() : "") %>"/>
+                                <input type="hidden" name="pharmaName" value="<%= Encode.forHtmlAttribute(request.getAttribute("pharmacyName") != null ? request.getAttribute("pharmacyName").toString() : "") %>"/>
                                 <input type="hidden" name="pharmacyInfo" value="<%= Encode.forHtmlAttribute(request.getAttribute("prefPharmacyId") != null ? request.getAttribute("prefPharmacyId").toString() : "") %>"/>
                                 <input type="hidden" name="pracNo"
                                        value="<%= Encode.forHtml((String)request.getAttribute("pracNo")) %>"/>

--- a/src/main/webapp/oscarRx/printRx/PreviewContent.jsp
+++ b/src/main/webapp/oscarRx/printRx/PreviewContent.jsp
@@ -84,7 +84,7 @@
 <body>
     <div topmargin="0" leftmargin="0" vlink="#0000FF" id="printableContent">
 
-    <form action="/form/formname" styleId="preview2Form">
+    <form action="${pageContext.request.contextPath}/form/formname.do" method="post" id="preview2Form">
         <input type="hidden" name="demographic_no" value="${sessionScope.RxSessionBean.demographicNo}"/>
         <table>
             <tr>
@@ -121,6 +121,7 @@
                                        value="<%= Encode.forHtml((String)request.getAttribute("patientDOBStr")) %>"/>
                                 <input type="hidden" name="pharmaFax" value="${requestScope.pharmacyFax}"/>
                                 <input type="hidden" name="pharmaName" value="${requestScope.pharmacyName}"/>
+                                <input type="hidden" name="pharmacyInfo" value="<%= Encode.forHtmlAttribute(request.getAttribute("prefPharmacyId") != null ? request.getAttribute("prefPharmacyId").toString() : "") %>"/>
                                 <input type="hidden" name="pracNo"
                                        value="<%= Encode.forHtml((String)request.getAttribute("pracNo")) %>"/>
                                 <input type="hidden" name="showPatientDOB" value="${requestScope.showPatientDOB}"/>
@@ -135,7 +136,7 @@
                                        value="<%=Encode.forHtml((String)request.getAttribute("patientChartNo"))%>"/>
                                 <input type="hidden" name="bandNumber" value="${requestScope.bandNumber}"/>
                                 <input type="hidden" name="patientPhone"
-                                       value="<fmt:message key="RxPreview.msgTel"/><%=Encode.forHtml((String)request.getAttribute("patientPhone")) %>"/>
+                                       value="<fmt:message key="RxPreview.msgTel"/>: <%=Encode.forHtml((String)request.getAttribute("patientPhone")) %>"/>
                                 <input type="hidden" name="rxDate"
                                        value="<%= Encode.forHtml((String)request.getAttribute("rxDateFormatted")) %>"/>
                                 <input type="hidden" name="sigDoctorName"
@@ -219,7 +220,8 @@
                                        value="${requestScope.signatureRequestId}"/>
                                 <img id="signature" style="width:260px; height:130px; object-fit: contain;"
                                      src="${requestScope.startimageUrl}" alt="digital_signature"/>
-                                <input type="hidden" name="imgFile" id="imgFile" value=""/>
+                                <input type="hidden" name="imgFile" id="imgFile" value=""
+                                       data-temp-path="<%= Encode.forHtmlAttribute(request.getAttribute("tempPath") != null ? request.getAttribute("tempPath").toString() : "") %>"/>
 
                                 <script type="text/javascript">
                                     var POLL_TIME = 2500;

--- a/src/main/webapp/oscarRx/printRx/PrintPreview.js
+++ b/src/main/webapp/oscarRx/printRx/PrintPreview.js
@@ -210,7 +210,9 @@ function printDivContent(divId) {
 function writeToEncounter(ctx, print, text, prefPharmacy, providerNo, demographicNo, curDate, userName) {
     try {
         const url = ctx + "/oscarRx/WriteToEncounter.do";
-        fetch(url, {
+        // Return the chain so callers (e.g. Fax & Add) can sequence after the note write
+        // completes; the trailing .catch resolves it on failure too, so faxing still proceeds.
+        return fetch(url, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/x-www-form-urlencoded'
@@ -230,6 +232,7 @@ function writeToEncounter(ctx, print, text, prefPharmacy, providerNo, demographi
             });
     } catch (e) {
         alert("ERROR: could not paste to EMR" + e);
+        return Promise.resolve();
     }
 }
 
@@ -379,13 +382,13 @@ function sendFax(scriptId, signatureRequestId, useSC, scAddress, ctx) {
 
 function printPasteToParent(ctx, rxPasteAsterisk, prefPharmacy, demographicNo, providerName, providerNo, pharmacyName,
                             pharmacyFax, prescribedBy) {
-    printPaste2Parent(ctx, true, false, true, rxPasteAsterisk, prefPharmacy, demographicNo, providerName,
+    return printPaste2Parent(ctx, true, false, true, rxPasteAsterisk, prefPharmacy, demographicNo, providerName,
         providerNo, pharmacyName, pharmacyFax, prescribedBy)
 }
 
 function faxPasteToParent(ctx, rxPasteAsterisk, prefPharmacy, demographicNo, providerName, providerNo, pharmacyName,
                             pharmacyFax, prescribedBy) {
-    printPaste2Parent(ctx, false, true, true, rxPasteAsterisk, prefPharmacy, demographicNo, providerName,
+    return printPaste2Parent(ctx, false, true, true, rxPasteAsterisk, prefPharmacy, demographicNo, providerName,
         providerNo, pharmacyName, pharmacyFax, prescribedBy)
 }
 
@@ -460,19 +463,24 @@ function printPaste2Parent(ctx, print, fax, pasteRx, rxPasteAsterisk, prefPharma
                     printIframe();
                 }
             } else if (pasteRx) {
-                writeToEncounter(ctx, print, text, prefPharmacy, providerNo, demographicNo,
+                // Standalone path: return the async write so the caller can wait for it.
+                return writeToEncounter(ctx, print, text, prefPharmacy, providerNo, demographicNo,
                     new Date().toISOString().substring(0, 10), providerName);
             }
         } else {
-            writeToEncounter(ctx, print, text, prefPharmacy, providerNo, demographicNo,
+            // Standalone path: return the async write so the caller can wait for it.
+            return writeToEncounter(ctx, print, text, prefPharmacy, providerNo, demographicNo,
                 new Date().toISOString().substring(0, 10), providerName);
         }
 
+        // Opener paths above mutate the note synchronously; resolve immediately.
+        return Promise.resolve();
     } catch (e) {
         alert("ERROR: could not paste to EMR" + e);
         if (print) {
             printIframe();
         }
+        return Promise.resolve();
     }
 
 }

--- a/src/main/webapp/oscarRx/printRx/PrintPreview.js
+++ b/src/main/webapp/oscarRx/printRx/PrintPreview.js
@@ -422,6 +422,10 @@ function printPaste2Parent(ctx, print, fax, pasteRx, rxPasteAsterisk, prefPharma
             if (rxNoNewLines && rxNoNewLines.value.length > 0) {
                 text += rxNoNewLines.value + "\n";
             }
+            const additionalNotes = document.getElementById("additionalNotes");
+            if (additionalNotes && additionalNotes.value.trim().length > 0) {
+                text += "\n" + additionalNotes.value.trim() + "\n";
+            }
         }
         if (rxPasteAsterisk) {
             if (prefPharmacy != null && prefPharmacy.trim() !== "") {

--- a/src/main/webapp/oscarRx/printRx/PrintPreview.js
+++ b/src/main/webapp/oscarRx/printRx/PrintPreview.js
@@ -106,7 +106,7 @@ function addNotes(scriptId) {
     document.getElementsByName('additNotes')[0].value = document.getElementById('additionalNotes').value.replace(/\n/g, "\r\n");
 }
 
-function printIframe(providerNo, demographicNo, userName) {
+function printIframe(providerNo, demographicNo, userName, ctx) {
     const browserName = navigator.appName;
     if (browserName === "Microsoft Internet Explorer") {
         alert("Use of Microsoft Internet Explorer is not permitted")
@@ -120,7 +120,7 @@ function printIframe(providerNo, demographicNo, userName) {
         self.onfocus = function () {
             self.setTimeout(function () {
                 if (demographicNo) {
-                    openEncounter(providerNo, demographicNo, providerNo, userName);
+                    openEncounter(providerNo, demographicNo, providerNo, userName, ctx);
                 }
                 self.parent.close();
             }, 1000);
@@ -204,13 +204,13 @@ function writeToEncounter(ctx, print, text, prefPharmacy, providerNo, demographi
         })
             .then(() => {
                 if (print) {
-                    printIframe(providerNo, demographicNo, userName);
+                    printIframe(providerNo, demographicNo, userName, ctx);
                 }
             })
             .catch((e) => {
                 alert("ERROR: could not paste to EMR" + e);
                 if (print) {
-                    printIframe(providerNo, demographicNo, userName);
+                    printIframe(providerNo, demographicNo, userName, ctx);
                 }
             });
     } catch (e) {
@@ -218,10 +218,14 @@ function writeToEncounter(ctx, print, text, prefPharmacy, providerNo, demographi
     }
 }
 
-function openEncounter(providerNo, demographicNo, curProviderNo, userName) {
+function openEncounter(providerNo, demographicNo, curProviderNo, userName, ctx) {
+    if (!ctx) {
+        const contextPath = window.location.pathname.split('/')[1];
+        ctx = window.location.origin + '/' + contextPath;
+    }
     const windowProps = "height=710,width=1024,location=no,scrollbars=yes,menubars=no,toolbars=no,resizable=yes,screenX=50,screenY=50,top=20,left=20";
     const currentDate = new Date().toISOString().substring(0, 10);
-    const url = "../oscarEncounter/IncomingEncounter.do?providerNo=" + providerNo + "&demographicNo=" + demographicNo + "&curProviderNo=" + curProviderNo + "&userName=" + userName + "&curDate=" + currentDate;
+    const url = ctx + "/oscarEncounter/IncomingEncounter.do?providerNo=" + providerNo + "&demographicNo=" + demographicNo + "&curProviderNo=" + curProviderNo + "&userName=" + userName + "&curDate=" + currentDate;
 
     if (window.parent.opener && window.parent.opener.document.forms["caseManagementEntryForm"] !== undefined) {
         // redirect if encounter window open

--- a/src/main/webapp/oscarRx/printRx/PrintPreview.js
+++ b/src/main/webapp/oscarRx/printRx/PrintPreview.js
@@ -399,8 +399,7 @@ function printPaste2Parent(ctx, print, fax, pasteRx, rxPasteAsterisk, prefPharma
             year: 'numeric',
             hour: '2-digit',
             minute: '2-digit',
-            hour12: true,
-            timeZone: 'UTC'
+            hour12: true
         });
         if (rxPasteAsterisk) {
             text += "**********************************************************************************\n";

--- a/src/main/webapp/oscarRx/printRx/PrintPreview.js
+++ b/src/main/webapp/oscarRx/printRx/PrintPreview.js
@@ -52,11 +52,26 @@ function updateCurrentInteractions(myDrugRefEnabled) {
     }
 }
 
-function resetReRxDrugList(ctx) {
+/**
+ * Resolves the application context path used to build absolute request URLs.
+ * When a context path is supplied (typically threaded from the JSP via
+ * ${pageContext.request.contextPath}) it is returned unchanged; otherwise it is
+ * derived from the current location so callers that cannot inject it still produce
+ * absolute, deployment-correct URLs.
+ *
+ * @param {string} ctx the context path to use, if already known
+ * @returns {string} an absolute context path (origin + first path segment when derived)
+ */
+function resolveContextPath(ctx) {
     if (!ctx) {
         const contextPath = window.location.pathname.split('/')[1];
         ctx = window.location.origin + '/' + contextPath;
     }
+    return ctx;
+}
+
+function resetReRxDrugList(ctx) {
+    ctx = resolveContextPath(ctx);
     const url = ctx + "/oscarRx/deleteRx.do?parameterValue=clearReRxDrugList";
     const data = "";
     fetch(url, {
@@ -219,10 +234,7 @@ function writeToEncounter(ctx, print, text, prefPharmacy, providerNo, demographi
 }
 
 function openEncounter(providerNo, demographicNo, curProviderNo, userName, ctx) {
-    if (!ctx) {
-        const contextPath = window.location.pathname.split('/')[1];
-        ctx = window.location.origin + '/' + contextPath;
-    }
+    ctx = resolveContextPath(ctx);
     const windowProps = "height=710,width=1024,location=no,scrollbars=yes,menubars=no,toolbars=no,resizable=yes,screenX=50,screenY=50,top=20,left=20";
     const currentDate = new Date().toISOString().substring(0, 10);
     const url = ctx + "/oscarEncounter/IncomingEncounter.do?providerNo=" + providerNo + "&demographicNo=" + demographicNo + "&curProviderNo=" + curProviderNo + "&userName=" + userName + "&curDate=" + currentDate;
@@ -259,7 +271,14 @@ function refreshImage(imgURL, signatureImg) {
     if (document.getElementById("signature") != null) {
         document.getElementById("signature").src = imgURL;
     }
-    document.getElementById('imgFile').value = signatureImg;
+    // The PDF servlet loads the signature via Image.getInstance(imgFile), which expects a
+    // local file path (or absolute URL) - not the context-relative preview servlet URL.
+    // Submit the signature's temp file path (rendered server-side as data-temp-path),
+    // mirroring the working ViewScript2.jsp flow; fall back to the preview URL if absent.
+    const imgFileElement = document.getElementById('imgFile');
+    if (imgFileElement) {
+        imgFileElement.value = imgFileElement.dataset.tempPath || signatureImg;
+    }
 }
 
 function unloadMess() {
@@ -326,11 +345,18 @@ function closeRxPreviewBootstrapModal() {
     }
 }
 
-function onPrint2(method, scriptId, useSC, scAddress) {
+function onPrint2(method, scriptId, useSC, scAddress, ctx) {
+    ctx = resolveContextPath(ctx);
     const rxPageSize = $('printPageSize').value;
     console.log("rxPagesize  " + rxPageSize);
 
-    let action = "../form/createcustomedpdf?__title=Rx&__method=" + method + "&useSC=" + useSC + "&scAddress=" + scAddress + "&rxPageSize=" + rxPageSize + "&scriptId=" + scriptId;
+    let action = ctx
+        + "/form/createcustomedpdf?__title=Rx"
+        + "&__method=" + encodeURIComponent(method)
+        + "&useSC=" + encodeURIComponent(useSC)
+        + "&scAddress=" + encodeURIComponent(scAddress)
+        + "&rxPageSize=" + encodeURIComponent(rxPageSize)
+        + "&scriptId=" + encodeURIComponent(scriptId);
     document.getElementById("preview2Form").action = action;
     if (method !== "oscarRxFax") {
         document.getElementById("preview2Form").target = "_blank";
@@ -340,7 +366,7 @@ function onPrint2(method, scriptId, useSC, scAddress) {
     return true;
 }
 
-function sendFax(scriptId, signatureRequestId, useSC, scAddress) {
+function sendFax(scriptId, signatureRequestId, useSC, scAddress, ctx) {
     if ('function' === typeof window.onbeforeunload) {
         window.onbeforeunload = null;
     }
@@ -348,7 +374,7 @@ function sendFax(scriptId, signatureRequestId, useSC, scAddress) {
     document.getElementById('finalFax').value = faxNumber.options[faxNumber.selectedIndex].value;
     document.getElementById('pdfId').value = signatureRequestId;
 
-    onPrint2('oscarRxFax', scriptId, useSC, scAddress);
+    onPrint2('oscarRxFax', scriptId, useSC, scAddress, ctx);
 }
 
 function printPasteToParent(ctx, rxPasteAsterisk, prefPharmacy, demographicNo, providerName, providerNo, pharmacyName,

--- a/src/main/webapp/oscarRx/printRx/PrintPreview.jsp
+++ b/src/main/webapp/oscarRx/printRx/PrintPreview.jsp
@@ -207,13 +207,14 @@
                                                     '${requestScope.providerNo}',
                                                     '${e:forJavaScript(requestScope.pharmacyName)}',
                                                     '${e:forJavaScript(requestScope.pharmacyFax)}',
-                                                    '${requestScope.prescribedBy}');
+                                                    '${requestScope.prescribedBy}').then(function() {
                                                         sendFax('${e:forJavaScript(param.scriptId)}',
                                                     '${requestScope.signatureRequestId}',
                                                     ${requestScope.useSC != null ? requestScope.useSC : false},
                                                     '${e:forJavaScript(requestScope.selectedAddress != null ? requestScope.selectedAddress : '')}',
                                                     '${ctx}'
-                                                        );"
+                                                        );
+                                                        });"
                                                 <c:if test="${requestScope.isFaxDisabled}">
                                                     disabled="disabled"
                                                 </c:if>>

--- a/src/main/webapp/oscarRx/printRx/PrintPreview.jsp
+++ b/src/main/webapp/oscarRx/printRx/PrintPreview.jsp
@@ -158,12 +158,12 @@
                                         <c:if test="${requestScope.reprint eq 'true'}">disabled</c:if>
                                         onClick="printPasteToParent('${ctx}',
                                                 ${requestScope.rxPasteAsterisk},
-                                                '${requestScope.prefPharmacy}',
+                                                '${e:forJavaScript(requestScope.prefPharmacy)}',
                                                 '${requestScope.demographicNo}',
-                                                '${requestScope.providerName}',
+                                                '${e:forJavaScript(requestScope.providerName)}',
                                                 '${requestScope.providerNo}',
-                                                '${requestScope.pharmacyName}',
-                                                '${requestScope.pharmacyFax}',
+                                                '${e:forJavaScript(requestScope.pharmacyName)}',
+                                                '${e:forJavaScript(requestScope.pharmacyFax)}',
                                                 '${requestScope.prescribedBy}');">
                                     Print &amp; Add to encounter note
                                 </button>
@@ -201,12 +201,12 @@
                                                 id="faxPasteButton"
                                                 onClick="faxPasteToParent('${ctx}',
                                                     ${requestScope.rxPasteAsterisk},
-                                                    '${requestScope.prefPharmacy}',
+                                                    '${e:forJavaScript(requestScope.prefPharmacy)}',
                                                     '${requestScope.demographicNo}',
-                                                    '${requestScope.providerName}',
+                                                    '${e:forJavaScript(requestScope.providerName)}',
                                                     '${requestScope.providerNo}',
-                                                    '${requestScope.pharmacyName}',
-                                                    '${requestScope.pharmacyFax}',
+                                                    '${e:forJavaScript(requestScope.pharmacyName)}',
+                                                    '${e:forJavaScript(requestScope.pharmacyFax)}',
                                                     '${requestScope.prescribedBy}');
                                                         sendFax('${e:forJavaScript(param.scriptId)}',
                                                     '${requestScope.signatureRequestId}',

--- a/src/main/webapp/oscarRx/printRx/PrintPreview.jsp
+++ b/src/main/webapp/oscarRx/printRx/PrintPreview.jsp
@@ -184,10 +184,11 @@
                                         <button type="button"
                                                 class="btn btn-secondary mb-2 w-100"
                                                 id="faxButton"
-                                                onClick="sendFax(${e:forJavaScript(param.scriptId)},
-                                                    ${requestScope.signatureRequestId},
+                                                onClick="sendFax('${e:forJavaScript(param.scriptId)}',
+                                                    '${requestScope.signatureRequestId}',
                                                     ${requestScope.useSC != null ? requestScope.useSC : false},
-                                                    ${requestScope.selectedAddress != null ? requestScope.selectedAddress : ''}
+                                                    '${e:forJavaScript(requestScope.selectedAddress != null ? requestScope.selectedAddress : '')}',
+                                                    '${ctx}'
                                                         );"
                                                 <c:if test="${requestScope.isFaxDisabled}">
                                                     disabled="disabled"
@@ -207,10 +208,11 @@
                                                     '${requestScope.pharmacyName}',
                                                     '${requestScope.pharmacyFax}',
                                                     '${requestScope.prescribedBy}');
-                                                        sendFax(${e:forHtml(param.scriptId)},
-                                                    ${requestScope.signatureRequestId},
+                                                        sendFax('${e:forJavaScript(param.scriptId)}',
+                                                    '${requestScope.signatureRequestId}',
                                                     ${requestScope.useSC != null ? requestScope.useSC : false},
-                                                    ${requestScope.selectedAddress != null ? requestScope.selectedAddress : ''}
+                                                    '${e:forJavaScript(requestScope.selectedAddress != null ? requestScope.selectedAddress : '')}',
+                                                    '${ctx}'
                                                         );"
                                                 <c:if test="${requestScope.isFaxDisabled}">
                                                     disabled="disabled"
@@ -233,9 +235,9 @@
                                 <div class="form-group">
                                     <label for="additionalNotes"></label>
                                     <textarea id="additionalNotes" class="form-control mb-2"
-                                              onchange="addNotes(${e:forJavaScript(param.scriptId)});"></textarea>
+                                              onchange="addNotes('${e:forJavaScript(param.scriptId)}');"></textarea>
                                     <button type="button" class="btn btn-primary"
-                                            onclick="addNotes(${e:forJavaScript(param.scriptId)});">
+                                            onclick="addNotes('${e:forJavaScript(param.scriptId)}');">
                                         Additional Rx Notes
                                     </button>
                                 </div>


### PR DESCRIPTION
## Summary by Sourcery

Harden prescription workflows and preview integrations while correcting search, formatting, encoding, and UI behavior across demographic and pharmacy features.

New Features:
- Support wildcard DOB searches while preserving date-input editing behavior.
- Add deployment-safe prescription preview and encounter/fax URL handling across context paths.

Bug Fixes:
- Prevent prescription PDFs from dropping the final prescription line.
- Prevent empty prescription saves and unintended archival of medications selected for re-prescribing but not staged.
- Clean persisted prescription drafts while preserving unsaved staging items.
- Fix prescription note formatting, signature file submission, pharmacy and phone/fax search behavior, and discontinue-dialog visibility.
- Correct demographic wildcard handling and prescription list CSS class rendering.
- Ensure additional prescription notes are included when printing or faxing.

Enhancements:
- Apply output-context encoding at presentation boundaries and improve null handling for prescription preview data.
- Improve prescription preview form submission and asynchronous note-writing flow.

Build:
- Update dependency lock files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes Rx save, preview/print/fax, and search flows to prevent data loss and 404s. Previously, empty Rx saves were possible and could archive meds checked for ReRx but not staged; PDFs could drop the last line; encoding leaked into notes and broke names with quotes. Now empty saves are blocked, only actually re‑prescribed originals are archived, the PDF renders all lines, and output encoding is applied at presentation points.

- Session and save flow: drop only persisted stash items on Rx open and staging page refresh; keep unsaved drafts. Guard server- and client-side against empty prescription saves. Accept only numeric `reRxDrugId` and archive only originals actually re‑prescribed.
- Print/preview/fax: fix context-path handling to stop 404s; sequence “Fax & Add” so the note write completes before faxing; include Additional Rx Notes in the encounter note; remove forced UTC in timestamps; ensure prescription lines render one per line in PDFs; submit the signature’s temp path to the PDF servlet.
- Encoding and search: move to per-context encoding (raw values in request, encode in JSP outputs) to prevent literal “\n” and quote-related errors; preserve wildcard `%` in demographic DOB searches and soften auto-formatting; normalize pharmacy phone/fax searches by stripping non-digits.
- UI fixes: restore Discontinue dialog visibility and heading weight; correct drug-list CSS class rendering and anchor class usage; pin right column content to top so long favourites don’t push the list down.
- Build/integration: refresh dependency locks (adds `ca.uhn.hapi.fhir:hapi-fhir-client` and `:hapi-fhir-structures-r4`, `com.auth0:java-jwt`, `io.jsonwebtoken:jjwt-*`, bumps `net.java.dev.jna`), and fix moved FHIR builder import path.

<sup>Written for commit 6503a114788ce8e56dc9be72cca5cee2098f3015. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openo-beta/Open-O/pull/2496?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

