### PR TITLE
WIP: Growth Chart Attachments on Consults

### DIFF
--- a/database/mysql/oscarinit.sql
+++ b/database/mysql/oscarinit.sql
@@ -8122,6 +8122,7 @@ CREATE TABLE IF NOT EXISTS `consultdocs` (
   `requestId` int(10) NOT NULL,
   `document_no` int(10) NOT NULL,
   `doctype` char(1) NOT NULL,
+  `form_table` varchar(50) DEFAULT NULL,
   `deleted` char(1) DEFAULT NULL,
   `attach_date` date,
   `provider_no` varchar(6) NOT NULL

--- a/database/mysql/updates/update-2026-08-21-consult-form-identity.sql
+++ b/database/mysql/updates/update-2026-08-21-consult-form-identity.sql
@@ -1,0 +1,7 @@
+ALTER TABLE consultdocs
+    ADD COLUMN form_table varchar(50) DEFAULT NULL;
+
+UPDATE consultdocs
+SET form_table = 'formAnnual'
+WHERE doctype = 'F'
+  AND form_table IS NULL;

--- a/src/main/java/ca/openosp/openo/commn/model/ConsultDocs.java
+++ b/src/main/java/ca/openosp/openo/commn/model/ConsultDocs.java
@@ -60,6 +60,9 @@ public class ConsultDocs extends AbstractModel<Integer> {
     @Column(name = "doctype")
     private String docType;
 
+    @Column(name = "form_table")
+    private String formTable;
+
     private String deleted;
 
     @Column(name = "attach_date")
@@ -110,6 +113,14 @@ public class ConsultDocs extends AbstractModel<Integer> {
 
     public void setDocType(String docType) {
         this.docType = docType;
+    }
+
+    public String getFormTable() {
+        return formTable;
+    }
+
+    public void setFormTable(String formTable) {
+        this.formTable = formTable;
     }
 
     public String getDeleted() {

--- a/src/main/java/ca/openosp/openo/documentManager/DocumentAttach.java
+++ b/src/main/java/ca/openosp/openo/documentManager/DocumentAttach.java
@@ -49,6 +49,37 @@ public class DocumentAttach {
         attachToConsult(currentList, oldList, documentType, providerNo, requestId);
     }
 
+    /**
+     * Synchronizes encounter-form links for a consultation using table-qualified form IDs.
+     *
+     * @param attachments validated encounter-form attachment keys
+     * @param providerNo attaching provider
+     * @param requestId consultation request identifier
+     */
+    public void attachFormsToConsult(List<EncounterFormAttachmentKey> attachments, String providerNo, Integer requestId) {
+        List<ConsultDocs> existing = consultDocsDao.findByRequestIdDocType(requestId, ConsultDocs.DOCTYPE_FORM);
+        List<EncounterFormAttachmentKey> oldKeys = new ArrayList<>();
+        for (ConsultDocs consultDoc : existing) {
+            String table = consultDoc.getFormTable() == null ? "formAnnual" : consultDoc.getFormTable();
+            EncounterFormAttachmentKey oldKey = EncounterFormAttachmentKey.of(table, consultDoc.getDocumentNo());
+            oldKeys.add(oldKey);
+            if (!attachments.contains(oldKey)) {
+                consultDoc.setDeleted("Y");
+                consultDocsDao.merge(consultDoc);
+            }
+        }
+
+        for (EncounterFormAttachmentKey key : attachments) {
+            if (oldKeys.contains(key)) {
+                continue;
+            }
+            ConsultDocs consultDoc = new ConsultDocs(
+                    requestId, key.getFormId(), ConsultDocs.DOCTYPE_FORM, providerNo);
+            consultDoc.setFormTable(key.getFormTable());
+            consultDocsDao.persist(consultDoc);
+        }
+    }
+
     private void attachToConsult(List<String> currentList, List<String> oldList, DocumentType documentType, String providerNo, Integer requestId) {
         for (String docId : currentList) {
             if (oldList.contains(docId)) {

--- a/src/main/java/ca/openosp/openo/documentManager/DocumentAttachmentManagerImpl.java
+++ b/src/main/java/ca/openosp/openo/documentManager/DocumentAttachmentManagerImpl.java
@@ -15,6 +15,7 @@ import ca.openosp.openo.documentManager.data.AttachmentLabResultData;
 import ca.openosp.openo.utility.DateUtils;
 import ca.openosp.openo.utility.LoggedInInfo;
 import ca.openosp.openo.utility.PDFGenerationException;
+import ca.openosp.openo.utility.WebUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -316,7 +317,12 @@ public class DocumentAttachmentManagerImpl implements DocumentAttachmentManager 
         }
 
         DocumentAttach documentAttach = new DocumentAttach();
-        documentAttach.attachToConsult(attachments, documentType, providerNo, requestId);
+        if (DocumentType.FORM == documentType) {
+            documentAttach.attachFormsToConsult(validateFormAttachmentKeys(
+                    loggedInInfo, attachments, demographicNo), providerNo, requestId);
+        } else {
+            documentAttach.attachToConsult(attachments, documentType, providerNo, requestId);
+        }
     }
 
     /**
@@ -344,7 +350,32 @@ public class DocumentAttachmentManagerImpl implements DocumentAttachmentManager 
         }
 
         DocumentAttach documentAttach = new DocumentAttach(demographicNo, editOnOcean);
-        documentAttach.attachToConsult(attachments, documentType, providerNo, requestId);
+        if (DocumentType.FORM == documentType) {
+            documentAttach.attachFormsToConsult(validateFormAttachmentKeys(
+                    loggedInInfo, attachments, demographicNo), providerNo, requestId);
+        } else {
+            documentAttach.attachToConsult(attachments, documentType, providerNo, requestId);
+        }
+    }
+
+    private List<EncounterFormAttachmentKey> validateFormAttachmentKeys(
+            LoggedInInfo loggedInInfo, String[] attachments, Integer demographicNo) {
+        List<EncounterFormAttachmentKey> keys = new ArrayList<>();
+        if (attachments == null) {
+            return keys;
+        }
+        for (String attachment : attachments) {
+            EncounterFormAttachmentKey key = EncounterFormAttachmentKey.parse(attachment);
+            EctFormData.PatientForm form = formsManager.getConsultForm(
+                    loggedInInfo, key.getFormTable(), key.getFormId(), demographicNo);
+            if (form == null) {
+                throw new SecurityException("Encounter form does not belong to the patient or is not attachable");
+            }
+            if (!keys.contains(key)) {
+                keys.add(key);
+            }
+        }
+        return keys;
     }
 
     /**
@@ -595,8 +626,18 @@ public class DocumentAttachmentManagerImpl implements DocumentAttachmentManager 
                 path = HRMUtil.renderHRM(loggedInInfo, documentId);
                 break;
             case FORM:
-                EctFormData.PatientForm patientForm = null;
-                path = formsManager.renderForm(request, response, patientForm);
+                String formTable = request.getParameter("formTable");
+                if (formTable == null) {
+                    path = formsManager.renderForm(request, response, (EctFormData.PatientForm) null);
+                    break;
+                }
+                String formId = WebUtils.positiveIntParamOrNull(request.getParameter("formId"));
+                String demographicNo = WebUtils.positiveIntParamOrNull(request.getParameter("demographicNo"));
+                if (formId == null || demographicNo == null) {
+                    throw new PDFGenerationException("A valid form and patient identifier are required");
+                }
+                path = formsManager.renderConsultForm(request, response,
+                        formTable, Integer.valueOf(formId), Integer.valueOf(demographicNo));
                 break;
         }
         return path;
@@ -632,7 +673,7 @@ public class DocumentAttachmentManagerImpl implements DocumentAttachmentManager 
 
     private void attachFormPDFs(HttpServletRequest request, HttpServletResponse response, List<EctFormData.PatientForm> attachedForms, ArrayList<Object> pdfDocumentList) throws PDFGenerationException {
         for (EctFormData.PatientForm form : attachedForms) {
-            Path path = formsManager.renderForm(request, response, form);
+            Path path = formsManager.renderConsultForm(request, response, form);
             pdfDocumentList.add(path.toString());
         }
     }

--- a/src/main/java/ca/openosp/openo/documentManager/EncounterFormAttachmentKey.java
+++ b/src/main/java/ca/openosp/openo/documentManager/EncounterFormAttachmentKey.java
@@ -1,0 +1,102 @@
+package ca.openosp.openo.documentManager;
+
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+/**
+ * Stable identity for an encounter-form attachment.
+ *
+ * <p>Encounter-form row identifiers are unique only within their form table. This value
+ * carries both parts through HTML form submission without ever using the submitted table
+ * name directly in a query.</p>
+ */
+public final class EncounterFormAttachmentKey {
+    private static final String DELIMITER = "|";
+    private static final Pattern SAFE_TABLE = Pattern.compile("[A-Za-z][A-Za-z0-9_]{0,49}");
+
+    private final String formTable;
+    private final int formId;
+
+    private EncounterFormAttachmentKey(String formTable, int formId) {
+        this.formTable = formTable;
+        this.formId = formId;
+    }
+
+    /**
+     * Creates a key from trusted server-side form metadata.
+     *
+     * @param formTable encounter-form database table
+     * @param formId encounter-form row identifier
+     * @return validated attachment key
+     */
+    public static EncounterFormAttachmentKey of(String formTable, int formId) {
+        validate(formTable, formId);
+        return new EncounterFormAttachmentKey(formTable, formId);
+    }
+
+    /**
+     * Parses an untrusted submitted key.
+     *
+     * @param value encoded value in {@code formTable|formId} format
+     * @return validated attachment key
+     * @throws IllegalArgumentException when the value is malformed
+     */
+    public static EncounterFormAttachmentKey parse(String value) {
+        if (value == null) {
+            throw new IllegalArgumentException("Encounter form attachment key is required");
+        }
+        int delimiter = value.indexOf(DELIMITER);
+        if (delimiter <= 0 || delimiter != value.lastIndexOf(DELIMITER)) {
+            throw new IllegalArgumentException("Invalid encounter form attachment key");
+        }
+
+        String table = value.substring(0, delimiter);
+        int id;
+        try {
+            id = Integer.parseInt(value.substring(delimiter + 1));
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Invalid encounter form identifier", e);
+        }
+        validate(table, id);
+        return new EncounterFormAttachmentKey(table, id);
+    }
+
+    private static void validate(String formTable, int formId) {
+        if (formTable == null || !SAFE_TABLE.matcher(formTable).matches()) {
+            throw new IllegalArgumentException("Invalid encounter form table");
+        }
+        if (formId <= 0) {
+            throw new IllegalArgumentException("Encounter form identifier must be positive");
+        }
+    }
+
+    public String getFormTable() {
+        return formTable;
+    }
+
+    public int getFormId() {
+        return formId;
+    }
+
+    public String encode() {
+        return formTable + DELIMITER + formId;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (!(other instanceof EncounterFormAttachmentKey)) {
+            return false;
+        }
+        EncounterFormAttachmentKey that = (EncounterFormAttachmentKey) other;
+        return formId == that.formId && formTable.equals(that.formTable);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(formTable, formId);
+    }
+}
+

--- a/src/main/java/ca/openosp/openo/documentManager/actions/DocumentPreview2Action.java
+++ b/src/main/java/ca/openosp/openo/documentManager/actions/DocumentPreview2Action.java
@@ -384,6 +384,9 @@ public class DocumentPreview2Action extends ActionSupport {
         String requestId = WebUtils.positiveIntParamOrNull(request.getParameter("requestId"));
 
         populateCommonDocs(loggedInInfo, demographicNo, documentAttachmentManager.getAttachedDocsForConsult(loggedInInfo, demographicNo, requestId));
+        request.setAttribute("allForms", formsManager.getConsultAttachableForms(
+                loggedInInfo, Integer.parseInt(demographicNo), false));
+        request.setAttribute("useQualifiedFormIds", true);
 		List<EFormData> allEForms = EFormUtil.listPatientEformsCurrent(Integer.valueOf(demographicNo), true);
         request.setAttribute("allEForms", allEForms);
 

--- a/src/main/java/ca/openosp/openo/form/pdfservlet/FormTemplatePdfRenderer.java
+++ b/src/main/java/ca/openosp/openo/form/pdfservlet/FormTemplatePdfRenderer.java
@@ -1,0 +1,130 @@
+package ca.openosp.openo.form.pdfservlet;
+
+import ca.openosp.openo.managers.NioFileManager;
+import ca.openosp.openo.util.ConcatPDF;
+import ca.openosp.openo.utility.PDFGenerationException;
+import com.itextpdf.text.DocumentException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import javax.servlet.ServletContext;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Callable adapter around the legacy template-and-plot PDF engine.
+ */
+@Service
+public class FormTemplatePdfRenderer {
+    @Autowired
+    private NioFileManager nioFileManager;
+
+    /**
+     * Renders one or more template pages into one temporary PDF.
+     *
+     * @param baseRequest authenticated request supplying the user's session
+     * @param requests server-defined render requests
+     * @return path to the generated temporary PDF
+     * @throws PDFGenerationException when rendering fails
+     */
+    public Path render(HttpServletRequest baseRequest, List<TemplatePdfRequest> requests)
+            throws PDFGenerationException {
+        if (requests == null || requests.isEmpty()) {
+            throw new PDFGenerationException("No form PDF pages were requested");
+        }
+
+        ArrayList<Object> renderedPages = new ArrayList<>();
+        try {
+            for (TemplatePdfRequest request : requests) {
+                renderedPages.add(new ByteArrayInputStream(renderPage(baseRequest, request)));
+            }
+            try (ByteArrayOutputStream combined = new ByteArrayOutputStream()) {
+                ConcatPDF.concat(renderedPages, combined);
+                return nioFileManager.saveTempFile("growth_chart_" + System.currentTimeMillis(), combined);
+            }
+        } catch (IOException | DocumentException e) {
+            throw new PDFGenerationException("The encounter form could not be rendered as a PDF", e);
+        }
+    }
+
+    private byte[] renderPage(HttpServletRequest baseRequest, TemplatePdfRequest request)
+            throws IOException, DocumentException {
+        Map<String, String[]> parameters = new LinkedHashMap<>();
+        parameters.put("form_class", new String[]{request.getFormClass()});
+        parameters.put("demographic_no", new String[]{String.valueOf(request.getDemographicNo())});
+        parameters.put("formId", new String[]{String.valueOf(request.getFormId())});
+        parameters.put("__title", new String[]{request.getTitle()});
+        parameters.put("__template", new String[]{request.getTemplate()});
+        parameters.put("__cfgfile", request.getPrintConfigs().toArray(new String[0]));
+        parameters.put("__cfgGraphicFile", request.getGraphicConfigs().toArray(new String[0]));
+        for (Map.Entry<String, String> override : request.getValueOverrides().entrySet()) {
+            parameters.put(override.getKey(), new String[]{override.getValue()});
+        }
+
+        HttpServletRequest isolatedRequest = new IsolatedParameterRequest(baseRequest, parameters);
+        try (ByteArrayOutputStream output = new ByteArrayOutputStream()) {
+            new AttachmentPdfEngine().render(isolatedRequest, baseRequest.getServletContext(), output);
+            return output.toByteArray();
+        }
+    }
+
+    private static final class AttachmentPdfEngine extends FrmPDFServlet {
+        private void render(HttpServletRequest request, ServletContext context, ByteArrayOutputStream output)
+                throws IOException, DocumentException {
+            generatePDFDocumentBytes(request, context, output, 0);
+        }
+    }
+
+    /**
+     * Prevents unrelated consultation parameters and attributes from entering form rendering.
+     */
+    private static final class IsolatedParameterRequest extends HttpServletRequestWrapper {
+        private final Map<String, String[]> parameters;
+
+        private IsolatedParameterRequest(HttpServletRequest request, Map<String, String[]> parameters) {
+            super(request);
+            this.parameters = parameters;
+        }
+
+        @Override
+        public String getParameter(String name) {
+            String[] values = parameters.get(name);
+            return values == null || values.length == 0 ? null : values[0];
+        }
+
+        @Override
+        public String[] getParameterValues(String name) {
+            return parameters.get(name);
+        }
+
+        @Override
+        public Map<String, String[]> getParameterMap() {
+            return Collections.unmodifiableMap(parameters);
+        }
+
+        @Override
+        public Enumeration<String> getParameterNames() {
+            return Collections.enumeration(parameters.keySet());
+        }
+
+        @Override
+        public Object getAttribute(String name) {
+            return null;
+        }
+
+        @Override
+        public Enumeration<String> getAttributeNames() {
+            return Collections.emptyEnumeration();
+        }
+    }
+}

--- a/src/main/java/ca/openosp/openo/form/pdfservlet/FrmPDFServlet.java
+++ b/src/main/java/ca/openosp/openo/form/pdfservlet/FrmPDFServlet.java
@@ -232,7 +232,7 @@ public class FrmPDFServlet extends HttpServlet {
                         cfgFile[idx2] = "";
                     }
 
-                    printCfg[idx2] = getCfgProp(cfgFile[idx2]);
+                    printCfg[idx2] = getCfgProp(cfgFile[idx2], ctx);
                 }
             }
 
@@ -256,7 +256,7 @@ public class FrmPDFServlet extends HttpServlet {
                     graphicCfg[idx] = new Properties[cfgGraphicFileNo];
                     for (int idx2 = 0; idx2 < cfgGraphicFileNo; ++idx2) {
                         cfgGraphicFile[idx2] += ".txt";
-                        graphicCfg[idx][idx2] = getCfgProp(cfgGraphicFile[idx2]);
+                        graphicCfg[idx][idx2] = getCfgProp(cfgGraphicFile[idx2], ctx);
                     }
                 }
             }
@@ -793,7 +793,7 @@ public class FrmPDFServlet extends HttpServlet {
         return baosPDF;
     }
 
-    protected Properties getCfgProp(String cfgFilename) {
+    protected Properties getCfgProp(String cfgFilename, ServletContext servletContext) {
         Properties ret = new Properties();
         
         // Input validation - reject null or empty
@@ -832,7 +832,7 @@ public class FrmPDFServlet extends HttpServlet {
         }
         
         // Try loading from classpath as fallback
-        Properties cpProps = loadFromClasspath(cleanFilename);
+        Properties cpProps = loadFromClasspath(cleanFilename, servletContext);
         if (cpProps != null) {
             return cpProps;
         }
@@ -863,7 +863,7 @@ public class FrmPDFServlet extends HttpServlet {
         }
     }
     
-    private Properties loadFromClasspath(String safeFilename) {
+    private Properties loadFromClasspath(String safeFilename, ServletContext servletContext) {
         try {
             // Build the resource path using only the safe filename
             String resourceBase = "/WEB-INF/classes/oscar/form/prop/";
@@ -878,7 +878,7 @@ public class FrmPDFServlet extends HttpServlet {
             }
             
             // Load from classpath
-            InputStream is = getServletContext().getResourceAsStream(fullResourcePath);
+            InputStream is = servletContext.getResourceAsStream(fullResourcePath);
             if (is != null) {
                 try (InputStream autoCloseIs = is) {
                     Properties props = new Properties();

--- a/src/main/java/ca/openosp/openo/form/pdfservlet/GrowthChartConsultPdfRenderer.java
+++ b/src/main/java/ca/openosp/openo/form/pdfservlet/GrowthChartConsultPdfRenderer.java
@@ -1,0 +1,101 @@
+package ca.openosp.openo.form.pdfservlet;
+
+import ca.openosp.openo.encounter.data.EctFormData;
+import ca.openosp.openo.form.FrmGrowth0_36Record;
+import ca.openosp.openo.form.FrmGrowthChartRecord;
+import ca.openosp.openo.utility.LoggedInInfo;
+import ca.openosp.openo.utility.PDFGenerationException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import javax.servlet.http.HttpServletRequest;
+import java.nio.file.Path;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * Renders saved standalone growth-chart encounter forms for consultation attachments.
+ */
+@Service
+public class GrowthChartConsultPdfRenderer {
+    @Autowired
+    private FormTemplatePdfRenderer templateRenderer;
+
+    /**
+     * Renders both clinically relevant sheets for a saved growth-chart form.
+     */
+    public Path render(HttpServletRequest request, EctFormData.PatientForm form)
+            throws PDFGenerationException {
+        LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
+        int demographicNo = Integer.parseInt(form.getDemoNo());
+        int formId = Integer.parseInt(form.getFormId());
+        try {
+            if ("formGrowthChart".equals(form.getTable())) {
+                Properties values = new FrmGrowthChartRecord().getFormRecord(
+                        loggedInInfo, demographicNo, formId);
+                return templateRenderer.render(request, growthChartRequests(
+                        demographicNo, formId, values));
+            }
+            if ("formGrowth0_36".equals(form.getTable())) {
+                Properties values = new FrmGrowth0_36Record().getFormRecord(
+                        loggedInInfo, demographicNo, formId);
+                return templateRenderer.render(request, infantGrowthRequests(
+                        demographicNo, formId, values));
+            }
+        } catch (SQLException e) {
+            throw new PDFGenerationException("The saved growth chart could not be loaded", e);
+        }
+        throw new PDFGenerationException("Unsupported growth chart form");
+    }
+
+    private List<TemplatePdfRequest> growthChartRequests(
+            int demographicNo, int formId, Properties values) {
+        boolean girl = "F".equals(values.getProperty("patientSex", ""));
+        String sex = girl ? "Girl" : "Boy";
+        Map<String, String> window = GrowthChartWindowMapper.mostRecentWindow(
+                values, List.of("date", "age", "stature", "weight", "comment", "bmi"), 42, 7);
+
+        List<TemplatePdfRequest> requests = new ArrayList<>();
+        requests.add(new TemplatePdfRequest(
+                "GrowthChart", demographicNo, formId, "Growth Charts",
+                "growthChart" + sex + "StatureWeight",
+                List.of("growthChart" + sex + "Print"),
+                List.of("growthChart" + sex + "Graphic", "growthChart" + sex + "Graphic2"),
+                window));
+        requests.add(new TemplatePdfRequest(
+                "GrowthChart", demographicNo, formId, "Growth Charts",
+                "growthChart" + sex + "BMI",
+                List.of("growthChart" + sex + "BMIPrint"),
+                List.of("growthChart" + sex + "GraphicBMI"),
+                window));
+        return requests;
+    }
+
+    private List<TemplatePdfRequest> infantGrowthRequests(
+            int demographicNo, int formId, Properties values) {
+        boolean girl = "F".equals(values.getProperty("patientSex", ""));
+        String sex = girl ? "Girl" : "Boy";
+        Map<String, String> lengthWindow = GrowthChartWindowMapper.mostRecentWindow(
+                values, List.of("date", "age", "length", "weight", "comment", "headCirc"), 20, 10);
+        Map<String, String> headWindow = GrowthChartWindowMapper.mostRecentWindow(
+                values, List.of("date", "age", "length", "weight", "comment", "headCirc"), 20, 5);
+
+        List<TemplatePdfRequest> requests = new ArrayList<>();
+        requests.add(new TemplatePdfRequest(
+                "Growth0_36", demographicNo, formId, "Growth Charts",
+                "growth" + sex + "Length0_36",
+                List.of("growth" + sex + "Length0_36Print"),
+                List.of("growth" + sex + "Length0_36Graphic", "growth" + sex + "Length0_36Graphic2"),
+                lengthWindow));
+        requests.add(new TemplatePdfRequest(
+                "Growth0_36", demographicNo, formId, "Growth Charts",
+                "growth" + sex + "Head0_36",
+                List.of("growth" + sex + "Head0_36Print"),
+                List.of("growth" + sex + "Head0_36Graphic", "growth" + sex + "Head0_36Graphic2"),
+                headWindow));
+        return requests;
+    }
+}

--- a/src/main/java/ca/openosp/openo/form/pdfservlet/GrowthChartWindowMapper.java
+++ b/src/main/java/ca/openosp/openo/form/pdfservlet/GrowthChartWindowMapper.java
@@ -1,0 +1,51 @@
+package ca.openosp.openo.form.pdfservlet;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * Maps the most recent populated measurement window into a template's visible table slots.
+ */
+public final class GrowthChartWindowMapper {
+    private GrowthChartWindowMapper() {
+    }
+
+    /**
+     * Produces the same pair-preserving swaps as the legacy growth-chart print JSPs.
+     */
+    public static Map<String, String> mostRecentWindow(
+            Properties values, List<String> fieldPrefixes, int maximumIndex, int windowSize) {
+        int highestPopulated = 0;
+        for (int index = 1; index <= maximumIndex; index++) {
+            for (String prefix : fieldPrefixes) {
+                if (!values.getProperty(prefix + "_" + index, "").trim().isEmpty()) {
+                    highestPopulated = index;
+                    break;
+                }
+            }
+        }
+        if (highestPopulated <= windowSize) {
+            return Map.of();
+        }
+
+        int windowStart = ((highestPopulated - 1) / windowSize) * windowSize + 1;
+        if (windowStart + windowSize - 1 > maximumIndex) {
+            windowStart = maximumIndex - windowSize + 1;
+        }
+
+        Map<String, String> overrides = new LinkedHashMap<>();
+        for (String prefix : fieldPrefixes) {
+            for (int offset = 0; offset < windowSize; offset++) {
+                int visibleIndex = offset + 1;
+                int sourceIndex = windowStart + offset;
+                String visibleKey = prefix + "_" + visibleIndex;
+                String sourceKey = prefix + "_" + sourceIndex;
+                overrides.put(visibleKey, values.getProperty(sourceKey, ""));
+                overrides.put(sourceKey, values.getProperty(visibleKey, ""));
+            }
+        }
+        return overrides;
+    }
+}

--- a/src/main/java/ca/openosp/openo/form/pdfservlet/TemplatePdfRequest.java
+++ b/src/main/java/ca/openosp/openo/form/pdfservlet/TemplatePdfRequest.java
@@ -1,0 +1,92 @@
+package ca.openosp.openo.form.pdfservlet;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+/**
+ * Typed, server-controlled request for the legacy form template PDF engine.
+ */
+public final class TemplatePdfRequest {
+    private static final Pattern SAFE_RESOURCE = Pattern.compile("[A-Za-z0-9_-]+");
+    private static final Pattern SAFE_FORM_CLASS = Pattern.compile("[A-Za-z0-9_]+");
+
+    private final String formClass;
+    private final int demographicNo;
+    private final int formId;
+    private final String title;
+    private final String template;
+    private final List<String> printConfigs;
+    private final List<String> graphicConfigs;
+    private final Map<String, String> valueOverrides;
+
+    /**
+     * Creates a validated template-render request.
+     */
+    public TemplatePdfRequest(String formClass, int demographicNo, int formId, String title,
+                              String template, List<String> printConfigs,
+                              List<String> graphicConfigs, Map<String, String> valueOverrides) {
+        if (formClass == null || !SAFE_FORM_CLASS.matcher(formClass).matches()) {
+            throw new IllegalArgumentException("Invalid form class");
+        }
+        if (demographicNo <= 0 || formId <= 0) {
+            throw new IllegalArgumentException("Form and demographic identifiers must be positive");
+        }
+        validateResource(template);
+        for (String config : printConfigs) {
+            validateResource(config);
+        }
+        for (String config : graphicConfigs) {
+            validateResource(config);
+        }
+        this.formClass = formClass;
+        this.demographicNo = demographicNo;
+        this.formId = formId;
+        this.title = title == null ? "" : title;
+        this.template = template;
+        this.printConfigs = Collections.unmodifiableList(new ArrayList<>(printConfigs));
+        this.graphicConfigs = Collections.unmodifiableList(new ArrayList<>(graphicConfigs));
+        this.valueOverrides = Collections.unmodifiableMap(new LinkedHashMap<>(valueOverrides));
+    }
+
+    private static void validateResource(String resource) {
+        if (resource == null || !SAFE_RESOURCE.matcher(resource).matches()) {
+            throw new IllegalArgumentException("Invalid PDF resource name");
+        }
+    }
+
+    public String getFormClass() {
+        return formClass;
+    }
+
+    public int getDemographicNo() {
+        return demographicNo;
+    }
+
+    public int getFormId() {
+        return formId;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getTemplate() {
+        return template;
+    }
+
+    public List<String> getPrintConfigs() {
+        return printConfigs;
+    }
+
+    public List<String> getGraphicConfigs() {
+        return graphicConfigs;
+    }
+
+    public Map<String, String> getValueOverrides() {
+        return valueOverrides;
+    }
+}

--- a/src/main/java/ca/openosp/openo/managers/ConsultationManagerImpl.java
+++ b/src/main/java/ca/openosp/openo/managers/ConsultationManagerImpl.java
@@ -671,14 +671,15 @@ public class ConsultationManagerImpl implements ConsultationManager {
          * Sure wish we didn't have to do this.  It's the only option without having to refactor a
          * whole string of dated code.
          */
-        List<EctFormData.PatientForm> allForms = formsManager.getEncounterFormsbyDemographicNumber(loggedInInfo, demographicNo, true, true);
         for (ConsultDocs attached : attachedForms) {
-            for (EctFormData.PatientForm form : allForms) {
-                if ((form.getFormId()).equals((attached.getDocumentNo() + ""))) {
-                    filteredForms.add(form);
-                    break;
-                }
+            String formTable = attached.getFormTable() == null ? "formAnnual" : attached.getFormTable();
+            EctFormData.PatientForm form = formsManager.getConsultForm(
+                    loggedInInfo, formTable, attached.getDocumentNo(), demographicNo);
+            if (form == null) {
+                throw new IllegalStateException("Attached encounter form could not be resolved: "
+                        + formTable + "|" + attached.getDocumentNo());
             }
+            filteredForms.add(form);
         }
 
         return filteredForms;

--- a/src/main/java/ca/openosp/openo/managers/FormsManager.java
+++ b/src/main/java/ca/openosp/openo/managers/FormsManager.java
@@ -42,6 +42,10 @@ public interface FormsManager {
 
     public List<PatientForm> getEncounterFormsbyDemographicNumber(LoggedInInfo loggedInInfo, Integer demographicId, boolean getAllVersions, boolean getOnlyPDFReadyForms);
 
+    public List<PatientForm> getConsultAttachableForms(LoggedInInfo loggedInInfo, Integer demographicId, boolean getAllVersions);
+
+    public PatientForm getConsultForm(LoggedInInfo loggedInInfo, String formTable, Integer formId, Integer demographicNo);
+
     public Integer saveFormDataAsEDoc(LoggedInInfo loggedInInfo, FormTransportContainer formTransportContainer);
 
     public Path renderForm(HttpServletRequest request, HttpServletResponse response, Integer formId, Integer demographicNo) throws PDFGenerationException;
@@ -50,6 +54,11 @@ public interface FormsManager {
 
     public Path renderForm(HttpServletRequest request, HttpServletResponse response, EctFormData.PatientForm form) throws PDFGenerationException;
 
+    public Path renderConsultForm(HttpServletRequest request, HttpServletResponse response,
+                                  EctFormData.PatientForm form) throws PDFGenerationException;
+
+    public Path renderConsultForm(HttpServletRequest request, HttpServletResponse response,
+                                  String formTable, Integer formId, Integer demographicNo) throws PDFGenerationException;
+
     public PatientForm getFormById(LoggedInInfo loggedInInfo, Integer formId, Integer demographicNo);
 }
-

--- a/src/main/java/ca/openosp/openo/managers/FormsManagerImpl.java
+++ b/src/main/java/ca/openosp/openo/managers/FormsManagerImpl.java
@@ -4,11 +4,14 @@ package ca.openosp.openo.managers;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 import org.apache.logging.log4j.Logger;
 import ca.openosp.openo.commn.dao.EFormDao;
@@ -28,6 +31,7 @@ import org.springframework.stereotype.Service;
 import ca.openosp.openo.documentManager.ConvertToEdoc;
 import ca.openosp.openo.documentManager.EDoc;
 import ca.openosp.openo.form.util.FormTransportContainer;
+import ca.openosp.openo.form.pdfservlet.GrowthChartConsultPdfRenderer;
 import ca.openosp.openo.log.LogAction;
 import ca.openosp.openo.encounter.data.EctFormData;
 import ca.openosp.openo.encounter.data.EctFormData.PatientForm;
@@ -41,6 +45,8 @@ import javax.servlet.http.HttpServletResponse;
  */
 @Service
 public class FormsManagerImpl implements FormsManager {
+    private static final Set<String> CONSULT_ATTACHABLE_FORM_TABLES =
+            Set.of("formAnnual", "formGrowthChart", "formGrowth0_36");
     private final Logger logger = MiscUtils.getLogger();
 
     @Autowired
@@ -60,6 +66,9 @@ public class FormsManagerImpl implements FormsManager {
 
     @Autowired
     private SecurityInfoManager securityInfoManager;
+
+    @Autowired
+    private GrowthChartConsultPdfRenderer growthChartConsultPdfRenderer;
 
 
     /**
@@ -168,6 +177,45 @@ public class FormsManagerImpl implements FormsManager {
         return patientFormList;
     }
 
+    @Override
+    public List<PatientForm> getConsultAttachableForms(LoggedInInfo loggedInInfo, Integer demographicId,
+                                                        boolean getAllVersions) {
+        if (!securityInfoManager.hasPrivilege(loggedInInfo, "_form", SecurityInfoManager.READ, null)) {
+            throw new RuntimeException("missing required sec object (_form)");
+        }
+
+        List<PatientForm> forms = new ArrayList<>();
+        for (EncounterForm encounterForm : getAllEncounterForms()) {
+            if (!CONSULT_ATTACHABLE_FORM_TABLES.contains(encounterForm.getFormTable())) {
+                continue;
+            }
+            PatientForm[] patientForms = EctFormData.getPatientForms(
+                    String.valueOf(demographicId), encounterForm.getFormTable());
+            int count = getAllVersions ? patientForms.length : Math.min(1, patientForms.length);
+            for (int i = 0; i < count; i++) {
+                PatientForm form = patientForms[i];
+                form.setTable(encounterForm.getFormTable());
+                form.setFormName(encounterForm.getFormName());
+                forms.add(form);
+            }
+        }
+        return forms;
+    }
+
+    @Override
+    public PatientForm getConsultForm(LoggedInInfo loggedInInfo, String formTable, Integer formId,
+                                      Integer demographicNo) {
+        if (!CONSULT_ATTACHABLE_FORM_TABLES.contains(formTable) || formId == null || formId <= 0) {
+            return null;
+        }
+        for (PatientForm form : getConsultAttachableForms(loggedInInfo, demographicNo, true)) {
+            if (formTable.equals(form.getTable()) && String.valueOf(formId).equals(form.getFormId())) {
+                return form;
+            }
+        }
+        return null;
+    }
+
 
     private List<String> getPDFReadyFormNames() {
         List<String> pdfReadyFormList = new ArrayList<>();
@@ -267,16 +315,54 @@ public class FormsManagerImpl implements FormsManager {
         return path;
     }
 
+    @Override
+    public Path renderConsultForm(HttpServletRequest request, HttpServletResponse response,
+                                  EctFormData.PatientForm form) throws PDFGenerationException {
+        if (form == null) {
+            throw new PDFGenerationException("The encounter form attachment could not be found");
+        }
+        if ("formGrowthChart".equals(form.getTable()) || "formGrowth0_36".equals(form.getTable())) {
+            LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
+            if (loggedInInfo != null && loggedInInfo.getLoggedInProvider() == null) {
+                loggedInInfo = LoggedInInfo.getLoggedInInfoFromRequest(request);
+            }
+            if (!securityInfoManager.hasPrivilege(loggedInInfo, "_form", SecurityInfoManager.READ, null)) {
+                throw new SecurityException("missing required sec object (_form)");
+            }
+            LogAction.addLogSynchronous(loggedInInfo, "FormsManager.saveFormAsTempPdf",
+                    form.getTable() + "|" + form.getFormId());
+            return growthChartConsultPdfRenderer.render(request, form);
+        }
+        return renderForm(request, response, form);
+    }
+
+    @Override
+    public Path renderConsultForm(HttpServletRequest request, HttpServletResponse response,
+                                  String formTable, Integer formId, Integer demographicNo) throws PDFGenerationException {
+        LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
+        if (loggedInInfo != null && loggedInInfo.getLoggedInProvider() == null) {
+            loggedInInfo = LoggedInInfo.getLoggedInInfoFromRequest(request);
+        }
+        PatientForm form = getConsultForm(loggedInInfo, formTable, formId, demographicNo);
+        if (form == null) {
+            throw new SecurityException("Encounter form does not belong to the patient or is not attachable");
+        }
+        return renderConsultForm(request, response, form);
+    }
+
     private FormTransportContainer getFormTransportContainer(HttpServletRequest request, HttpServletResponse response,
                                                              EctFormData.PatientForm form) throws PDFGenerationException {
         LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
-        String formId = request.getParameter("formId") != null ? request.getParameter("formId") : form.getFormId();
-        String formName = request.getParameter("formName") != null ? request.getParameter("formName")
-                : form.getFormName();
-        String demographicNo = request.getParameter("demographicNo") != null ? request.getParameter("demographicNo")
-                : form.getDemoNo();
-        String formPath = "/form/forwardshortcutname.jsp?method=fetch&formname=" + formName + "&demographic_no="
-                + demographicNo + "&formId=" + formId;
+        String formId = form != null ? form.getFormId() : request.getParameter("formId");
+        String formName = form != null ? form.getFormName() : request.getParameter("formName");
+        String demographicNo = form != null ? form.getDemoNo() : request.getParameter("demographicNo");
+        if (formId == null || formName == null || demographicNo == null) {
+            throw new PDFGenerationException("The encounter form rendering identity is incomplete");
+        }
+        String formPath = "/form/forwardshortcutname.jsp?method=fetch&formname="
+                + URLEncoder.encode(formName, StandardCharsets.UTF_8) + "&demographic_no="
+                + URLEncoder.encode(demographicNo, StandardCharsets.UTF_8) + "&formId="
+                + URLEncoder.encode(formId, StandardCharsets.UTF_8);
         FormTransportContainer formTransportContainer = null;
         try {
             formTransportContainer = new FormTransportContainer(response, request, formPath);

--- a/src/main/webapp/documentManager/attachDocument.jsp
+++ b/src/main/webapp/documentManager/attachDocument.jsp
@@ -552,17 +552,36 @@
                                     </button>
                                 </li>
                                 <c:forEach items="${ allForms }" var="form" varStatus="loop">
+                                    <c:set var="formKey" value="${form.formId}"/>
+                                    <c:set var="formDomId" value="formNo${form.formId}"/>
+                                    <c:if test="${useQualifiedFormIds}">
+                                        <c:set var="formKey" value="${form.table}|${form.formId}"/>
+                                        <c:set var="formDomId" value="formNo_${form.table}_${form.formId}"/>
+                                    </c:if>
                                     <li class="form ${loop.index > 19 ? 'hide' : ''}">
                                         <input class="form_check attachable_check" type="checkbox" name="formNo"
-                                               id="formNo${ form.formId }" value="${form.formId}"
+                                               id="${e:forHtmlAttribute(formDomId)}"
+                                               value="${e:forHtmlAttribute(formKey)}"
+                                               data-form-id="${e:forHtmlAttribute(form.formId)}"
+                                               data-form-table="${e:forHtmlAttribute(form.table)}"
                                                title="${e:forHtmlAttribute(form.formName)}"/>
-                                        <label for="formNo${form.formId}">
+                                        <label for="${e:forHtmlAttribute(formDomId)}">
                                             <c:out value="${ form.formName } ${ form.getEdited() }"/>
                                         </label>
-                                        <button class="preview-button" type="button" title="Preview"
-                                                onclick="getPdf('FORM', '${form.formId}', 'method=renderFormPDF&formId=${form.formId}&formName=${form.formName}&demographicNo=${form.getDemoNo()}')">
-                                            Preview
-                                        </button>
+                                        <c:choose>
+                                            <c:when test="${useQualifiedFormIds}">
+                                                <button class="preview-button" type="button" title="Preview"
+                                                        onclick="getPdf('FORM', '${e:forJavaScript(formKey)}', 'method=renderFormPDF&formId=' + encodeURIComponent('${e:forJavaScript(form.formId)}') + '&formTable=' + encodeURIComponent('${e:forJavaScript(form.table)}') + '&demographicNo=' + encodeURIComponent('${e:forJavaScript(form.getDemoNo())}'))">
+                                                    Preview
+                                                </button>
+                                            </c:when>
+                                            <c:otherwise>
+                                                <button class="preview-button" type="button" title="Preview"
+                                                        onclick="getPdf('FORM', '${e:forJavaScript(form.formId)}', 'method=renderFormPDF&formId=' + encodeURIComponent('${e:forJavaScript(form.formId)}') + '&formName=' + encodeURIComponent('${e:forJavaScript(form.formName)}') + '&demographicNo=' + encodeURIComponent('${e:forJavaScript(form.getDemoNo())}'))">
+                                                    Preview
+                                                </button>
+                                            </c:otherwise>
+                                        </c:choose>
                                     </li>
                                 </c:forEach>
                             </ul>

--- a/src/main/webapp/oscarEncounter/oscarConsultationRequest/ConsultationFormRequest.jsp
+++ b/src/main/webapp/oscarEncounter/oscarConsultationRequest/ConsultationFormRequest.jsp
@@ -2030,13 +2030,17 @@ if (userAgent != null) {
                                                     <td><h3>Forms</h3></td>
                                                 </tr>
                                                 <c:forEach items="${ attachedForms }" var="attachedForm">
-                                                    <tr id="entry_formNo${ attachedForm.formId }"
-                                                        data-formName="${ attachedForm.formName }"
-                                                        data-formDate="${ attachedForm.getEdited() }">
+                                                    <c:set var="attachedFormKey" value="${attachedForm.table}|${attachedForm.formId}"/>
+                                                    <c:set var="attachedFormDomId" value="formNo_${attachedForm.table}_${attachedForm.formId}"/>
+                                                    <tr id="entry_${e:forHtmlAttribute(attachedFormDomId)}"
+                                                        data-form-name="${e:forHtmlAttribute(attachedForm.formName)}"
+                                                        data-form-date="${e:forHtmlAttribute(attachedForm.getEdited())}"
+                                                        data-form-id="${e:forHtmlAttribute(attachedForm.formId)}"
+                                                        data-form-table="${e:forHtmlAttribute(attachedForm.table)}">
                                                         <td>
                                                             <c:out value="${ attachedForm.formName }"/>
-                                                            <input name="formNo" value="${ attachedForm.formId }"
-                                                                   id="delegate_formNo${ attachedForm.formId }"
+                                                            <input name="formNo" value="${e:forHtmlAttribute(attachedFormKey)}"
+                                                                   id="delegate_${e:forHtmlAttribute(attachedFormDomId)}"
                                                                    class="delegateAttachment" type="hidden">
                                                         </td>
                                                     </tr>
@@ -3122,21 +3126,26 @@ if (userAgent != null) {
             function addFormIfNotFound(form, demographicNo, delegate) {
                 const checkboxName = form.getAttribute('name');
                 const formValue = form.getAttribute('value');
-                const formId = "formNo" + formValue;
-                const formName = document.getElementById("entry_" + formId).getAttribute('data-formName');
-                const formDate = document.getElementById("entry_" + formId).getAttribute('data-formDate');
+                const formDomId = form.id.substring("delegate_".length);
+                const row = document.getElementById("entry_" + formDomId);
+                const formName = row.getAttribute('data-form-name');
+                const formDate = row.getAttribute('data-form-date');
+                const formId = row.getAttribute('data-form-id');
+                const formTable = row.getAttribute('data-form-table');
 
                 const checkbox = jQuery('<input>', {
                     class: 'form_check',
                     type: 'checkbox',
                     name: checkboxName,
-                    id: formId,
+                    id: formDomId,
                     value: formValue,
+                    'data-form-id': formId,
+                    'data-form-table': formTable,
                     title: formName
                 });
 
                 const label = jQuery('<label>', {
-                    for: formId,
+                    for: formDomId,
                     text: "(Not Latest Version) " + formName + " " + formDate
                 });
 
@@ -3146,7 +3155,9 @@ if (userAgent != null) {
                     text: 'Preview',
                     title: 'Preview'
                 }).click(function () {
-                    getPdf('FORM', formValue, 'method=renderFormPDF&formId=' + formValue + '&formName=' + formName + '&demographicNo=' + demographicNo);
+                    getPdf('FORM', formValue, 'method=renderFormPDF&formId=' + encodeURIComponent(formId)
+                        + '&formTable=' + encodeURIComponent(formTable)
+                        + '&demographicNo=' + encodeURIComponent(demographicNo));
                 });
 
                 const newLiFormElement = jQuery('<li>', {
@@ -3171,7 +3182,7 @@ if (userAgent != null) {
                 jQuery("#attachDocumentDisplay").load(trigger.data('poload'), function (response, status, xhr) {
                     if (status === "success") {
                         $mainForm.find(".delegateAttachment").each(function (index, data) {
-                            let delegateKey = this.id.split("_")[1];
+                            let delegateKey = this.id.substring("delegate_".length);
 
                             // DOC sections share name="docNo" with distinct ids; look up by name+value.
                             // Skip if server-pre-attached; else mark as unsaved client-side selection.
@@ -3249,8 +3260,14 @@ if (userAgent != null) {
                             if (seenDelegates[key]) return;
                             seenDelegates[key] = true;
                             var input = buildDelegateInput(element);
-                            // entry_ row id uses name+value (not checkbox id) so the three DOC sections share a row key.
-                            var row = jQuery("<tr>", {id: "entry_" + element.attr("name") + element.val()});
+                            // DOC sections use name+value to share a row key. Qualified form values use their safe DOM id.
+                            var rowId = element.hasClass("form_check")
+                                ? "entry_" + element.attr("id")
+                                : "entry_" + element.attr("name") + element.val();
+                            if (element.hasClass("form_check")) {
+                                jQuery(document.getElementById(rowId)).remove();
+                            }
+                            var row = jQuery("<tr>", {id: rowId});
                             var column = jQuery("<td>");
                             var target = "#attachedDocumentsTable";
 
@@ -3261,6 +3278,12 @@ if (userAgent != null) {
 
                             if (element.hasClass("form_check")) {
                                 target = "#attachedFormsTable";
+                                row.attr({
+                                    'data-form-name': element.attr("title"),
+                                    'data-form-date': '',
+                                    'data-form-id': element.attr("data-form-id"),
+                                    'data-form-table': element.attr("data-form-table")
+                                });
                             }
 
                             if (element.hasClass("eForm_check")) {
@@ -3283,7 +3306,10 @@ if (userAgent != null) {
 
                             if (!checkedElement.is(':checked')) {
                                 var oldType = checkedElement.attr("class").split(" ")[0];
-                                $mainForm.find("#entry_" + checkedElement.attr("name") + checkedElement.val()).remove();
+                                var oldRowId = checkedElement.hasClass("form_pre_check")
+                                    ? "entry_" + checkedElement.attr("id")
+                                    : "entry_" + checkedElement.attr("name") + checkedElement.val();
+                                jQuery(document.getElementById(oldRowId)).remove();
                                 checkedElement.removeClass(oldType).addClass(oldType.split("_")[0] + "_check");
                                 // Drop pre-attached so a subsequent re-check fires the private-doc warning.
                                 checkedElement.removeAttr("data-pre-attached");
@@ -3324,5 +3350,3 @@ if (userAgent != null) {
         return noteStr.toString();
     }
 %>
-
-

--- a/src/test-modern/java/ca/openosp/openo/documentManager/DocumentAttachTest.java
+++ b/src/test-modern/java/ca/openosp/openo/documentManager/DocumentAttachTest.java
@@ -1,0 +1,50 @@
+package ca.openosp.openo.documentManager;
+
+import ca.openosp.openo.commn.dao.ConsultDocsDao;
+import ca.openosp.openo.commn.dao.EFormDocsDao;
+import ca.openosp.openo.commn.model.ConsultDocs;
+import ca.openosp.openo.test.unit.OpenOUnitTestBase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class DocumentAttachTest extends OpenOUnitTestBase {
+    private ConsultDocsDao consultDocsDao;
+
+    @BeforeEach
+    void setUp() {
+        consultDocsDao = mock(ConsultDocsDao.class);
+        registerMock(ConsultDocsDao.class, consultDocsDao);
+        registerMock(EFormDocsDao.class, mock(EFormDocsDao.class));
+    }
+
+    @Test
+    void distinguishesSameNumericIdFromDifferentFormTables() {
+        ConsultDocs annual = new ConsultDocs(11, 5, ConsultDocs.DOCTYPE_FORM, "999998");
+        annual.setFormTable("formAnnual");
+        when(consultDocsDao.findByRequestIdDocType(11, ConsultDocs.DOCTYPE_FORM))
+                .thenReturn(List.of(annual));
+
+        new DocumentAttach().attachFormsToConsult(List.of(
+                EncounterFormAttachmentKey.of("formAnnual", 5),
+                EncounterFormAttachmentKey.of("formGrowthChart", 5)), "999998", 11);
+
+        verify(consultDocsDao, never()).merge(annual);
+        assertNull(annual.getDeleted());
+
+        ArgumentCaptor<ConsultDocs> inserted = ArgumentCaptor.forClass(ConsultDocs.class);
+        verify(consultDocsDao).persist(inserted.capture());
+        assertEquals(5, inserted.getValue().getDocumentNo());
+        assertEquals("formGrowthChart", inserted.getValue().getFormTable());
+        assertEquals(ConsultDocs.DOCTYPE_FORM, inserted.getValue().getDocType());
+    }
+}

--- a/src/test-modern/java/ca/openosp/openo/documentManager/EncounterFormAttachmentKeyTest.java
+++ b/src/test-modern/java/ca/openosp/openo/documentManager/EncounterFormAttachmentKeyTest.java
@@ -1,0 +1,34 @@
+package ca.openosp.openo.documentManager;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@Tag("unit")
+@Tag("fast")
+class EncounterFormAttachmentKeyTest {
+
+    @Test
+    void roundTripsQualifiedFormIdentity() {
+        EncounterFormAttachmentKey key = EncounterFormAttachmentKey.parse("formGrowthChart|42");
+
+        assertEquals("formGrowthChart", key.getFormTable());
+        assertEquals(42, key.getFormId());
+        assertEquals("formGrowthChart|42", key.encode());
+        assertEquals(key, EncounterFormAttachmentKey.of("formGrowthChart", 42));
+    }
+
+    @Test
+    void rejectsMalformedAndUnsafeValues() {
+        assertThrows(IllegalArgumentException.class, () -> EncounterFormAttachmentKey.parse(null));
+        assertThrows(IllegalArgumentException.class, () -> EncounterFormAttachmentKey.parse("42"));
+        assertThrows(IllegalArgumentException.class, () -> EncounterFormAttachmentKey.parse("formAnnual|0"));
+        assertThrows(IllegalArgumentException.class, () -> EncounterFormAttachmentKey.parse("formAnnual|-1"));
+        assertThrows(IllegalArgumentException.class,
+                () -> EncounterFormAttachmentKey.parse("formGrowthChart;DROP TABLE consultdocs|1"));
+        assertThrows(IllegalArgumentException.class,
+                () -> EncounterFormAttachmentKey.parse("formGrowthChart|1|2"));
+    }
+}

--- a/src/test-modern/java/ca/openosp/openo/form/pdfservlet/GrowthChartWindowMapperTest.java
+++ b/src/test-modern/java/ca/openosp/openo/form/pdfservlet/GrowthChartWindowMapperTest.java
@@ -1,0 +1,74 @@
+package ca.openosp.openo.form.pdfservlet;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Tag("unit")
+@Tag("fast")
+class GrowthChartWindowMapperTest {
+    private static final List<String> FIELDS = List.of("date", "weight");
+
+    @Test
+    void leavesEmptyAndFirstWindowRecordsUnchanged() {
+        assertTrue(GrowthChartWindowMapper.mostRecentWindow(
+                new Properties(), FIELDS, 42, 7).isEmpty());
+
+        Properties firstWindow = measurements(1, 7);
+        assertTrue(GrowthChartWindowMapper.mostRecentWindow(
+                firstWindow, FIELDS, 42, 7).isEmpty());
+    }
+
+    @Test
+    void mapsMostRecentCompleteWindowToVisibleSlotsWithoutBreakingPairs() {
+        Properties values = measurements(1, 42);
+
+        Map<String, String> overrides = GrowthChartWindowMapper.mostRecentWindow(
+                values, FIELDS, 42, 7);
+
+        assertEquals("date-36", overrides.get("date_1"));
+        assertEquals("weight-36", overrides.get("weight_1"));
+        assertEquals("date-42", overrides.get("date_7"));
+        assertEquals("weight-42", overrides.get("weight_7"));
+        assertEquals("date-1", overrides.get("date_36"));
+        assertEquals("weight-1", overrides.get("weight_36"));
+    }
+
+    @Test
+    void mapsPartiallyPopulatedLaterWindowUsingLegacyWindowBoundaries() {
+        Properties values = measurements(1, 9);
+
+        Map<String, String> overrides = GrowthChartWindowMapper.mostRecentWindow(
+                values, FIELDS, 42, 7);
+
+        assertEquals("date-8", overrides.get("date_1"));
+        assertEquals("weight-9", overrides.get("weight_2"));
+        assertEquals("", overrides.get("date_7"));
+    }
+
+    @Test
+    void supportsFiveRowInfantHeadCircumferenceWindow() {
+        Properties values = measurements(1, 20);
+
+        Map<String, String> overrides = GrowthChartWindowMapper.mostRecentWindow(
+                values, FIELDS, 20, 5);
+
+        assertEquals("date-16", overrides.get("date_1"));
+        assertEquals("weight-20", overrides.get("weight_5"));
+    }
+
+    private Properties measurements(int start, int end) {
+        Properties values = new Properties();
+        for (int index = start; index <= end; index++) {
+            values.setProperty("date_" + index, "date-" + index);
+            values.setProperty("weight_" + index, "weight-" + index);
+        }
+        return values;
+    }
+}


### PR DESCRIPTION
## Changes made
- Update consultdocs to store growth chart information.
- Update `ConsultationFormRequest.jsp` to route growth chart form ids.
- Update backend to route the growth chart information to the consult JSP.

## Summary by Sourcery

Support securely attaching, previewing, and rendering growth chart encounter forms in consultations.

New Features:
- Enable consultations to attach and render growth chart encounter forms, including both standard and infant chart variants.

Bug Fixes:
- Preserve distinct consultation attachments when different form tables contain the same numeric form ID.
- Validate submitted form identities and ensure attached forms belong to the specified patient before processing or rendering.

Enhancements:
- Use table-qualified encounter-form identities throughout consultation attachment selection, preview, retrieval, and PDF generation.
- Refactor consultation form rendering to support server-controlled template requests and growth-chart measurement windows.

Tests:
- Add unit coverage for qualified form identities, duplicate numeric IDs across form tables, and growth-chart window mapping.

Chores:
- Add the consultation document schema migration and backfill existing form attachments with their legacy form table.